### PR TITLE
LC-297: Set surefire configuration redirectTestOutputToFile to false.

### DIFF
--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -154,7 +154,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
-          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <redirectTestOutputToFile>false</redirectTestOutputToFile>
           <!--ensure consistent timezone for unit tests-->
           <!--suppress UnresolvedMavenProperty -->
           <argLine>${argLine} -Duser.timezone=UTC</argLine>


### PR DESCRIPTION
Set surefire configuration redirectTestOutputToFile to false so test output is visible in CI/CD console output.