### PR TITLE
LC-320 add DatabaseConnector field handling

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.connector.jdbc;
 
 import com.kmwllc.lucille.connector.AbstractConnector;
+import com.kmwllc.lucille.core.ConfigUtils;
 import com.kmwllc.lucille.core.ConnectorException;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Publisher;
@@ -14,51 +15,55 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Database Connector - This connector can run a select statement and return the rows 
+ * Database Connector - This connector can run a select statement and return the rows
  * from the database as documents which are published to a topic for processing.
  * If "otherSQLs" are set, the sql and otherSQLs must all be ordered by their join key
  * and the otherJoinFields must be populated.  If those parameters are populated
  * this connector will run the otherSQL statements in parallel and flatten the rows from
  * the otherSQL statements onto the Document as a child document
- * 
- * @author kwatters
  *
+ * @author kwatters
  */
 public class DatabaseConnector extends AbstractConnector {
 
   private static final Logger log = LogManager.getLogger(DatabaseConnector.class);
 
-  private String driver;
-  private String connectionString;
-  private String jdbcUser;
-  private String jdbcPassword;
-  private String preSql;
-  private String sql;
-  private String postSql;
-  private String idField;
-  private List<String> otherSQLs = new ArrayList<String>();
-  private List<String> otherJoinFields;
-  private Connection connection = null;
+  private final String driver;
+  private final String connectionString;
+  private final String jdbcUser;
+  private final String jdbcPassword;
+  private final String preSql;
+  private final String sql;
+  private final String postSql;
+  private final String idField;
+  private final List<String> otherSQLs;
+  private final List<String> otherJoinFields;
+  private Connection connection;
 
   // The constructor that takes the config.
   public DatabaseConnector(Config config) {
     super(config);
     // TODO: move to base class functionality
     // docIdPrefix = config.getString("docIdPrefix");
+
+    // required config
     driver = config.getString("driver");
     connectionString = config.getString("connectionString");
     jdbcUser = config.getString("jdbcUser");
     jdbcPassword = config.getString("jdbcPassword");
     sql = config.getString("sql");
     idField = config.getString("idField");
-    if (config.hasPath("preSql"))
-      preSql = config.getString("preSql");
-    if (config.hasPath("postSql"))
-      postSql = config.getString("postSql");
+
+    // optional config
+    preSql = ConfigUtils.getOrDefault(config, "preSql", null);
+    postSql = ConfigUtils.getOrDefault(config, "postSql", null);
     if (config.hasPath("otherSQLs")) {
       otherSQLs = config.getStringList("otherSQLs");
       otherJoinFields = config.getStringList("otherJoinFields");
-    }  
+    } else {
+      otherSQLs = new ArrayList<>();
+      otherJoinFields = new ArrayList<>();
+    }
   }
 
   // create a jdbc connection
@@ -66,19 +71,21 @@ public class DatabaseConnector extends AbstractConnector {
     try {
       Class.forName(driver);
     } catch (ClassNotFoundException e) {
-      // TODO better error handling/logging
-      e.printStackTrace();
-      setState(ConnectorState.ERROR);
-      throw(e);
+      tempLoggingHandling(e);
+      throw (e);
     }
     try {
       connection = DriverManager.getConnection(connectionString, jdbcUser, jdbcPassword);
     } catch (SQLException e) {
-      // TODO better logging/error handling.
-      e.printStackTrace();
-      setState(ConnectorState.ERROR);
-      throw(e);
+      tempLoggingHandling(e);
+      throw (e);
     }
+  }
+
+  private void tempLoggingHandling(Exception e) {
+    // TODO better logging/error handling.
+    e.printStackTrace();
+    setState(ConnectorState.ERROR);
   }
 
   private void setState(ConnectorState error) {
@@ -88,97 +95,96 @@ public class DatabaseConnector extends AbstractConnector {
 
   @Override
   public void execute(Publisher publisher) throws ConnectorException {
-    
+
     try {
-    setState(ConnectorState.RUNNING);
-    // connect to the database.
-    createConnection();
-    // run the pre-sql (if specified)
-    runSql(preSql);
+      setState(ConnectorState.RUNNING);
+      // connect to the database.
+      createConnection();
+      // run the pre-sql (if specified)
+      runSql(preSql);
 
-    ResultSet rs = null;
-    try {
-      log.info("Running primary sql");
-      Statement state = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-      rs = state.executeQuery(sql);
-    } catch (SQLException e) {
-      e.printStackTrace();
-      setState(ConnectorState.ERROR);
-      throw(e);
-    }
-
-    log.info("Describing primary set...");
-    String[] columns = getColumnNames(rs);
-    int idColumn = -1;
-    for (int i = 0; i < columns.length; i++) {
-      if (columns[i].equalsIgnoreCase(idField)) {
-        idColumn = i + 1;
-        break;
+      ResultSet rs;
+      try {
+        log.info("Running primary sql");
+        Statement state = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        rs = state.executeQuery(sql);
+      } catch (SQLException e) {
+        tempLoggingHandling(e);
+        throw (e);
       }
-    }
 
-    ArrayList<ResultSet> otherResults = new ArrayList<ResultSet>();
-    ArrayList<String[]> otherColumns = new ArrayList<String[]>();
-    for (String otherSQL : otherSQLs) {
-      log.info("Describing other result set... {}", otherSQL );
-      // prepare the other sql query 
-      // TODO: run all sql statements in parallel.
-      ResultSet rs2 = runJoinSQL(otherSQL);
-      String[] columns2 = getColumnNames(rs2);
-      otherResults.add(rs2);
-      otherColumns.add(columns2);
-    }
-
-    log.info("Processing rows...");
-    
-    while (rs.next()) {
-      // Need the ID column from the RS.
-      String id = createDocId(rs.getString(idColumn));
-      
-      Document doc = Document.create(id);
-      
-      // Add each column / field name to the doc
-      for (int i = 1; i <= columns.length; i++) {
-        // TODO: how do we normalize our column names?  (lowercase is probably ok and likely desirable as 
-        // sometimes databases return columns in upper/lower case depending on which db you talk to.)
-        String fieldName = columns[i-1].toLowerCase();
-        if (i == idColumn && Document.ID_FIELD.equals(fieldName)) {
-          // we already have this column because it's the id column.
-          continue;
-        }
-        // log.info("Add Field {} Value {} -- Doc {}", columns[i-1].toLowerCase(), rs.getString(i), doc);
-        String fieldValue = rs.getString(i);
-        if (fieldValue != null) {
-          doc.setOrAdd(fieldName, fieldValue);
+      log.info("Describing primary set...");
+      String[] columns = getColumnNames(rs);
+      int idColumn = -1;
+      for (int i = 0; i < columns.length; i++) {
+        if (columns[i].equalsIgnoreCase(idField)) {
+          idColumn = i + 1;
+          break;
         }
       }
 
-      if (!otherResults.isEmpty()) {
-        // this is the primary key that the result set is ordered by.
-        Integer joinId = rs.getInt(idField);
-        int childId = -1;
-        int j = 0;
-        for (ResultSet otherResult : otherResults) {
-          iterateOtherSQL(otherResult, otherColumns.get(j), doc, joinId, childId, otherJoinFields.get(j));
-          j++;
-        }
+      ArrayList<ResultSet> otherResults = new ArrayList<ResultSet>();
+      ArrayList<String[]> otherColumns = new ArrayList<String[]>();
+      for (String otherSQL : otherSQLs) {
+        log.info("Describing other result set... {}", otherSQL);
+        // prepare the other sql query
+        // TODO: run all sql statements in parallel.
+        ResultSet rs2 = runJoinSQL(otherSQL);
+        String[] columns2 = getColumnNames(rs2);
+        otherResults.add(rs2);
+        otherColumns.add(columns2);
       }
-      
-      // Fix the duplicate id field value that occurs
-     // doc.setField("id", id);
-      // feed the accumulated document.
-      publisher.publish(doc);
-    }
 
-    // close all results
-    rs.close();
-    for (ResultSet ors : otherResults) {
-      ors.close();
-    }
-    // the post sql.
-    runSql(postSql);
-    flush();
-    setState(ConnectorState.STOPPED);
+      log.info("Processing rows...");
+
+      while (rs.next()) {
+        // Need the ID column from the RS.
+        String id = createDocId(rs.getString(idColumn));
+
+        Document doc = Document.create(id);
+
+        // Add each column / field name to the doc
+        for (int i = 1; i <= columns.length; i++) {
+          // TODO: how do we normalize our column names?  (lowercase is probably ok and likely desirable as
+          // sometimes databases return columns in upper/lower case depending on which db you talk to.)
+          String fieldName = columns[i - 1].toLowerCase();
+          if (i == idColumn && Document.ID_FIELD.equals(fieldName)) {
+            // we already have this column because it's the id column.
+            continue;
+          }
+          // log.info("Add Field {} Value {} -- Doc {}", columns[i-1].toLowerCase(), rs.getString(i), doc);
+          String fieldValue = rs.getString(i);
+          if (fieldValue != null) {
+            doc.setOrAdd(fieldName, fieldValue);
+          }
+        }
+
+        if (!otherResults.isEmpty()) {
+          // this is the primary key that the result set is ordered by.
+          Integer joinId = rs.getInt(idField);
+          int childId = -1;
+          int j = 0;
+          for (ResultSet otherResult : otherResults) {
+            iterateOtherSQL(otherResult, otherColumns.get(j), doc, joinId, childId, otherJoinFields.get(j));
+            j++;
+          }
+        }
+
+        // Fix the duplicate id field value that occurs
+        // doc.setField("id", id);
+        // feed the accumulated document.
+        publisher.publish(doc);
+      }
+
+      // close all results
+      rs.close();
+      for (ResultSet ors : otherResults) {
+        ors.close();
+      }
+      // the post sql.
+      runSql(postSql);
+      flush();
+      setState(ConnectorState.STOPPED);
     } catch (Exception e) {
       setState(ConnectorState.ERROR);
       throw new ConnectorException("Exception caught during connector execution", e);
@@ -195,14 +201,14 @@ public class DatabaseConnector extends AbstractConnector {
   private void iterateOtherSQL(ResultSet rs2, String[] columns2, Document doc, Integer joinId, int childId, String joinField) throws SQLException {
     while (rs2.next()) {
       // TODO: support non INT primary key
-      Integer otherJoinId = rs2.getInt(joinField);
+      int otherJoinId = rs2.getInt(joinField);
 
       if (otherJoinId < joinId) {
         // advance until we get to the id on the right side that we want.
         continue;
       }
       if (otherJoinId > joinId) {
-        // we've gone too far.. lets back up and break out , move forward the primary result set.
+        // we've gone too far… let's back up and break out , move forward the primary result set.
         rs2.previous();
         break;
       }
@@ -225,20 +231,18 @@ public class DatabaseConnector extends AbstractConnector {
     if (!rs2.isLast()) {
       rs2.previous();
     }
-
   }
 
   private ResultSet runJoinSQL(String sql) throws SQLException {
-    ResultSet rs2 = null;
+    ResultSet rs2;
     try {
       // TODO: can we do this with forward only ?
       log.info("Running other sql");
       Statement state2 = connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
       rs2 = state2.executeQuery(sql);
     } catch (SQLException e) {
-      e.printStackTrace();
-      setState(ConnectorState.ERROR);
-      throw(e);
+      tempLoggingHandling(e);
+      throw (e);
     }
     return rs2;
   }
@@ -263,8 +267,7 @@ public class DatabaseConnector extends AbstractConnector {
         state.executeUpdate(sql);
         state.close();
       } catch (SQLException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
+        tempLoggingHandling(e);
       }
     }
   }
@@ -275,69 +278,6 @@ public class DatabaseConnector extends AbstractConnector {
     setState(ConnectorState.STOPPED);
   }
 
-  public String getDriver() {
-    return driver;
-  }
-
-  public void setDriver(String driver) {
-    this.driver = driver;
-  }
-
-  public String getConnectionString() {
-    return connectionString;
-  }
-
-  public void setConnectionString(String connectionString) {
-    this.connectionString = connectionString;
-  }
-
-  public String getJdbcUser() {
-    return jdbcUser;
-  }
-
-  public void setJdbcUser(String jdbcUser) {
-    this.jdbcUser = jdbcUser;
-  }
-
-  public String getJdbcPassword() {
-    return jdbcPassword;
-  }
-
-  public void setJdbcPassword(String jdbcPassword) {
-    this.jdbcPassword = jdbcPassword;
-  }
-
-  public String getPreSql() {
-    return preSql;
-  }
-
-  public void setPreSql(String preSql) {
-    this.preSql = preSql;
-  }
-
-  public String getSql() {
-    return sql;
-  }
-
-  public void setSql(String sql) {
-    this.sql = sql;
-  }
-
-  public String getPostSql() {
-    return postSql;
-  }
-
-  public void setPostSql(String postSql) {
-    this.postSql = postSql;
-  }
-
-  public String getIdField() {
-    return idField;
-  }
-
-  public void setIdField(String idField) {
-    this.idField = idField;
-  }
 
   @Override
   public void close() throws ConnectorException {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
@@ -44,7 +44,7 @@ public class DatabaseConnector extends AbstractConnector {
   private final List<String> otherJoinFields;
   private final List<Connection> connections = new ArrayList<>();
   // TODO: consider moving this down to the base connector class.
-  private ConnectorState state = null;
+  //  private ConnectorState state = null;
 
   // The constructor that takes the config.
   public DatabaseConnector(Config config) {
@@ -96,7 +96,7 @@ public class DatabaseConnector extends AbstractConnector {
   }
 
   private void setState(ConnectorState newState) {
-    this.state = newState;
+    // this.state = newState;
   }
 
   @Override

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
@@ -45,7 +45,7 @@ public class DatabaseConnector extends AbstractConnector {
   private final String idField;
   private final List<String> otherSQLs;
   private final List<String> otherJoinFields;
-  private final Set<String> ignoreFields;
+  private final Set<String> ignoreColumns;
   private final List<Connection> connections = new ArrayList<>();
   // TODO: consider moving this down to the base connector class.
   //  private ConnectorState state = null;
@@ -76,9 +76,9 @@ public class DatabaseConnector extends AbstractConnector {
       otherSQLs = new ArrayList<>();
       otherJoinFields = null;
     }
-    ignoreFields = new HashSet<>();
+    ignoreColumns = new HashSet<>();
     if (config.hasPath("ignoreFields")) {
-      ignoreFields.addAll(
+      ignoreColumns.addAll(
           config.getStringList("ignoreFields")
               .stream()
               .map(String::toLowerCase)
@@ -183,7 +183,7 @@ public class DatabaseConnector extends AbstractConnector {
           }
 
           // continue if field is in the ignore set
-          if (ignoreFields.contains(fieldName)) {
+          if (ignoreColumns.contains(fieldName)) {
             continue;
           }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
@@ -176,8 +176,13 @@ public class DatabaseConnector extends AbstractConnector {
           // sometimes databases return columns in upper/lower case depending on which db you talk to.)
           String fieldName = columns[i - 1].toLowerCase();
 
-          // continue if it is an id column or if this field is in the ignore list
-          if (i == idColumn || ignoreFields.contains(fieldName)) {
+          // continue if it is an id column and has the same name as the id field
+          if ((i == idColumn && Document.ID_FIELD.equals(fieldName))) {
+            continue;
+          }
+
+          // continue if field is in the ignore set
+          if (ignoreFields.contains(fieldName)) {
             continue;
           }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
@@ -77,9 +77,9 @@ public class DatabaseConnector extends AbstractConnector {
       otherJoinFields = null;
     }
     ignoreColumns = new HashSet<>();
-    if (config.hasPath("ignoreFields")) {
+    if (config.hasPath("ignoreColumns")) {
       ignoreColumns.addAll(
-          config.getStringList("ignoreFields")
+          config.getStringList("ignoreColumns")
               .stream()
               .map(String::toLowerCase)
               .collect(Collectors.toSet()));
@@ -177,7 +177,7 @@ public class DatabaseConnector extends AbstractConnector {
           String fieldName = columns[i - 1].toLowerCase();
 
           // continue if it is an id column and has the same name as the id field
-          if ((i == idColumn && Document.ID_FIELD.equals(fieldName))) {
+          if (i == idColumn && Document.ID_FIELD.equals(fieldName)) {
             // we already have this column because it's the id column.
             continue;
           }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -336,7 +336,7 @@ public class DatabaseConnectorTest {
     assertEquals("1", doc1.getString("table_id"));
     assertEquals("2", doc2.getString("table_id"));
 
-    // "other_id" is not in the document
+    // "other_id" is still in the document
     assertTrue(doc1.has("other_id"));
     assertEquals("id1", doc1.getString("other_id"));
     assertTrue(doc2.has("other_id"));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -195,7 +195,7 @@ public class DatabaseConnectorTest {
     Config config = ConfigFactory.parseMap(configValues);
     // create the connector with the config
     DatabaseConnector connector = new DatabaseConnector(config);
-    // create a publisher to record all the docs sent to it.  
+    // create a publisher to record all the docs sent to it.
     // run the connector
 
     connector.execute(publisher);
@@ -207,7 +207,7 @@ public class DatabaseConnectorTest {
       System.err.println(d);
     }
 
-    // TODO: 
+    // TODO:
     //    for (Document doc : publisher.getPublishedDocs()) {
     //      System.out.println(doc);
     //    }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -270,7 +270,7 @@ public class DatabaseConnectorTest {
       connector.execute(publisher);
     } catch (ConnectorException e) {
       // expected
-      assertEquals( "Field name \"id\" is reserved, please rename it or add it to the ignore list",
+      assertEquals("Field name \"id\" is reserved, please rename it or add it to the ignore list",
           e.getCause().getMessage());
     }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -25,33 +25,33 @@ import static org.junit.Assert.*;
 public class DatabaseConnectorTest {
 
   private static final Logger log = LoggerFactory.getLogger(DatabaseConnectorTest.class);
-  
+
   @Rule
   public final DBTestHelper dbHelper = new DBTestHelper("org.h2.Driver", "jdbc:h2:mem:test", "",
       "", "db-test-start.sql", "db-test-end.sql");
 
   private Publisher publisher;
   private PersistingLocalMessageManager manager;
-  
+
   private String testRunId = "testRunId";
   private String connectorName = "testConnector";
   private String pipelineName = "testPipeline";
-  
+
   @Before
   public void initTestMode() throws Exception {
     // set com.kmwllc.lucille into loopback mode for local / standalone testing.
     manager = new PersistingLocalMessageManager();
     publisher = new PublisherImpl(ConfigFactory.empty(), manager, testRunId, pipelineName);
   }
-  
+
   @Test
   public void testDatabaseConnector() throws Exception {
-    
+
     // The only connection to the h2 database should be the dbHelper
     assertEquals(1, dbHelper.checkNumConnections());
-    
+
     // Create the test config
-    HashMap<String,Object> configValues = new HashMap<String,Object>();
+    HashMap<String, Object> configValues = new HashMap<>();
     configValues.put("name", connectorName);
     configValues.put("pipeline", pipelineName);
     configValues.put("driver", "org.h2.Driver");
@@ -60,20 +60,20 @@ public class DatabaseConnectorTest {
     configValues.put("jdbcPassword", "");
     configValues.put("sql", "select id,name,type from animal order by id");
     configValues.put("idField", "id");
-    
+
     // create a config object off that map
     Config config = ConfigFactory.parseMap(configValues);
 
     // create the connector with the config
     DatabaseConnector connector = new DatabaseConnector(config);
-    
+
     // start the connector 
     connector.execute(publisher);
 
     // Confirm there were 3 results.
     List<Document> docsSentForProcessing = manager.getSavedDocumentsSentForProcessing();
     assertEquals(3, docsSentForProcessing.size());
-    
+
     // System.out.println(docsSentForProcessing.get(0));
     // confirm first doc is 1
     assertEquals("1", docsSentForProcessing.get(0).getId());
@@ -88,18 +88,18 @@ public class DatabaseConnectorTest {
     assertEquals("3", docsSentForProcessing.get(2).getId());
     assertEquals("Blaze", docsSentForProcessing.get(2).getStringList("name").get(0));
     assertEquals("Cat", docsSentForProcessing.get(2).getStringList("type").get(0));
-    
+
     connector.close();
     assertEquals(1, dbHelper.checkNumConnections());
-    
+
   }
 
   @Test
   public void testCompaniesQuery() throws ConnectorException, SQLException {
-    
+
     assertEquals(1, dbHelper.checkNumConnections());
-    
-    HashMap<String,Object> configValues = new HashMap<>();
+
+    HashMap<String, Object> configValues = new HashMap<>();
     configValues.put("name", connectorName);
     configValues.put("pipeline", pipelineName);
     configValues.put("driver", "org.h2.Driver");
@@ -129,17 +129,17 @@ public class DatabaseConnectorTest {
     assertEquals("1-2", docsSentForProcessing.get(1).getStringList("company_id").get(0));
     // The name field shouldn't be set because the value was null in the database
     assertFalse(docsSentForProcessing.get(1).has("name"));
-    
+
     connector.close();
     assertEquals(1, dbHelper.checkNumConnections());
   }
 
   @Test
   public void testJoiningDatabaseConnector() throws Exception {
-    
+
     assertEquals(1, dbHelper.checkNumConnections());
-    
-    HashMap<String,Object> configValues = new HashMap<String,Object>();
+
+    HashMap<String, Object> configValues = new HashMap<>();
     configValues.put("name", connectorName);
     configValues.put("pipeline", pipelineName);
 
@@ -150,39 +150,39 @@ public class DatabaseConnectorTest {
     configValues.put("sql", "select id,name from animal");
     configValues.put("idField", "id");
     // a list of other sql statements
-    ArrayList<String> otherSql = new ArrayList<String>();
+    ArrayList<String> otherSql = new ArrayList<>();
     otherSql.add("select id as meal_id, animal_id,name from meal order by animal_id");
     // The join fields. id goes to animal_id
-    ArrayList<String> otherJoinFields = new ArrayList<String>();
+    ArrayList<String> otherJoinFields = new ArrayList<>();
     otherJoinFields.add("animal_id");
     configValues.put("otherSQLs", otherSql);
-    configValues.put("otherJoinFields",otherJoinFields); 
+    configValues.put("otherJoinFields", otherJoinFields);
     // create a config object off that map
     Config config = ConfigFactory.parseMap(configValues);
     // create the connector with the config
     DatabaseConnector connector = new DatabaseConnector(config);
     // run the connector
     connector.execute(publisher);
-    
+
     List<Document> docs = manager.getSavedDocumentsSentForProcessing();
     assertEquals(3, docs.size());
 
     // TODO: better verification / edge cases.. also formalize the "children" docs.
-    String expected ="{\"id\":\"1\",\"name\":\"Matt\",\".children\":[{\"id\":\"0\",\"meal_id\":\"1\",\"animal_id\":\"1\",\"name\":\"breakfast\"},{\"id\":\"1\",\"meal_id\":\"2\",\"animal_id\":\"1\",\"name\":\"lunch\"},{\"id\":\"2\",\"meal_id\":\"3\",\"animal_id\":\"1\",\"name\":\"dinner\"}],\"run_id\":\"testRunId\"}";
+    String expected = "{\"id\":\"1\",\"name\":\"Matt\",\".children\":[{\"id\":\"0\",\"meal_id\":\"1\",\"animal_id\":\"1\",\"name\":\"breakfast\"},{\"id\":\"1\",\"meal_id\":\"2\",\"animal_id\":\"1\",\"name\":\"lunch\"},{\"id\":\"2\",\"meal_id\":\"3\",\"animal_id\":\"1\",\"name\":\"dinner\"}],\"run_id\":\"testRunId\"}";
     assertEquals(expected, docs.get(0).toString());
-    
+
     connector.close();
     assertEquals(1, dbHelper.checkNumConnections());
 
   }
-  
+
   // TODO: not implemented yet.
   // @Test
   public void testCollapsingDatabaseConnector() throws Exception {
     // TODO: implement me
     assertEquals(1, dbHelper.checkNumConnections());
-    
-    HashMap<String,Object> configValues = new HashMap<String,Object>();
+
+    HashMap<String, Object> configValues = new HashMap<>();
     configValues.put("name", connectorName);
     configValues.put("pipeline", pipelineName);
     configValues.put("driver", "org.h2.Driver");
@@ -198,16 +198,16 @@ public class DatabaseConnectorTest {
     DatabaseConnector connector = new DatabaseConnector(config);
     // create a publisher to record all the docs sent to it.  
     // run the connector
-    
+
     connector.execute(publisher);
-    
+
     List<Document> docs = manager.getSavedDocumentsSentForProcessing();
     assertEquals(3, docs.size());
 
-    for (Document d: docs) {
+    for (Document d : docs) {
       System.err.println(d);
     }
-    
+
     // TODO: 
     //    for (Document doc : publisher.getPublishedDocs()) {
     //      System.out.println(doc);
@@ -222,10 +222,10 @@ public class DatabaseConnectorTest {
 
   @Test
   public void testClose() throws ConnectorException, SQLException {
-    
+
     assertEquals(1, dbHelper.checkNumConnections());
     // Create a test config
-    HashMap<String,Object> configValues = new HashMap<String,Object>();
+    HashMap<String, Object> configValues = new HashMap<>();
     configValues.put("name", connectorName);
     configValues.put("pipeline", pipelineName);
     configValues.put("driver", "org.h2.Driver");
@@ -243,13 +243,67 @@ public class DatabaseConnectorTest {
     // call the execute method, then close the connection
     connector.execute(publisher);
     assertEquals(2, dbHelper.checkNumConnections());
-    
+
     assertFalse(connector.isClosed());
     connector.close();
     // verify that the connection is actually closed
     assertTrue(connector.isClosed());
     assertEquals(1, dbHelper.checkNumConnections());
-    
   }
-  
+
+  @Test(expected = ConnectorException.class)
+  public void testReservedFieldError() throws ConnectorException {
+    HashMap<String, Object> configValues = new HashMap<>();
+    configValues.put("name", connectorName);
+    configValues.put("pipeline", pipelineName);
+    configValues.put("driver", "org.h2.Driver");
+    configValues.put("connectionString", "jdbc:h2:mem:test");
+    configValues.put("jdbcUser", "");
+    configValues.put("jdbcPassword", "");
+    configValues.put("sql", "select * from table_with_id_column");
+    configValues.put("idField", "other_id");
+
+    Config config = ConfigFactory.parseMap(configValues);
+    DatabaseConnector connector = new DatabaseConnector(config);
+
+    connector.execute(publisher);
+  }
+
+  @Test
+  public void testTableWithIdColumn() throws ConnectorException {
+
+    HashMap<String, Object> configValues = new HashMap<>();
+    configValues.put("name", connectorName);
+    configValues.put("pipeline", pipelineName);
+    configValues.put("driver", "org.h2.Driver");
+    configValues.put("connectionString", "jdbc:h2:mem:test");
+    configValues.put("jdbcUser", "");
+    configValues.put("jdbcPassword", "");
+    configValues.put("ignoreFields", List.of("id"));
+    configValues.put("sql", "select id as table_id, * from table_with_id_column");
+    configValues.put("idField", "other_id");
+
+    Config config = ConfigFactory.parseMap(configValues);
+    DatabaseConnector connector = new DatabaseConnector(config);
+
+    connector.execute(publisher);
+
+    List<Document> docsSentForProcessing = manager.getSavedDocumentsSentForProcessing();
+    assertEquals(2, docsSentForProcessing.size());
+
+    Document doc1 = docsSentForProcessing.get(0);
+    Document doc2 = docsSentForProcessing.get(1);
+
+    // document id is coming from the "other_id" column
+    assertEquals("id1", doc1.getId());
+    assertEquals("id2", doc2.getId());
+
+    // "id" column is renamed to "table_id"
+    assertEquals("1", doc1.getString("table_id"));
+    assertEquals("2", doc2.getString("table_id"));
+
+    // "other_id" is not in the document
+    assertFalse(doc1.has("other_id"));
+    assertFalse(doc2.has("other_id"));
+  }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -270,8 +270,8 @@ public class DatabaseConnectorTest {
       connector.execute(publisher);
     } catch (ConnectorException e) {
       // expected
-      // todo why does this not pass ?
-//      assertEquals( "Field name \"id\" is reserved, please rename it or add it to the ignore list", e.getMessage());
+      assertEquals( "Field name \"id\" is reserved, please rename it or add it to the ignore list",
+          e.getCause().getMessage());
     }
 
     connector.close();

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -287,7 +287,7 @@ public class DatabaseConnectorTest {
     configValues.put("connectionString", "jdbc:h2:mem:test");
     configValues.put("jdbcUser", "");
     configValues.put("jdbcPassword", "");
-    configValues.put("ignoreFields", List.of("id"));
+    configValues.put("ignoreColumns", List.of("id"));
     configValues.put("sql", "select id as table_id, * from table_with_id_column");
     configValues.put("idField", "other_id");
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -265,13 +265,11 @@ public class DatabaseConnectorTest {
     Config config = ConfigFactory.parseMap(configValues);
     DatabaseConnector connector = new DatabaseConnector(config);
 
-    try {
+    Throwable exception = assertThrows(ConnectorException.class, () -> {
       connector.execute(publisher);
-    } catch (ConnectorException e) {
-      // expected
-      assertEquals("Field name \"id\" is reserved, please rename it or add it to the ignore list",
-          e.getCause().getMessage());
-    }
+    });
+    assertEquals("Field name \"id\" is reserved, please rename it or add it to the ignore list",
+        exception.getCause().getMessage());
 
     connector.close();
     assertEquals(1, dbHelper.checkNumConnections());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -288,9 +288,7 @@ public class DatabaseConnectorTest {
     Config config = ConfigFactory.parseMap(configValues);
     DatabaseConnector connector = new DatabaseConnector(config);
 
-    Throwable exception = assertThrows(ConnectorException.class, () -> {
-      connector.execute(publisher);
-    });
+    Throwable exception = assertThrows(ConnectorException.class, () -> connector.execute(publisher));
     assertEquals("Field name \"id\" is reserved, please rename it or add it to the ignore list",
         exception.getCause().getMessage());
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -122,7 +122,6 @@ public class DatabaseConnectorTest {
     // The doc ID should have the 'company-' prefix
     assertEquals("company-1-1", docsSentForProcessing.get(0).getId());
     // There should also be a company_id field containing the company ID
-    Document doc1 = docsSentForProcessing.get(0); // todo remove this line
     assertEquals("1-1", docsSentForProcessing.get(0).getStringList("company_id").get(0));
     assertEquals("Acme", docsSentForProcessing.get(0).getStringList("name").get(0));
 
@@ -313,8 +312,10 @@ public class DatabaseConnectorTest {
     assertEquals("2", doc2.getString("table_id"));
 
     // "other_id" is not in the document
-    assertFalse(doc1.has("other_id"));
-    assertFalse(doc2.has("other_id"));
+    assertTrue(doc1.has("other_id"));
+    assertEquals("id1", doc1.getString("other_id"));
+    assertTrue(doc2.has("other_id"));
+    assertEquals("id2", doc2.getString("other_id"));
 
     connector.close();
     assertEquals(1, dbHelper.checkNumConnections());

--- a/lucille-core/src/test/resources/db-test-end.sql
+++ b/lucille-core/src/test/resources/db-test-end.sql
@@ -3,3 +3,4 @@ DROP TABLE attribute;
 DROP TABLE meal;
 DROP TABLE data;
 DROP TABLE companies;
+drop table table_with_id_column;

--- a/lucille-core/src/test/resources/db-test-start.sql
+++ b/lucille-core/src/test/resources/db-test-start.sql
@@ -29,3 +29,7 @@ INSERT INTO data VALUES (6, 3, 2, 'white');
 CREATE TABLE companies(company_id VARCHAR, name VARCHAR);
 INSERT INTO companies VALUES ('1-1', 'Acme');
 INSERT INTO companies VALUES ('1-2', NULL);
+
+create table table_with_id_column(id int, value int, other_id varchar(10));
+insert into table_with_id_column values (1, 1, 'id1');
+insert into table_with_id_column values (2, 2, 'id2');


### PR DESCRIPTION
**Issue**
Currently, the database connector will silently fail when a Lucille document reserved field (such as id) encounters the same field name (column) in the database it is connecting to.

**Desired Solution**
Skip setting field value if the field name is called id

**Implemented Solution**
- explicit exception for reserved table column names
- introduction of the `ignoreColumns` configuration parameter