### PR TITLE
Changed existing Rest High Level Client in OpenSearchIndexer to Java Client

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -19,15 +19,9 @@
   <dependencies>
     <dependency>
       <groupId>org.opensearch.client</groupId>
-      <artifactId>opensearch-rest-client</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-java</artifactId>
       <version>2.6.0</version>
     </dependency>
-
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -17,13 +17,6 @@
   <name>Lucille Core</name>
 
   <dependencies>
-
-<!--    <dependency>-->
-<!--      <groupId>org.opensearch.client</groupId>-->
-<!--      <artifactId>opensearch-rest-high-level-client</artifactId>-->
-<!--      <version>${opensearch-rest-high-level-client.version}</version>-->
-<!--    </dependency>-->
-
     <dependency>
       <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-rest-client</artifactId>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -18,10 +18,21 @@
 
   <dependencies>
 
+<!--    <dependency>-->
+<!--      <groupId>org.opensearch.client</groupId>-->
+<!--      <artifactId>opensearch-rest-high-level-client</artifactId>-->
+<!--      <version>${opensearch-rest-high-level-client.version}</version>-->
+<!--    </dependency>-->
+
     <dependency>
       <groupId>org.opensearch.client</groupId>
-      <artifactId>opensearch-rest-high-level-client</artifactId>
-      <version>${opensearch-rest-high-level-client.version}</version>
+      <artifactId>opensearch-rest-client</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-java</artifactId>
+      <version>2.6.0</version>
     </dependency>
 
     <dependency>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -23,6 +23,16 @@
       <version>2.6.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <version>5.1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.1.4</version>
+    </dependency>
+    <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
       <version>8.6.0</version>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -20,17 +20,17 @@
     <dependency>
       <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-java</artifactId>
-      <version>2.6.0</version>
+      <version>${opensearch-java.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <version>5.1.5</version>
+      <version>${httpcore5.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <version>5.1.4</version>
+      <version>${httpclient5.version}</version>
     </dependency>
     <dependency>
       <groupId>co.elastic.clients</groupId>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -138,7 +138,7 @@ public class OpenSearchIndexer extends Indexer {
       }
     }
     BulkResponse response = client.bulk(br.build());
-    if (response.errors()) {
+    if (response != null && response.errors()) {
       for (BulkResponseItem item : response.items()) {
         log.error("OpenSearchIndexer response has received error(s)", item.error().reason());
       }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -3,6 +3,7 @@ package com.kmwllc.lucille.indexer;
 import com.kmwllc.lucille.core.ConfigUtils;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Indexer;
+import com.kmwllc.lucille.core.IndexerException;
 import com.kmwllc.lucille.core.KafkaDocument;
 import com.kmwllc.lucille.message.IndexerMessageManager;
 import com.kmwllc.lucille.message.KafkaIndexerMessageManager;
@@ -141,6 +142,7 @@ public class OpenSearchIndexer extends Indexer {
     if (response != null && response.errors()) {
       for (BulkResponseItem item : response.items()) {
         log.error("OpenSearchIndexer response has received error(s)", item.error().reason());
+        throw new IndexerException(item.error().reason());
       }
     }
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -145,9 +145,7 @@ public class OpenSearchIndexer extends Indexer {
     BulkResponse response = client.bulk(br.build());
     if (response != null && response.errors()) {
       for (BulkResponseItem item : response.items()) {
-        String reason = item.error().reason();
-        log.error("OpenSearchIndexer response has received error(s)", reason);
-        throw new IndexerException(reason);
+        throw new IndexerException(item.error().reason());
       }
     }
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -3,38 +3,33 @@ package com.kmwllc.lucille.indexer;
 import com.kmwllc.lucille.core.ConfigUtils;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Indexer;
-import com.kmwllc.lucille.core.KafkaDocument;
 import com.kmwllc.lucille.message.IndexerMessageManager;
 import com.kmwllc.lucille.message.KafkaIndexerMessageManager;
 import com.kmwllc.lucille.util.OpenSearchUtils;
 import com.typesafe.config.Config;
-import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkResponse;
-import org.opensearch.action.index.IndexRequest;
-import org.opensearch.client.RequestOptions;
-import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.index.VersionType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import sun.misc.Signal;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.misc.Signal;
 
 public class OpenSearchIndexer extends Indexer {
 
   private static final Logger log = LoggerFactory.getLogger(OpenSearchIndexer.class);
 
-  private final RestHighLevelClient client;
+  private final OpenSearchClient client;
   private final String index;
 
   private final String routingField;
 
-  private final VersionType versionType;
+  //flag for using partial update API when sending documents to opensearch
+  private final boolean update;
 
-  public OpenSearchIndexer(Config config, IndexerMessageManager manager, RestHighLevelClient client, String metricsPrefix) {
+  public OpenSearchIndexer(Config config, IndexerMessageManager manager, OpenSearchClient client, String metricsPrefix) {
     super(config, manager, metricsPrefix);
     if (this.indexOverrideField != null) {
       throw new IllegalArgumentException(
@@ -43,15 +38,14 @@ public class OpenSearchIndexer extends Indexer {
     this.client = client;
     this.index = OpenSearchUtils.getOpenSearchIndex(config);
     this.routingField = config.hasPath("indexer.routingField") ? config.getString("indexer.routingField") : null;
-    this.versionType =
-        config.hasPath("indexer.versionType") ? VersionType.fromString(config.getString("indexer.versionType")) : null;
+    this.update = config.hasPath("opensearch.update") ? config.getBoolean("opensearch.update") : false;
   }
 
   public OpenSearchIndexer(Config config, IndexerMessageManager manager, boolean bypass, String metricsPrefix) {
     this(config, manager, getClient(config, bypass), metricsPrefix);
   }
 
-  private static RestHighLevelClient getClient(Config config, boolean bypass) {
+  private static OpenSearchClient getClient(Config config, boolean bypass) {
     return bypass ? null : OpenSearchUtils.getOpenSearchRestClient(config);
   }
 
@@ -62,7 +56,7 @@ public class OpenSearchIndexer extends Indexer {
     }
     boolean response;
     try {
-      response = client.ping(RequestOptions.DEFAULT);
+      response = client.ping().value();
     } catch (Exception e) {
       log.error("Couldn't ping OpenSearch ", e);
       return false;
@@ -76,11 +70,11 @@ public class OpenSearchIndexer extends Indexer {
 
   @Override
   public void closeConnection() {
-    if (client != null) {
+    if (client != null && client._transport() != null) {
       try {
-        client.close();
+        client._transport().close();
       } catch (Exception e) {
-        log.error("Error closing OpenSearchClient", e);
+        log.error("Error closing Opensearchclient", e);
       }
     }
   }
@@ -92,47 +86,40 @@ public class OpenSearchIndexer extends Indexer {
       return;
     }
 
-    BulkRequest bulkRequest = new BulkRequest(index);
+    BulkRequest.Builder br = new BulkRequest.Builder();
 
-    // determine what field to use as id field and iterate over the documents
     for (Document doc : documents) {
-      Map<String, Object> indexerDoc = getIndexerDoc(doc);
+      Map<String, Object> indexerDoc = doc.asMap();
 
       // remove children documents field from indexer doc (processed from doc by addChildren method call below)
       indexerDoc.remove(Document.CHILDREN_FIELD);
 
       // if a doc id override value exists, make sure it is used instead of pre-existing doc id
       String docId = Optional.ofNullable(getDocIdOverride(doc)).orElse(doc.getId());
+      indexerDoc.put(Document.ID_FIELD, docId);
 
       // handle special operations required to add children documents
       addChildren(doc, indexerDoc);
 
-      // create new IndexRequest
-      IndexRequest indexRequest = new IndexRequest(index);
-      indexRequest.id(docId);
-      if (routingField != null) {
-        indexRequest.routing(doc.getString(routingField));
-      }
-      indexRequest.source(indexerDoc);
-
-      if (versionType != null) {
-        indexRequest.versionType(versionType);
-        if (versionType == VersionType.EXTERNAL || versionType == VersionType.EXTERNAL_GTE) {
-          // the partition doesn’t need to be included in the version. We assume the doc id is used as the
-          // kafka message key, which should guarantee that all “versions” of a given document have the
-          // same kafka message key and therefore get mapped to the same topic partition.
-          indexRequest.version(((KafkaDocument) doc).getOffset());
-        }
+      if (update) {
+        br.operations(op -> op
+            .update(up -> up
+                .index(index)
+                .id(docId)
+                .document(doc)
+            ));
+      } else {
+        br.operations(op -> op
+            .index(idx -> idx
+                .index(index)
+                .id(docId)
+                .document(indexerDoc)
+            ));
       }
 
-      // add indexRequest to bulkRequest
-      bulkRequest.add(indexRequest);
-    }
 
-    BulkResponse response = client.bulk(bulkRequest, RequestOptions.DEFAULT);
-    if (response.hasFailures()) {
-      log.error(response.buildFailureMessage());
     }
+    client.bulk(br.build());
   }
 
   private void addChildren(Document doc, Map<String, Object> indexerDoc) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -107,16 +107,6 @@ public class OpenSearchIndexer extends Indexer {
       // handle special operations required to add children documents
       addChildren(doc, indexerDoc);
 
-//      if (versionType != null) {
-//        indexRequest.versionType(versionType);
-//        if (versionType == VersionType.External || versionType == VersionType.ExternalGte) {
-//          // the partition doesn’t need to be included in the version. We assume the doc id is used as the
-//          // kafka message key, which should guarantee that all “versions” of a given document have the
-//          // same kafka message key and therefore get mapped to the same topic partition.
-//          indexRequest.version(((KafkaDocument) doc).getOffset());
-//        }
-//      }
-
       // seems as though passing null to .routing(), .version(), or .versionType() will not affect the indexing process
       String routing = doc.getString(routingField);
       Long versionNum = (versionType == VersionType.External || versionType == VersionType.ExternalGte)

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -143,7 +143,8 @@ public class OpenSearchIndexer extends Indexer {
       }
     }
     BulkResponse response = client.bulk(br.build());
-    if (response != null && response.errors()) {
+    // We're choosing not to check response.errors(), instead iterating to be sure whether errors exist
+    if (response != null) {
       for (BulkResponseItem item : response.items()) {
         if (item.error() != null) {
           throw new IndexerException(item.error().reason());

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -107,21 +107,30 @@ public class OpenSearchIndexer extends Indexer {
       // handle special operations required to add children documents
       addChildren(doc, indexerDoc);
 
-      if (versionType != null) {
-        indexRequest.versionType(versionType);
-        if (versionType == VersionType.External || versionType == VersionType.ExternalGte) {
-          // the partition doesn’t need to be included in the version. We assume the doc id is used as the
-          // kafka message key, which should guarantee that all “versions” of a given document have the
-          // same kafka message key and therefore get mapped to the same topic partition.
-          indexRequest.version(((KafkaDocument) doc).getOffset());
-        }
-      }
+//      if (versionType != null) {
+//        indexRequest.versionType(versionType);
+//        if (versionType == VersionType.External || versionType == VersionType.ExternalGte) {
+//          // the partition doesn’t need to be included in the version. We assume the doc id is used as the
+//          // kafka message key, which should guarantee that all “versions” of a given document have the
+//          // same kafka message key and therefore get mapped to the same topic partition.
+//          indexRequest.version(((KafkaDocument) doc).getOffset());
+//        }
+//      }
+
+      // seems as though passing null to .routing(), .version(), or .versionType() will not affect the indexing process
+      String routing = doc.getString(routingField);
+      Long versionNum = (versionType == VersionType.External || versionType == VersionType.ExternalGte)
+          ? ((KafkaDocument) doc).getOffset()
+          : null;
 
       if (update) {
         br.operations(op -> op
             .update(up -> up
                 .index(index)
                 .id(docId)
+                .routing(routing)
+                .versionType(versionType)
+                .version(versionNum)
                 .document(doc)
             ));
       } else {
@@ -129,6 +138,9 @@ public class OpenSearchIndexer extends Indexer {
             .index(idx -> idx
                 .index(index)
                 .id(docId)
+                .routing(routing)
+                .versionType(versionType)
+                .version(versionNum)
                 .document(indexerDoc)
             ));
       }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -145,7 +145,9 @@ public class OpenSearchIndexer extends Indexer {
     BulkResponse response = client.bulk(br.build());
     if (response != null && response.errors()) {
       for (BulkResponseItem item : response.items()) {
-        throw new IndexerException(item.error().reason());
+        if (item.error() != null) {
+          throw new IndexerException(item.error().reason());
+        }
       }
     }
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -113,14 +113,7 @@ public class OpenSearchIndexer extends Indexer {
 
       // handle special operations required to add children documents
       addChildren(doc, indexerDoc);
-
-      Function<UpdateOperation.Builder, ObjectBuilder<UpdateOperation>> fn = new Function<Builder, ObjectBuilder<UpdateOperation>>() {
-        @Override
-        public ObjectBuilder<UpdateOperation> apply(Builder builder) {
-          return null;
-        }
-      };
-
+      
       String routing = doc.getString(routingField);
       Long versionNum = (versionType == VersionType.External || versionType == VersionType.ExternalGte)
         ? ((KafkaDocument) doc).getOffset()

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.util;
 
 import com.typesafe.config.Config;
+import java.net.URI;
 import nl.altindag.ssl.SSLFactory;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -10,8 +11,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder.HttpClientConfigCallback;
-
-import java.net.URI;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -2,19 +2,23 @@ package com.kmwllc.lucille.util;
 
 import com.typesafe.config.Config;
 import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLEngine;
 import nl.altindag.ssl.SSLFactory;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
-import org.opensearch.client.RestClient;
-import org.opensearch.client.RestClientBuilder.HttpClientConfigCallback;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.core5.function.Factory;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.reactor.ssl.TlsDetails;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
-import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 
 /**
  * Utility methods for communicating with OpenSearch.
@@ -33,16 +37,17 @@ public class OpenSearchUtils {
     URI hostUri = URI.create(getOpenSearchUrl(config));
 
     //Establish credentials to use basic authentication.
-    final CredentialsProvider provider = new BasicCredentialsProvider();
+    final BasicCredentialsProvider provider = new BasicCredentialsProvider();
 
     // get user info from URI if present and setup BasicAuth credentials if needed
     String userInfo = hostUri.getUserInfo();
+    HttpHost host = new HttpHost(hostUri.getScheme(), hostUri.getHost(), hostUri.getPort());
     if (userInfo != null) {
       int pos = userInfo.indexOf(":");
       String username = userInfo.substring(0, pos);
       String password = userInfo.substring(pos + 1);
-      provider.setCredentials(AuthScope.ANY,
-          new UsernamePasswordCredentials(username, password));
+      provider.setCredentials(new AuthScope(host),
+          new UsernamePasswordCredentials(username, password.toCharArray()));
     }
 
     // needed to allow for local testing of HTTPS
@@ -51,23 +56,55 @@ public class OpenSearchUtils {
     if (allowInvalidCert) {
       sslFactoryBuilder
           .withTrustingAllCertificatesWithoutValidation()
-          .withHostnameVerifier((host, session) -> true);
+          .withHostnameVerifier((sampleHost, sampleSession) -> true);
     } else {
       sslFactoryBuilder.withDefaultTrustMaterial();
     }
 
     SSLFactory sslFactory = sslFactoryBuilder.build();
 
-    RestClient restClient = RestClient.builder(new HttpHost(hostUri.getHost(), hostUri.getPort(), hostUri.getScheme()))
-        .setHttpClientConfigCallback(new HttpClientConfigCallback() {
-          @Override
-          public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-            return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext(sslFactory.getSslContext())
-                .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
-          }
-        }).build();
+//    RestClient restClient = RestClient.builder(new HttpHost(hostUri.getHost(), hostUri.getPort(), hostUri.getScheme()))
+//        .setHttpClientConfigCallback(new HttpClientConfigCallback() {
+//          @Override
+//          public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+//            return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext(sslFactory.getSslContext())
+//                .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
+//          }
+//        }).build();
+//
+//    final OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+//    final OpenSearchClient client = new OpenSearchClient(transport);
+//
+//    return client;
 
-    final OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+
+    ApacheHttpClient5TransportBuilder builder = ApacheHttpClient5TransportBuilder.builder(host);
+    builder.setHttpClientConfigCallback(httpClientBuilder -> {
+      final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
+          //.setSslContext(SSLContextBuilder.create().build())
+          .setSslContext(sslFactory.getSslContext())
+          .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {
+            @Override
+            public TlsDetails create(final SSLEngine sslEngine) {
+              return new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol());
+            }
+  //            @Override
+  //            public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+  //              return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext()
+  //                  .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
+  //            }
+        }).build();
+      final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
+          .create()
+          .setTlsStrategy(tlsStrategy)
+          .build();
+
+      return httpClientBuilder
+          .setDefaultCredentialsProvider(provider)
+          .setConnectionManager(connectionManager);
+    });
+
+    final OpenSearchTransport transport = ApacheHttpClient5TransportBuilder.builder(host).build();
     final OpenSearchClient client = new OpenSearchClient(transport);
 
     return client;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -68,35 +68,26 @@ public class OpenSearchUtils {
             boolean allowInvalidCert = getAllowInvalidCert(config);
             TlsStrategy tlsStrategy = null;
             SSLContext sslContext = null;
+            try {
             if (allowInvalidCert) {
-              try {
-                sslContext = SSLContextBuilder.create()
+              sslContext = SSLContextBuilder.create()
                     .loadTrustMaterial(null, (chains, authType) -> true)
                     .build();
-              } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException(e);
-              } catch (KeyManagementException e) {
-                throw new RuntimeException(e);
-              } catch (KeyStoreException e) {
-                throw new RuntimeException(e);
-              }
+
               tlsStrategy = ClientTlsStrategyBuilder.create()
                   .setSslContext(sslContext)
                   .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                   .build();
             } else {
-              try {
-                sslContext = SSLContextBuilder.create()
+              sslContext = SSLContextBuilder.create()
                     .build();
-              } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException(e);
-              } catch (KeyManagementException e) {
-                throw new RuntimeException(e);
-              }
               tlsStrategy = ClientTlsStrategyBuilder.create()
                   .setSslContext(sslContext)
                   //.setHostnameVerifier(new DefaultHostnameVerifier())
                   .build();
+            }
+            } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+              throw new RuntimeException(e);
             }
 
             final var connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -3,17 +3,21 @@ package com.kmwllc.lucille.util;
 import com.typesafe.config.Config;
 import java.net.URI;
 import java.security.KeyManagementException;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import javax.net.ssl.SSLEngine;
 import nl.altindag.ssl.SSLFactory;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.function.Factory;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
@@ -25,74 +29,136 @@ import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
  */
 public class OpenSearchUtils {
 
+  public static OpenSearchClient getOpenSearchRestClient(Config config) {
+    return getOpenSearchRestClientInternal(config);
+  }
+
   /**
    * Generate a RestHighLevelClient from the given config file. Supports Http OpenSearchClients.
    *
    * @param config The configuration file to generate a client from
    * @return the RestHighLevelClient client
    */
-  public static OpenSearchClient getOpenSearchRestClient(Config config) {
+  public static OpenSearchClient getOpenSearchRestClientInternal(Config config) {
+    try {
+      var env = System.getenv();
+      var https = Boolean.parseBoolean(env.getOrDefault("HTTPS", "true"));
+      var hostname = env.getOrDefault("HOST", "localhost");
+      var port = Integer.parseInt(env.getOrDefault("PORT", "9200"));
+      var user = env.getOrDefault("USERNAME", "admin");
+      var pass = env.getOrDefault("PASSWORD", "admin");
 
-    // get host uri
-    URI hostUri = URI.create(getOpenSearchUrl(config));
+      // get host uri
+      URI hostUri = URI.create(getOpenSearchUrl(config));
 
-    //Establish credentials to use basic authentication.
-    final BasicCredentialsProvider provider = new BasicCredentialsProvider();
+      String userInfo = hostUri.getUserInfo();
 
-    // get user info from URI if present and setup BasicAuth credentials if needed
-    String userInfo = hostUri.getUserInfo();
-    HttpHost host = new HttpHost(hostUri.getScheme(), hostUri.getHost(), hostUri.getPort());
-    if (userInfo != null) {
-      int pos = userInfo.indexOf(":");
-      String username = userInfo.substring(0, pos);
-      String password = userInfo.substring(pos + 1);
-      provider.setCredentials(new AuthScope(host),
-          new UsernamePasswordCredentials(username, password.toCharArray()));
-    }
+      final var hosts = new HttpHost[] {
+          new HttpHost(hostUri.getScheme(), hostUri.getHost(), hostUri.getPort())
+      };
 
-    // needed to allow for local testing of HTTPS
-    SSLFactory.Builder sslFactoryBuilder = SSLFactory.builder();
-    boolean allowInvalidCert = getAllowInvalidCert(config);
-    if (allowInvalidCert) {
-      sslFactoryBuilder
-          .withTrustingAllCertificatesWithoutValidation()
-          .withHostnameVerifier((sampleHost, sampleSession) -> true);
-    } else {
-      sslFactoryBuilder.withDefaultTrustMaterial();
-    }
 
-    SSLFactory sslFactory = sslFactoryBuilder.build();
-
-    ApacheHttpClient5TransportBuilder builder = ApacheHttpClient5TransportBuilder.builder(host);
-    builder.setHttpClientConfigCallback(httpClientBuilder -> {
-      final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
-          //.setSslContext(SSLContextBuilder.create().build())
-          .setSslContext(sslFactory.getSslContext())
-          .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {
-            @Override
-            public TlsDetails create(final SSLEngine sslEngine) {
-              return new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol());
-            }
-  //            @Override
-  //            public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-  //              return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext()
-  //                  .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
-  //            }
-        }).build();
-      final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
-          .create()
-          .setTlsStrategy(tlsStrategy)
+      final var sslContext = SSLContextBuilder.create()
+          .loadTrustMaterial(null, (chains, authType) -> true)
           .build();
 
-      return httpClientBuilder
-          .setDefaultCredentialsProvider(provider)
-          .setConnectionManager(connectionManager);
-    });
 
-    final OpenSearchTransport transport = ApacheHttpClient5TransportBuilder.builder(host).build();
-    final OpenSearchClient client = new OpenSearchClient(transport);
+      final var transport = ApacheHttpClient5TransportBuilder
+          .builder(hosts)
+          .setMapper(new JacksonJsonpMapper())
+          .setHttpClientConfigCallback(httpClientBuilder -> {
+            final var credentialsProvider = new BasicCredentialsProvider();
+            if (userInfo != null) {
+              int pos = userInfo.indexOf(":");
+              String username = userInfo.substring(0, pos);
+              String password = userInfo.substring(pos + 1);
+              for (final var host : hosts) {
+                credentialsProvider.setCredentials(
+                    new AuthScope(host),
+                    new UsernamePasswordCredentials(username, password.toCharArray()));
+              }
+            }
 
-    return client;
+            // Disable SSL/TLS verification as our local testing clusters use self-signed certificates
+            final var tlsStrategy = ClientTlsStrategyBuilder.create()
+                .setSslContext(sslContext)
+                .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                .build();
+
+            final var connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
+                .setTlsStrategy(tlsStrategy)
+                .build();
+
+            return httpClientBuilder
+                .setDefaultCredentialsProvider(credentialsProvider)
+                .setConnectionManager(connectionManager);
+          })
+          .build();
+
+      return new OpenSearchClient(transport);
+    } catch (Exception e) {
+      System.out.println("failed to make transport client");
+      return null;
+    }
+
+//    //Establish credentials to use basic authentication.
+//    final BasicCredentialsProvider provider = new BasicCredentialsProvider();
+//
+//    // get user info from URI if present and setup BasicAuth credentials if needed
+//    String userInfo = hostUri.getUserInfo();
+//    HttpHost host = new HttpHost(hostUri.getScheme(), hostUri.getHost(), hostUri.getPort());
+//    if (userInfo != null) {
+//      int pos = userInfo.indexOf(":");
+//      String username = userInfo.substring(0, pos);
+//      String password = userInfo.substring(pos + 1);
+//      provider.setCredentials(new AuthScope(host),
+//          new UsernamePasswordCredentials(username, password.toCharArray()));
+//    }
+//
+//    // needed to allow for local testing of HTTPS
+//    SSLFactory.Builder sslFactoryBuilder = SSLFactory.builder();
+//    boolean allowInvalidCert = getAllowInvalidCert(config);
+//    if (allowInvalidCert) {
+//      sslFactoryBuilder
+//          .withTrustingAllCertificatesWithoutValidation()
+//          .withHostnameVerifier((sampleHost, sampleSession) -> true);
+//    } else {
+//      sslFactoryBuilder.withDefaultTrustMaterial();
+//    }
+//
+//    SSLFactory sslFactory = sslFactoryBuilder.build();
+//
+//    ApacheHttpClient5TransportBuilder builder = ApacheHttpClient5TransportBuilder.builder(host);
+//    builder.setHttpClientConfigCallback(httpClientBuilder -> {
+//      final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
+//          //.setSslContext(SSLContextBuilder.create().build())
+//          .setSslContext(sslFactory.getSslContext())
+//          .setHostnameVerifier(sslFactory.getHostnameVerifier())
+//          .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {
+//            @Override
+//            public TlsDetails create(final SSLEngine sslEngine) {
+//              return new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol());
+//            }
+//  //            @Override
+//  //            public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+//  //              return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext()
+//  //                  .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
+//  //            }
+//        }).build();
+//      final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
+//          .create()
+//          .setTlsStrategy(tlsStrategy)
+//          .build();
+//
+//      return httpClientBuilder
+//          .setDefaultCredentialsProvider(provider)
+//          .setConnectionManager(connectionManager);
+//    });
+//
+//    final OpenSearchTransport transport = ApacheHttpClient5TransportBuilder.builder(host).build();
+//    final OpenSearchClient client = new OpenSearchClient(transport);
+//
+//    return client;
   }
 
   public static String getOpenSearchUrl(Config config) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -2,28 +2,19 @@ package com.kmwllc.lucille.util;
 
 import com.typesafe.config.Config;
 import java.net.URI;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import javax.net.ssl.SSLEngine;
-import nl.altindag.ssl.SSLFactory;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
-import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
-import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.core5.function.Factory;
-import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
-import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
-import org.apache.hc.core5.http.HttpHost;
-import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 
 /**
  * Utility methods for communicating with OpenSearch.
@@ -48,15 +39,13 @@ public class OpenSearchUtils {
 
       String userInfo = hostUri.getUserInfo();
 
-      final var hosts = new HttpHost[] {
+      final var hosts = new HttpHost[]{
           new HttpHost(hostUri.getScheme(), hostUri.getHost(), hostUri.getPort())
       };
-
 
       final var sslContext = SSLContextBuilder.create()
           .loadTrustMaterial(null, (chains, authType) -> true)
           .build();
-
 
       final var transport = ApacheHttpClient5TransportBuilder
           .builder(hosts)
@@ -88,7 +77,6 @@ public class OpenSearchUtils {
                   .setHostnameVerifier(new DefaultHostnameVerifier())
                   .build();
             }
-
 
             final var connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
                 .setTlsStrategy(tlsStrategy)

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -63,21 +63,6 @@ public class OpenSearchUtils {
 
     SSLFactory sslFactory = sslFactoryBuilder.build();
 
-//    RestClient restClient = RestClient.builder(new HttpHost(hostUri.getHost(), hostUri.getPort(), hostUri.getScheme()))
-//        .setHttpClientConfigCallback(new HttpClientConfigCallback() {
-//          @Override
-//          public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-//            return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext(sslFactory.getSslContext())
-//                .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
-//          }
-//        }).build();
-//
-//    final OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
-//    final OpenSearchClient client = new OpenSearchClient(transport);
-//
-//    return client;
-
-
     ApacheHttpClient5TransportBuilder builder = ApacheHttpClient5TransportBuilder.builder(host);
     builder.setHttpClientConfigCallback(httpClientBuilder -> {
       final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -63,7 +63,7 @@ public class OpenSearchUtils {
               }
             }
 
-            // Disable SSL/TLS verification as our local testing clusters use self-signed certificates
+            // Potentially disable SSL/TLS verification for when testing locally
             boolean allowInvalidCert = getAllowInvalidCert(config);
             TlsStrategy tlsStrategy = null;
             if (allowInvalidCert) {
@@ -93,65 +93,6 @@ public class OpenSearchUtils {
       System.out.println("failed to make transport client");
       return null;
     }
-
-//    //Establish credentials to use basic authentication.
-//    final BasicCredentialsProvider provider = new BasicCredentialsProvider();
-//
-//    // get user info from URI if present and setup BasicAuth credentials if needed
-//    String userInfo = hostUri.getUserInfo();
-//    HttpHost host = new HttpHost(hostUri.getScheme(), hostUri.getHost(), hostUri.getPort());
-//    if (userInfo != null) {
-//      int pos = userInfo.indexOf(":");
-//      String username = userInfo.substring(0, pos);
-//      String password = userInfo.substring(pos + 1);
-//      provider.setCredentials(new AuthScope(host),
-//          new UsernamePasswordCredentials(username, password.toCharArray()));
-//    }
-//
-//    // needed to allow for local testing of HTTPS
-//    SSLFactory.Builder sslFactoryBuilder = SSLFactory.builder();
-//    boolean allowInvalidCert = getAllowInvalidCert(config);
-//    if (allowInvalidCert) {
-//      sslFactoryBuilder
-//          .withTrustingAllCertificatesWithoutValidation()
-//          .withHostnameVerifier((sampleHost, sampleSession) -> true);
-//    } else {
-//      sslFactoryBuilder.withDefaultTrustMaterial();
-//    }
-//
-//    SSLFactory sslFactory = sslFactoryBuilder.build();
-//
-//    ApacheHttpClient5TransportBuilder builder = ApacheHttpClient5TransportBuilder.builder(host);
-//    builder.setHttpClientConfigCallback(httpClientBuilder -> {
-//      final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
-//          //.setSslContext(SSLContextBuilder.create().build())
-//          .setSslContext(sslFactory.getSslContext())
-//          .setHostnameVerifier(sslFactory.getHostnameVerifier())
-//          .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {
-//            @Override
-//            public TlsDetails create(final SSLEngine sslEngine) {
-//              return new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol());
-//            }
-//  //            @Override
-//  //            public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-//  //              return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext()
-//  //                  .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
-//  //            }
-//        }).build();
-//      final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
-//          .create()
-//          .setTlsStrategy(tlsStrategy)
-//          .build();
-//
-//      return httpClientBuilder
-//          .setDefaultCredentialsProvider(provider)
-//          .setConnectionManager(connectionManager);
-//    });
-//
-//    final OpenSearchTransport transport = ApacheHttpClient5TransportBuilder.builder(host).build();
-//    final OpenSearchClient client = new OpenSearchClient(transport);
-//
-//    return client;
   }
 
   public static String getOpenSearchUrl(Config config) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -1,5 +1,6 @@
 package com.kmwllc.lucille.util;
 
+import com.kmwllc.lucille.indexer.OpenSearchIndexer;
 import com.typesafe.config.Config;
 import java.net.URI;
 import java.security.KeyManagementException;
@@ -18,11 +19,15 @@ import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility methods for communicating with OpenSearch.
  */
 public class OpenSearchUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(OpenSearchIndexer.class);
 
   /**
    * Generate a RestHighLevelClient from the given config file. Supports Apache Http OpenSearchClient
@@ -101,7 +106,7 @@ public class OpenSearchUtils {
 
       return new OpenSearchClient(transport);
     } catch (Exception e) {
-      System.out.println("failed to make transport client");
+      log.error("Failed to make transport client for open search indexer", e);
       return null;
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -292,7 +292,7 @@ public class OpenSearchIndexerTest {
   @Test
   public void testDocumentVersioning() throws Exception {
     PersistingLocalMessageManager manager = new PersistingLocalMessageManager();
-    Config config = ConfigFactory.load("OpenSearchIndexerTest/routing.conf");
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/versioning.conf");
 
     KafkaDocument doc = new KafkaDocument(
         new ObjectMapper().createObjectNode()

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -39,6 +39,10 @@ public class OpenSearchIndexerTest {
     setupOpenSearchClient();
   }
 
+  // TODO:
+  // - see if there's a modern way to skip before test or mark individual tests that need it / don't need it
+  // - try to override when statement with new when that returns a BulkResponse that has Errors in it
+  // - if that doesn't work, make new client
   private void setupOpenSearchClient() throws IOException {
     mockClient = Mockito.mock(OpenSearchClient.class);
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -46,9 +46,6 @@ public class OpenSearchIndexerTest {
     setupOpenSearchClient();
   }
 
-  // TODO:
-  // - try to override when statement with new when that returns a BulkResponse that has Errors in it
-  // - if that doesn't work, make new client
   private void setupOpenSearchClient() throws IOException {
     mockClient = Mockito.mock(OpenSearchClient.class);
 
@@ -63,16 +60,6 @@ public class OpenSearchIndexerTest {
     BulkRequest mockBulkRequest = Mockito.mock(BulkRequest.class);
     Mockito.when(mockRequestBuilder.build()).thenReturn(mockBulkRequest);
     Mockito.when(mockClient.bulk(mockBulkRequest)).thenReturn(mockResponse);
-
-//    // mocking for the bulk response items and error causes
-//    BulkResponseItem.Builder mockItemBuilder = Mockito.mock(BulkResponseItem.Builder.class);
-//    BulkResponseItem mockItem = Mockito.mock(BulkResponseItem.class);
-//    ErrorCause mockError = new ErrorCause.Builder().reason("mock reason").type("mock-type").build();
-//    Mockito.when(mockItemBuilder.build()).thenReturn(mockItem);
-//    Mockito.when(mockItem.error()).thenReturn(mockError);
-//
-//    List<BulkResponseItem> bulkResponseItems = Arrays.asList(mockItem, mockItem);
-//    Mockito.when(mockResponse.items()).thenReturn(bulkResponseItems);
   }
 
   /**
@@ -351,7 +338,6 @@ public class OpenSearchIndexerTest {
     BulkResponse mockResponse = Mockito.mock(BulkResponse.class);
     BulkRequest mockBulkRequest = Mockito.mock(BulkRequest.class);
     Mockito.when(mockRequestBuilder.build()).thenReturn(mockBulkRequest);
-    //Mockito.when(mockClient.bulk(mockBulkRequest)).thenReturn(mockResponse);
     Mockito.when(mockClient.bulk(ArgumentMatchers.any(BulkRequest.class))).thenReturn(mockResponse);
 
     // mocking for the bulk response items and error causes

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1,5 +1,9 @@
 package com.kmwllc.lucille.indexer;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kmwllc.lucille.core.Document;
@@ -9,30 +13,22 @@ import com.kmwllc.lucille.message.IndexerMessageManager;
 import com.kmwllc.lucille.message.PersistingLocalMessageManager;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import org.opensearch.client.RequestOptions;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.VersionType;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
-import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.client.transport.endpoints.BooleanResponse;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class OpenSearchIndexerTest {
 

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/versioning.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/versioning.conf
@@ -1,6 +1,6 @@
 indexer {
   type : "OpenSearch"
-  versionType: "external_gte"
+  versionType: "ExternalGte"
   batchSize : 1
   batchTimeout : 1000
   logRate : 1000

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -24,8 +24,6 @@
     <jackson.version>2.12.2</jackson.version>
     <!-- todo if updated to version 9 will need to add solr-solrj-zookeeper dependency -->
     <lucene-solr.version>8.11.1</lucene-solr.version>
-    <opensearch-rest-client.version>1.2.0</opensearch-rest-client.version>
-    <opensearch-rest-high-level-client.version>1.2.3</opensearch-rest-high-level-client.version>
     <opensearch.version>0.1.0</opensearch.version>
     <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
     <elasticsearch.version>7.17.3</elasticsearch.version>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -25,6 +25,9 @@
     <!-- todo if updated to version 9 will need to add solr-solrj-zookeeper dependency -->
     <lucene-solr.version>8.11.1</lucene-solr.version>
     <opensearch.version>0.1.0</opensearch.version>
+    <opensearch-java.version>2.6.0</opensearch-java.version>
+    <httpcore5.version>5.1.5</httpcore5.version>
+    <httpclient5.version>5.1.4</httpclient5.version>
     <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
     <elasticsearch.version>7.17.3</elasticsearch.version>
     <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>
@@ -36,6 +39,7 @@
     <netty.version>4.1.89.Final</netty.version>
     <grpc.version>1.53.0</grpc.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
   </properties>
 
   <repositories>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -27,7 +27,7 @@
     <opensearch.version>0.1.0</opensearch.version>
     <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
     <elasticsearch.version>7.17.3</elasticsearch.version>
-    <sslcontext-kickstart.version>7.0.3</sslcontext-kickstart.version>
+    <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>
     <aws-java-sdk-sts.version>1.12.39</aws-java-sdk-sts.version>
     <vfs-s3.version>4.3.6</vfs-s3.version>
     <log4j.version>2.17.0</log4j.version>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -14,6 +14,8 @@
   <properties>
     <at>@</at>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>


### PR DESCRIPTION
LC-335
Changed from RestHighLevelClient to JavaClient for OpenSearch in light of the fact that OpenSearch 3.0.0 will no longer support RestHighLevelClient. 