### PR TITLE
LC-358: add test coverage for Document.asMap()

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
@@ -597,7 +597,11 @@ public class HashMapDocument implements Document, Serializable {
 
   @Override
   public Map<String, Object> asMap() {
-    return data.getData();
+    // create a shallow copy of the document data
+    // adding, replacing, or removing entries in the returned map will not affect the original document
+    // however, updates made to an object inside the map (for example, changing the contents of an array value) will
+    // be evident when that same object is retrieved from the original document
+    return (Map<String, Object>)data.getData().clone();
   }
 
   @Override

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
@@ -257,6 +257,32 @@ public abstract class DocumentTest {
   }
 
   @Test
+  public void testAsMapReturnsCopy() {
+    // confirm that modifying the map returned by Document.asMap does not affect the original document
+    // this assumption is important in various Indexers where a Document is converted to a Map and then
+    // various "ignoreFields" are removed from that map before indexing. The list of "ignoreFields" might include
+    // the id field. But we never want the id of the _original_ document to be removed. In particular, that ID
+    // is needed later in the workflow for accounting.
+    Document document = createDocument("123");
+    document.setField("myField", "hello");
+    Map docMap = document.asMap();
+    docMap.remove(Document.ID_FIELD);
+    docMap.remove("myField");
+    docMap.put("myField2", "hello2");
+    assertEquals("123", document.getId());
+    assertEquals("hello", document.getString("myField"));
+    assertFalse(document.has("myField2"));
+
+    // Note that we do not currently test whether asMap returns a shallow or deep copy of the document data.
+    // For example, modifying the contents of an array value inside the Map might or might not affect the contents
+    // of that same array in the original document. Deep copying could be tested as follows but HashMapDocument would not pass:
+    // byte[] myBytes = new byte[]{0x3c, 0x4c, 0x5c};
+    // document.setField("myBytes", myBytes);
+    // ((byte[])docMap.get("myBytes"))[0] = 0x5c;
+    // assertEquals(0x5c, document.getBytes("myBytes")[0]);
+  }
+
+  @Test
   public void testAddToField() {
     Document document = createDocument("123");
     assertFalse(document.has("field1"));


### PR DESCRIPTION
add test and update HashMapDocument.asMap to return shallow copy of internal data so test passes