### PR TITLE
LC-372 Fix bug with Intermitten Failures for AddRandomFieldTest

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
@@ -29,7 +29,7 @@ import java.util.stream.IntStream;
  * <br>
  * <p>
  * <b>inputDataPath</b> (String, Optional) : file path to a text file that stores datapoints to be randomly placed into field,
- *  defaults to numeric data based on range size
+ *  defaults to numeric data based on range size (0 -> rangeSize - 1)
  * </p>
  * <p>
  * <b>fieldName</b> (String, Optional) : Field name of field where data is placed, defaults to "data"
@@ -45,14 +45,10 @@ import java.util.stream.IntStream;
  * <b>maxNumOfTerms</b> (Integer, Optional) : maximum number of terms to be in the field, defaults to 1
  * </p>
  * <p>
- * <b>fieldStructure</b> (FieldType, Optional) : setting for structure of field, default or nested, allows for further settings to be easily added
+ * <b>isNested</b> (FieldType, Optional) : setting for structure of field, default or nested
  * </p>
  */
 public class AddRandomField extends Stage {
-
-  enum FieldStructure {
-    DEFAULT, NESTED
-  }
 
   private final String inputDataPath;
   private final String fieldName;
@@ -146,7 +142,7 @@ public class AddRandomField extends Stage {
       }
     } else {
       // create sequential list of numbers ending at range size
-      List<Integer> seqList = IntStream.range(1, rangeSize)
+      List<Integer> seqList = IntStream.range(0, rangeSize)
           .boxed().collect(Collectors.toList());
       uniqueValues = seqList.stream().map(i -> i.toString()).collect(Collectors.toList());
     }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
@@ -146,7 +146,7 @@ public class AddRandomField extends Stage {
       }
     } else {
       // create sequential list of numbers ending at range size
-      List<Integer> seqList = IntStream.rangeClosed(1, rangeSize)
+      List<Integer> seqList = IntStream.range(1, rangeSize)
           .boxed().collect(Collectors.toList());
       uniqueValues = seqList.stream().map(i -> i.toString()).collect(Collectors.toList());
     }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/AddRandomFieldTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/AddRandomFieldTest.java
@@ -40,9 +40,9 @@ public class AddRandomFieldTest {
     int docVal1 = Integer.valueOf(doc1.getString("data"));
     int docVal2 = Integer.valueOf(doc2.getString("data"));
     int docVal3 = Integer.valueOf(doc3.getString("data"));
-    assertTrue(0 < docVal1 && docVal1 < 20);
-    assertTrue(0 < docVal2 && docVal2 < 20);
-    assertTrue(0 < docVal3 && docVal3 < 20);
+    assertTrue(0 <= docVal1 && docVal1 < 20);
+    assertTrue(0 <= docVal2 && docVal2 < 20);
+    assertTrue(0 <= docVal3 && docVal3 < 20);
   }
 
   /**


### PR DESCRIPTION
Saw errors due to the randomness of this stage, fixed by changing the range of the values being generated from closed to open. Confirmed no errors by using IntelliJ repeat feature to run all tests for this Stage 10,000+ times