### PR TITLE
LC-263 include line number when logging csv processing errors, where possible

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
@@ -176,7 +176,7 @@ public class CSVConnector extends AbstractConnector {
         if (line.length != header.length) {
           // the line/row number reported here may differ from the physical line number in the file, if the CSV contains
           // a quoted value that spans multiple lines
-          log.warn(String.format("Logical row %d of the csv has a different number of columns than the header.", lineNum));
+          log.warn("Logical row {} of the csv has a different number of columns than the header.", lineNum);
           continue;
         }
         String docId = "";
@@ -211,12 +211,12 @@ public class CSVConnector extends AbstractConnector {
         moveFile(filePath, moveToAfterProcessing);
       }
     } catch (CsvException e) { // base class for most opencsv exceptions
-      log.error("Error during CSV processing at line " + e.getLineNumber(), e);
+      log.error("Error during CSV processing at line {}", e.getLineNumber(), e);
       if (moveToErrorFolder != null) {
         moveFile(filePath, moveToErrorFolder);
       }
     } catch (CsvMalformedLineException e) { // an IOException, not a CsvException
-      log.error("Error during CSV processing at line " + e.getLineNumber(), e);
+      log.error("Error during CSV processing at line {}", e.getLineNumber(), e);
       if (moveToErrorFolder != null) {
         moveFile(filePath, moveToErrorFolder);
       }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
@@ -8,6 +8,9 @@ import com.opencsv.CSVParser;
 import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvException;
+import com.opencsv.exceptions.CsvMalformedLineException;
+import com.opencsv.exceptions.CsvValidationException;
 import com.typesafe.config.Config;
 import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -171,7 +174,9 @@ public class CSVConnector extends AbstractConnector {
           continue;
         }
         if (line.length != header.length) {
-          log.warn(String.format("Line %d of the csv has a different number of columns than columns in the header.", lineNum));
+          // the line/row number reported here may differ from the physical line number in the file, if the CSV contains
+          // a quoted value that spans multiple lines
+          log.warn(String.format("Logical row %d of the csv has a different number of columns than the header.", lineNum));
           continue;
         }
         String docId = "";
@@ -205,13 +210,22 @@ public class CSVConnector extends AbstractConnector {
       if (moveToAfterProcessing != null) {
         moveFile(filePath, moveToAfterProcessing);
       }
+    } catch (CsvException e) { // base class for most opencsv exceptions
+      log.error("Error during CSV processing at line " + e.getLineNumber(), e);
+      if (moveToErrorFolder != null) {
+        moveFile(filePath, moveToErrorFolder);
+      }
+    } catch (CsvMalformedLineException e) { // an IOException, not a CsvException
+      log.error("Error during CSV processing at line " + e.getLineNumber(), e);
+      if (moveToErrorFolder != null) {
+        moveFile(filePath, moveToErrorFolder);
+      }
     } catch (Exception e) {
       log.error("Error during CSV processing", e);
       if (moveToErrorFolder != null) {
         moveFile(filePath, moveToErrorFolder);
       }
     }
-
   }
 
   private String createDocId(ArrayList<String> idColumnData) {


### PR DESCRIPTION
When opencsv throws a CsvException or CsvMalformedLineException we can call getLineNumber() to obtain the physical line number where the error was encountered.

This PR simply updates the CsvConnector's error logging code to include the line number when we can get it.

For the following csv file, the error should reference line 9:

```
a,b,c      # line 1: header
1,2,3      # line 2: valid row
           # line 3: empty row that is skipped
4,5,"      # line 4: beginning of a multi-line row
           # line 5: part of multi-line row
6"         # line 6: end of multi-line row
7,8,9.     # line 7: valid row
10,11      # line 8: row with too few columns, but still accepted (only generates warning) 
13,14,15"  # line 9: row with unterminated quote -- beginning of problem
16,17
19,20,21
22,23
```

Tests are not included because the only behavior being changed here is log output. We don't have a good way to capture log output in tests.

I found that the following library works: 

```
    <!--  test dependency for capturing log output -->
    <dependency>
        <groupId>io.github.hakky54</groupId>
        <artifactId>logcaptor</artifactId>
        <version>2.9.0</version>
        <scope>test</scope>
    </dependency>
```

However, it requires the maven-surefire-plugin configuration in lucille-parent.xml to be updated with:

```
          <classpathDependencyExcludes>
              <classpathDependencyExclude>org.apache.logging.log4j:log4j-slf4j-impl</classpathDependencyExclude>
              <classpathDependencyExclude>org.apache.logging.log4j:log4j-slf4j2-impl</classpathDependencyExclude>
          </classpathDependencyExcludes>
```

which breaks HeartBeatTest where we're attempting to read from a physical log file. Deferring the issue of capturing log output in tests to elsewhere.

This PR is meant as a replacement for https://github.com/kmwtechnology/lucille/pull/61

The earlier PR was too aggressive in trying to recover from csv parsing exceptions, leading to scenarios where the reported line number could be wrong and some lines after an initial error might not be parsed properly.