### PR TITLE
LC-386 Rename methods in Messenger classes for better clarity and consistency

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -167,7 +167,7 @@ public abstract class Indexer implements Runnable {
     try {
       // blocking poll with a timeout which we assume to be in the range of
       // several milliseconds to several seconds
-      doc = messenger.pollCompleted();
+      doc = messenger.pollDocToIndex();
     } catch (Exception e) {
       log.info("Indexer interrupted ", e);
       terminate();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
@@ -113,7 +113,7 @@ class Worker implements Runnable {
             messenger.sendEvent(result, null, Event.Type.DROP);
           } else {
             // send the completed document to the queue for indexing
-            messenger.sendCompleted(result);
+            messenger.sendForIndexing(result);
           }
         }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/HybridIndexerMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/HybridIndexerMessenger.java
@@ -46,7 +46,7 @@ public class HybridIndexerMessenger implements IndexerMessenger {
   }
 
   @Override
-  public Document pollCompleted() throws Exception {
+  public Document pollDocToIndex() throws Exception {
     return pipelineDest.poll(LocalMessenger.POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/HybridWorkerMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/HybridWorkerMessenger.java
@@ -87,7 +87,7 @@ public class HybridWorkerMessenger implements WorkerMessenger {
    *
    */
   @Override
-  public void sendCompleted(Document document) throws Exception {
+  public void sendForIndexing(Document document) throws Exception {
     pipelineDest.put(document);
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/IndexerMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/IndexerMessenger.java
@@ -22,7 +22,7 @@ public interface IndexerMessenger {
    * to several seconds so that this method can be called from within a polling loop that
    * periodically checks other conditions even when no Documents are available.
    */
-  Document pollCompleted() throws Exception;
+  Document pollDocToIndex() throws Exception;
 
   /**
    * Make the designated Event available to the Publisher or any other component that is listening for

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaIndexerMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaIndexerMessenger.java
@@ -35,7 +35,7 @@ public class KafkaIndexerMessenger implements IndexerMessenger {
    * Polls for a document that has been processed by the pipeine and is waiting to be indexed.
    */
   @Override
-  public Document pollCompleted() throws Exception {
+  public Document pollDocToIndex() throws Exception {
     ConsumerRecords<String, KafkaDocument> consumerRecords = destConsumer.poll(KafkaUtils.POLL_INTERVAL);
     KafkaUtils.validateAtMostOneRecord(consumerRecords);
     if (consumerRecords.count() > 0) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaWorkerMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaWorkerMessenger.java
@@ -64,7 +64,7 @@ public class KafkaWorkerMessenger implements WorkerMessenger {
    *
    */
   @Override
-  public void sendCompleted(Document document) throws Exception {
+  public void sendForIndexing(Document document) throws Exception {
     RecordMetadata result = kafkaDocumentProducer.send(
         new ProducerRecord<>(KafkaUtils.getDestTopicName(pipelineName), document.getId(), document)).get();
     kafkaDocumentProducer.flush();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/LocalMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/LocalMessenger.java
@@ -49,7 +49,7 @@ public class LocalMessenger implements IndexerMessenger, PublisherMessenger, Wor
   private String pipelineName;
 
   @Override
-  public Document pollCompleted() throws Exception {
+  public Document pollDocToIndex() throws Exception {
     return pipelineDest.poll(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 
@@ -63,7 +63,7 @@ public class LocalMessenger implements IndexerMessenger, PublisherMessenger, Wor
   }
 
   @Override
-  public void sendCompleted(Document document) throws Exception {
+  public void sendForIndexing(Document document) throws Exception {
     pipelineDest.put(document);
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/PublisherMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/PublisherMessenger.java
@@ -35,7 +35,7 @@ public interface PublisherMessenger {
    * Intended to be called in a polling loop where pollEvent() would periodically timeout
    * so that other conditions can be checked as the loop is waiting for the next event.
    *
-   * Events sent via WorkerMessenger.sendEvent() and IndexMessageManager.sendEvent()
+   * Events sent via WorkerMessenger.sendEvent() and IndexMessenger.sendEvent()
    * are returned by the current method, PublisherMessenger.pollEvent()
    */
   Event pollEvent() throws Exception;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/TestMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/TestMessenger.java
@@ -29,8 +29,8 @@ public class TestMessenger implements IndexerMessenger, PublisherMessenger,
   }
 
   @Override
-  public Document pollCompleted() throws Exception {
-    return messenger.pollCompleted();
+  public Document pollDocToIndex() throws Exception {
+    return messenger.pollDocToIndex();
   }
 
   @Override
@@ -44,9 +44,9 @@ public class TestMessenger implements IndexerMessenger, PublisherMessenger,
   }
 
   @Override
-  public void sendCompleted(Document document) throws Exception {
+  public void sendForIndexing(Document document) throws Exception {
     savedDestMessages.add(document);
-    messenger.sendCompleted(document);
+    messenger.sendForIndexing(document);
   }
 
   @Override
@@ -98,15 +98,24 @@ public class TestMessenger implements IndexerMessenger, PublisherMessenger,
     messenger.batchComplete(batch);
   }
 
-  public List<Event> getSavedEvents() {
+  /**
+   * Returns the ordered history of all Events sent via sendEvent().
+   */
+  public List<Event> getSentEvents() {
     return savedEventMessages;
   }
 
-  public List<Document> getSavedDocumentsSentForProcessing() {
+  /**
+   * Returns the ordered history of all Documents sent via sendForProcessing().
+   */
+  public List<Document> getDocsSentForProcessing() {
     return savedSourceMessages;
   }
 
-  public List<Document> getSavedCompletedDocuments() {
+  /**
+   * Returns the ordered history of all Documents sent via sendForIndexing().
+   */
+  public List<Document> getDocsSentForIndexing() {
     return savedDestMessages;
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/WorkerMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/WorkerMessenger.java
@@ -7,8 +7,8 @@ import com.kmwllc.lucille.core.Event;
  * API that a Worker uses to exchange messages with other components.
  *
  * A Worker needs a way to 1) receive Documents to process, 2) send processed Documents to
- * a destination, and 3) send Events relating to Documents being processed (e.g. if a child Document is
- * created, if a Document can't be processed, etc.)
+ * a destination where they can wait for indexing, and 3) send Events relating to
+ * Documents being processed (e.g. if a child Document is created, if a Document can't be processed, etc.)
  *
  */
 public interface WorkerMessenger {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/WorkerMessenger.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/WorkerMessenger.java
@@ -34,7 +34,7 @@ public interface WorkerMessenger {
    * Submit a given Document so that it can be received by an Indexer component that
    * would call IndexerMessenger.pollCompleted()
    */
-  void sendCompleted(Document document) throws Exception;
+  void sendForIndexing(Document document) throws Exception;
 
   /**
    * Submit a given Document to a "Dead Letter Queue" for Documents that cannot be processed.

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/CSVConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/CSVConnectorTest.java
@@ -42,7 +42,7 @@ public class CSVConnectorTest {
     //  d, "e,f", g
     //  x, y, z
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(3, docs.size());
 
     System.out.println(docs.get(1));
@@ -64,7 +64,7 @@ public class CSVConnectorTest {
     //  x	y	z
 
     // verify that tabs takes precedence over specified separator character
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     System.out.println(docs.get(1));
     assertEquals(3, docs.size());
     assertEquals("\"e,f", docs.get(1).getString("field2"));
@@ -93,7 +93,7 @@ public class CSVConnectorTest {
     // Pizza, 10, Italy
     // Tofu Soup, 12, Korea
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(3, docs.size());
 
     // retrieve a document from the list and ensure that the first column does not contain the BOM
@@ -179,7 +179,7 @@ public class CSVConnectorTest {
     //  d	f	g
     //  x	y	z
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(3, docs.size());
     assertEquals("a", docs.get(0).getString("field1"));
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/JSONConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/JSONConnectorTest.java
@@ -28,7 +28,7 @@ public class JSONConnectorTest {
     // {"id": "2", "field3":"val3", "field2":["val2-2a", "val2-2b"]}
     // {"id": "3", "field4":"val4", "field5":"val5"}
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(3, docs.size());
 
     // prefix should be applied to doc ids and run_id should be added

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/SequenceConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/SequenceConnectorTest.java
@@ -22,7 +22,7 @@ public class SequenceConnectorTest {
     Connector connector = new SequenceConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(100, docs.size());
 
     // prefix should be applied to doc ids and run_id should be added

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/SolrConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/SolrConnectorTest.java
@@ -62,8 +62,8 @@ public class SolrConnectorTest {
 
     //verify(mockPublisher, times(2)).publish(testDoc);
 
-    assertEquals(2, messenger.getSavedDocumentsSentForProcessing().size());
-    for (Document doc : messenger.getSavedDocumentsSentForProcessing()) {
+    assertEquals(2, messenger.getDocsSentForProcessing().size());
+    for (Document doc : messenger.getDocsSentForProcessing()) {
       assertEquals(testDoc, doc);
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/VFSConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/VFSConnectorTest.java
@@ -25,7 +25,7 @@ public class VFSConnectorTest {
     String[] fileNames = {"a.json", "b.json", "c.json", "d.json",
         "subdir1/e.json", "subdir1/e.json.gz", "subdir1/e.yaml", "subdir1/f.jsonl"};
     int docCount = 0;
-    for (Document doc : messenger.getSavedDocumentsSentForProcessing()) {
+    for (Document doc : messenger.getDocsSentForProcessing()) {
       String docId = doc.getId();
       String filePath = doc.getString(VFSConnector.FILE_PATH);
       // skip if it's an automatically generated Finder file because the directory was opened
@@ -52,9 +52,9 @@ public class VFSConnectorTest {
     Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
     Connector connector = new VFSConnector(config);
     connector.execute(publisher);
-    Assert.assertEquals(3, messenger.getSavedDocumentsSentForProcessing().size());
+    Assert.assertEquals(3, messenger.getDocsSentForProcessing().size());
     String[] fileNames = {"a.json", "b.json", "c.json"};
-    for (Document doc : messenger.getSavedDocumentsSentForProcessing()) {
+    for (Document doc : messenger.getDocsSentForProcessing()) {
       String docId = doc.getId();
       String filePath = doc.getString(VFSConnector.FILE_PATH);
       String content = new String(doc.getBytes(VFSConnector.CONTENT));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/XMLConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/XMLConnectorTest.java
@@ -27,7 +27,7 @@ public class XMLConnectorTest {
     Connector connector = new XMLConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
 
     assertEquals(2, docs.size());
 
@@ -49,7 +49,7 @@ public class XMLConnectorTest {
     Connector connector = new XMLConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
 
     // ensure that in a nested scenario, the nested tag does not get included
     assertEquals(2, docs.size());
@@ -65,7 +65,7 @@ public class XMLConnectorTest {
     Connector connector = new XMLConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
 
     assertEquals(1, docs.size());
 
@@ -87,7 +87,7 @@ public class XMLConnectorTest {
     Connector connector = new XMLConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
 
     assertEquals(1, docs.size());
 
@@ -108,7 +108,7 @@ public class XMLConnectorTest {
     Connector connector = new XMLConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
 
     assertEquals(1, docs.size());
 
@@ -130,7 +130,7 @@ public class XMLConnectorTest {
     Connector connector = new XMLConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
 
     assertEquals(2, docs.size());
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -70,7 +70,7 @@ public class DatabaseConnectorTest {
     connector.execute(publisher);
 
     // Confirm there were 3 results.
-    List<Document> docsSentForProcessing = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docsSentForProcessing = messenger.getDocsSentForProcessing();
     assertEquals(3, docsSentForProcessing.size());
 
     // System.out.println(docsSentForProcessing.get(0));
@@ -113,7 +113,7 @@ public class DatabaseConnectorTest {
 
     connector.execute(publisher);
 
-    List<Document> docsSentForProcessing = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docsSentForProcessing = messenger.getDocsSentForProcessing();
     assertEquals(2, docsSentForProcessing.size());
 
     // The doc ID should have the 'company-' prefix
@@ -161,7 +161,7 @@ public class DatabaseConnectorTest {
     // run the connector
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(3, docs.size());
 
     // TODO: better verification / edge cases.. also formalize the "children" docs.
@@ -197,7 +197,7 @@ public class DatabaseConnectorTest {
 
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(3, docs.size());
 
     for (Document d : docs) {
@@ -312,7 +312,7 @@ public class DatabaseConnectorTest {
 
     connector.execute(publisher);
 
-    List<Document> docsSentForProcessing = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docsSentForProcessing = messenger.getDocsSentForProcessing();
     assertEquals(2, docsSentForProcessing.size());
 
     Document doc1 = docsSentForProcessing.get(0);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/PublisherImplTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/PublisherImplTest.java
@@ -70,8 +70,8 @@ public class PublisherImplTest {
     assertEquals(1, publisher.numPublished());
     assertEquals(1, publisher.numPending());
 
-    assertEquals(1, messenger.getSavedDocumentsSentForProcessing().size());
-    assertEquals(doc, messenger.getSavedDocumentsSentForProcessing().get(0));
+    assertEquals(1, messenger.getDocsSentForProcessing().size());
+    assertEquals(doc, messenger.getDocsSentForProcessing().get(0));
 
     Event finishEvent = new Event(doc.getId(), "run1", "", Event.Type.FINISH);
     publisher.handleEvent(finishEvent);
@@ -238,32 +238,32 @@ public class PublisherImplTest {
 
     assertEquals(0, publisher.numPublished());
     assertEquals(0, publisher.numPending());
-    assertEquals(0, messenger.getSavedDocumentsSentForProcessing().size());
+    assertEquals(0, messenger.getDocsSentForProcessing().size());
     publisher.publish(doc1);
     assertEquals(0, publisher.numPublished());
     assertEquals(0, publisher.numPending());
-    assertEquals(0, messenger.getSavedDocumentsSentForProcessing().size());
+    assertEquals(0, messenger.getDocsSentForProcessing().size());
     publisher.publish(doc2);
     assertEquals(1, publisher.numPublished());
     assertEquals(1, publisher.numPending());
-    assertEquals(1, messenger.getSavedDocumentsSentForProcessing().size());
-    assertEquals("before", messenger.getSavedDocumentsSentForProcessing().get(0).getId());
+    assertEquals(1, messenger.getDocsSentForProcessing().size());
+    assertEquals("before", messenger.getDocsSentForProcessing().get(0).getId());
     publisher.publish(doc3);
     assertEquals(1, publisher.numPublished());
     assertEquals(1, publisher.numPending());
-    assertEquals(1, messenger.getSavedDocumentsSentForProcessing().size());
+    assertEquals(1, messenger.getDocsSentForProcessing().size());
     publisher.publish(doc4);
     assertEquals(2, publisher.numPublished());
     assertEquals(2, publisher.numPending());
-    assertEquals(2, messenger.getSavedDocumentsSentForProcessing().size());
-    assertEquals("collapseMe", messenger.getSavedDocumentsSentForProcessing().get(1).getId());
+    assertEquals(2, messenger.getDocsSentForProcessing().size());
+    assertEquals("collapseMe", messenger.getDocsSentForProcessing().get(1).getId());
     publisher.flush();
     assertEquals(3, publisher.numPublished());
     assertEquals(3, publisher.numPending());
-    assertEquals(3, messenger.getSavedDocumentsSentForProcessing().size());
-    assertEquals("after", messenger.getSavedDocumentsSentForProcessing().get(2).getId());
+    assertEquals(3, messenger.getDocsSentForProcessing().size());
+    assertEquals("after", messenger.getDocsSentForProcessing().get(2).getId());
 
-    Document collapsedDoc = messenger.getSavedDocumentsSentForProcessing().get(1);
+    Document collapsedDoc = messenger.getDocsSentForProcessing().get(1);
     assertEquals("run1", collapsedDoc.getRunId());
     assertEquals(Arrays.asList(new String[]{"val1", "val2"}), collapsedDoc.getStringList("field1"));
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
@@ -51,13 +51,13 @@ public class CSVIndexerTest {
     doc2.setField("f2","def");
 
     CSVIndexer indexer = new CSVIndexer(config, messenger, false,"testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
     indexer.run(2);
 
-    assertEquals(2, messenger.getSavedEvents().size());
+    assertEquals(2, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 1; i <= events.size(); i++) {
       assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       assertEquals(Event.Type.FINISH, events.get(i - 1).getType());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -73,13 +73,13 @@ public class ElasticsearchIndexerTest {
     Document doc2 = Document.create("doc2", "test_run");
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
     indexer.run(2);
 
-    Assert.assertEquals(2, messenger.getSavedEvents().size());
+    Assert.assertEquals(2, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       Assert.assertEquals(Event.Type.FINISH, events.get(i - 1).getType());
@@ -98,14 +98,14 @@ public class ElasticsearchIndexerTest {
     Document doc5 = Document.create("doc5", "test_run");
 
     ElasticsearchIndexer indexer = new ErroringElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
-    messenger.sendCompleted(doc5);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
+    messenger.sendForIndexing(doc5);
     indexer.run(5);
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals(5, events.size());
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());
@@ -136,11 +136,11 @@ public class ElasticsearchIndexerTest {
     Document doc4 = Document.create("doc4", "test_run");
     Document doc5 = Document.create("doc5", "test_run");
 
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
-    messenger.sendCompleted(doc5);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
+    messenger.sendForIndexing(doc5);
     indexer.run(5);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -156,9 +156,9 @@ public class ElasticsearchIndexerTest {
 
     assertEquals(doc5.getId(), indexRequest.id());
 
-    Assert.assertEquals(5, messenger.getSavedEvents().size());
+    Assert.assertEquals(5, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -174,7 +174,7 @@ public class ElasticsearchIndexerTest {
     doc.setField("myJsonField", jsonNode);
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -190,9 +190,9 @@ public class ElasticsearchIndexerTest {
     assertEquals(doc.getId(), indexRequest.id());
     assertEquals(doc.asMap().get("myJsonField"), map.get("myJsonField"));
 
-    Assert.assertEquals(1, messenger.getSavedEvents().size());
+    Assert.assertEquals(1, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -208,7 +208,7 @@ public class ElasticsearchIndexerTest {
     doc.setField("myJsonField", jsonNode);
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -223,9 +223,9 @@ public class ElasticsearchIndexerTest {
     assertEquals(doc.getId(), map.get("id"));
     assertEquals(doc.asMap().get("myJsonField"), map.get("myJsonField"));
 
-    Assert.assertEquals(1, messenger.getSavedEvents().size());
+    Assert.assertEquals(1, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -241,7 +241,7 @@ public class ElasticsearchIndexerTest {
     doc.setField("myJsonField", jsonNode);
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -256,9 +256,9 @@ public class ElasticsearchIndexerTest {
     assertEquals(doc.getId(), map.get("id"));
     assertEquals(doc.asMap().get("myJsonField"), map.get("myJsonField"));
 
-    Assert.assertEquals(1, messenger.getSavedEvents().size());
+    Assert.assertEquals(1, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -274,7 +274,7 @@ public class ElasticsearchIndexerTest {
     doc.setField("field1", "value1");
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -302,7 +302,7 @@ public class ElasticsearchIndexerTest {
     doc.setKafkaMetadata(new ConsumerRecord<>("testing", 0, 100, null, null));
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -325,7 +325,7 @@ public class ElasticsearchIndexerTest {
     Config config = ConfigFactory.load(configPath);
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -399,16 +399,16 @@ public class ElasticsearchIndexerTest {
     Document doc3 = Document.create("doc3", "test_run");
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient2, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
 
     indexer.run(3);
 
     IndexerException exc = assertThrows(IndexerException.class, () -> indexer.sendToIndex(Arrays.asList(doc, doc2, doc3)));
     assertEquals("mock reason", exc.getMessage());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     assertEquals(3, events.size());
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -76,13 +76,13 @@ public class OpenSearchIndexerTest {
     Document doc2 = Document.create("doc2", "test_run");
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
     indexer.run(2);
 
-    Assert.assertEquals(2, messenger.getSavedEvents().size());
+    Assert.assertEquals(2, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       Assert.assertEquals(Event.Type.FINISH, events.get(i - 1).getType());
@@ -101,14 +101,14 @@ public class OpenSearchIndexerTest {
     Document doc5 = Document.create("doc5", "test_run");
 
     OpenSearchIndexer indexer = new ErroringOpenSearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
-    messenger.sendCompleted(doc5);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
+    messenger.sendForIndexing(doc5);
     indexer.run(5);
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals(5, events.size());
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());
@@ -139,11 +139,11 @@ public class OpenSearchIndexerTest {
     Document doc4 = Document.create("doc4", "test_run");
     Document doc5 = Document.create("doc5", "test_run");
 
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
-    messenger.sendCompleted(doc5);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
+    messenger.sendForIndexing(doc5);
     indexer.run(5);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(
@@ -160,9 +160,9 @@ public class OpenSearchIndexerTest {
 
     assertEquals(doc5.getId(), indexRequest.id());
 
-    Assert.assertEquals(5, messenger.getSavedEvents().size());
+    Assert.assertEquals(5, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -178,7 +178,7 @@ public class OpenSearchIndexerTest {
     doc.setField("myJsonField", jsonNode);
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -194,9 +194,9 @@ public class OpenSearchIndexerTest {
     assertEquals(doc.getId(), indexRequest.id());
     assertEquals(doc.asMap().get("myJsonField"), map.get("myJsonField"));
 
-    Assert.assertEquals(1, messenger.getSavedEvents().size());
+    Assert.assertEquals(1, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -212,7 +212,7 @@ public class OpenSearchIndexerTest {
     doc.setField("myJsonField", jsonNode);
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -227,9 +227,9 @@ public class OpenSearchIndexerTest {
     assertEquals(doc.getId(), map.get("id"));
     assertEquals(doc.asMap().get("myJsonField"), map.get("myJsonField"));
 
-    Assert.assertEquals(1, messenger.getSavedEvents().size());
+    Assert.assertEquals(1, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -245,7 +245,7 @@ public class OpenSearchIndexerTest {
     doc.setField("myJsonField", jsonNode);
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -260,9 +260,9 @@ public class OpenSearchIndexerTest {
     assertEquals(doc.getId(), map.get("id"));
     assertEquals(doc.asMap().get("myJsonField"), map.get("myJsonField"));
 
-    Assert.assertEquals(1, messenger.getSavedEvents().size());
+    Assert.assertEquals(1, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }
@@ -277,7 +277,7 @@ public class OpenSearchIndexerTest {
     doc.setField("field1", "value1");
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -306,7 +306,7 @@ public class OpenSearchIndexerTest {
     doc.setKafkaMetadata(new ConsumerRecord<>("testing", 0, 100, null, null));
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
     ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
 
@@ -359,16 +359,16 @@ public class OpenSearchIndexerTest {
     Document doc3 = Document.create("doc3", "test_run");
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient2, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
 
     indexer.run(3);
 
     IndexerException exc = assertThrows(IndexerException.class, () -> indexer.sendToIndex(Arrays.asList(doc, doc2, doc3)));
     assertEquals("mock reason", exc.getMessage());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     assertEquals(3, events.size());
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
@@ -54,8 +54,8 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
     indexer.run(2);
 
     // Each batch should be sent to Solr via a call to solrClient.add()
@@ -67,9 +67,9 @@ public class SolrIndexerTest {
     assertEquals(doc.getId(), getCapturedID(captor, 0, 0));
     assertEquals(doc2.getId(), getCapturedID(captor, 1, 0));
 
-    assertEquals(2, messenger.getSavedEvents().size());
+    assertEquals(2, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 1; i <= events.size(); i++) {
       assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       assertEquals(Event.Type.FINISH, events.get(i - 1).getType());
@@ -93,8 +93,8 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
     indexer.run(2);
 
     // Each batch should be sent to Solr via a call to solrClient.add()
@@ -106,9 +106,9 @@ public class SolrIndexerTest {
     assertEquals(doc.getId(), getCapturedID(captor, 0, 0));
     assertEquals(doc2.getId(), getCapturedID(captor, 0, 1));
 
-    assertEquals(2, messenger.getSavedEvents().size());
+    assertEquals(2, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 1; i <= events.size(); i++) {
       assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       assertEquals(Event.Type.FINISH, events.get(i - 1).getType());
@@ -138,9 +138,9 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
     indexer.run(3);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -153,10 +153,10 @@ public class SolrIndexerTest {
     assertEquals(doc2.getId(), getCapturedID(captor, 1, 0));
     assertEquals("doc3_overriden", getCapturedID(captor, 2, 0));
 
-    assertEquals(3, messenger.getSavedEvents().size());
+    assertEquals(3, messenger.getSentEvents().size());
 
     // confirm that events are sent using original doc IDs, not overriden ones
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 1; i <= events.size(); i++) {
       assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       assertEquals(Event.Type.FINISH, events.get(i - 1).getType());
@@ -185,7 +185,7 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -206,8 +206,8 @@ public class SolrIndexerTest {
     // the children should have been added via solrDoc.addChildDocument
     assertFalse(solrDoc.containsKey(Document.CHILDREN_FIELD));
 
-    assertEquals(1, messenger.getSavedEvents().size());
-    List<Event> events = messenger.getSavedEvents();
+    assertEquals(1, messenger.getSentEvents().size());
+    List<Event> events = messenger.getSentEvents();
     assertEquals(1, events.size());
     assertEquals("doc1", events.get(0).getDocumentId());
     assertEquals(Event.Type.FINISH, events.get(0).getType());
@@ -235,10 +235,10 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc1);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
     indexer.run(4);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -251,7 +251,7 @@ public class SolrIndexerTest {
     // confirm that docs are sent to the correct collection
     Map<String, List<SolrInputDocument>> collectionDocs = new HashMap<>();
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 0; i < 4; i++) {
       SolrInputDocument sDoc = captor.getAllValues().get(i).stream().findFirst().get();
       String collection = colCaptor.getAllValues().get(i);
@@ -302,7 +302,7 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc1);
+    messenger.sendForIndexing(doc1);
     indexer.run(1);
 
     ArgumentCaptor<List<String>> delCaptor = ArgumentCaptor.forClass(List.class);
@@ -336,8 +336,8 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc1);
-    messenger.sendCompleted(doc2);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
     indexer.run(2);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -373,9 +373,9 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc1);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
     indexer.run(3);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -446,10 +446,10 @@ public class SolrIndexerTest {
         .thenReturn(mock(UpdateResponse.class));
 
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(otherDoc1);
-    messenger.sendCompleted(doc1);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(otherDoc1);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
     indexer.run(4);
 
     InOrder inOrder = inOrder(solrClient);
@@ -521,9 +521,9 @@ public class SolrIndexerTest {
         .thenReturn(mock(UpdateResponse.class));
 
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc1);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
     indexer.run(3);
 
     InOrder inOrder = inOrder(solrClient);
@@ -573,9 +573,9 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc1);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
     indexer.run(3);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -618,9 +618,9 @@ public class SolrIndexerTest {
     SolrClient solrClient = mock(SolrClient.class);
 
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc1);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
     indexer.run(3);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -645,14 +645,14 @@ public class SolrIndexerTest {
     Document doc5 = Document.create("doc5", "test_run");
 
     Indexer indexer = new ErroringIndexer(config, messenger, true);
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
-    messenger.sendCompleted(doc5);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
+    messenger.sendForIndexing(doc5);
     indexer.run(5);
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     assertEquals(5, events.size());
     for (int i = 1; i <= events.size(); i++) {
       assertEquals("doc" + i, events.get(i - 1).getDocumentId());
@@ -673,12 +673,12 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
     verify(solrClient, times(0)).add((captor.capture()));
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     MatcherAssert.assertThat(1, equalTo(events.size()));
     MatcherAssert.assertThat(
         "Attempting to index a document with a nested object field to solr should result in an "
@@ -702,12 +702,12 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
     verify(solrClient, times(0)).add((captor.capture()));
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     MatcherAssert.assertThat(1, equalTo(events.size()));
     MatcherAssert.assertThat(
         "Attempting to index a document with a nested object field to solr should result in an "
@@ -729,12 +729,12 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
     verify(solrClient, times(0)).add((captor.capture()));
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     MatcherAssert.assertThat(1, equalTo(events.size()));
     MatcherAssert.assertThat(
         "Attempting to index a document with a nested object field to solr should result in an "
@@ -758,12 +758,12 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
     verify(solrClient, times(0)).add((captor.capture()));
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     MatcherAssert.assertThat(1, equalTo(events.size()));
     MatcherAssert.assertThat(
         "Attempting to index a document with a nested object field to solr should result in an "
@@ -785,12 +785,12 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
     verify(solrClient, times(0)).add((captor.capture()));
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     MatcherAssert.assertThat(1, equalTo(events.size()));
     MatcherAssert.assertThat(
         "Attempting to index a document with a nested object field to solr should result in an "
@@ -814,12 +814,12 @@ public class SolrIndexerTest {
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
-    messenger.sendCompleted(doc);
+    messenger.sendForIndexing(doc);
     indexer.run(1);
 
     ArgumentCaptor<Collection<SolrInputDocument>> captor = ArgumentCaptor.forClass(Collection.class);
     verify(solrClient, times(0)).add((captor.capture()));
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     MatcherAssert.assertThat(1, equalTo(events.size()));
     MatcherAssert.assertThat(
         "Attempting to index a document with a nested object field to solr should result in an "

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/XPathExtractorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/XPathExtractorTest.java
@@ -117,7 +117,7 @@ public class XPathExtractorTest {
     Connector connector = new XMLConnector(config);
     connector.execute(publisher);
 
-    List<Document> docs = messenger.getSavedDocumentsSentForProcessing();
+    List<Document> docs = messenger.getDocsSentForProcessing();
 
     Stage stage = factory.get("XMLConnectorTest/joint.conf");
     stage.processDocument(docs.get(0));

--- a/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
+++ b/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
@@ -83,13 +83,13 @@ public class WeaviateIndexerTest {
     Document doc2 = Document.create("doc2", "test_run");
 
     WeaviateIndexer indexer = new WeaviateIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
     indexer.run(2);
 
-    Assert.assertEquals(2, messenger.getSavedEvents().size());
+    Assert.assertEquals(2, messenger.getSentEvents().size());
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       Assert.assertEquals(Event.Type.FINISH, events.get(i - 1).getType());
@@ -108,14 +108,14 @@ public class WeaviateIndexerTest {
     Document doc5 = Document.create("doc5", "test_run");
 
     WeaviateIndexer indexer = new CorruptedWeaviateIndexer(config, messenger, mockClient, "testing");
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
-    messenger.sendCompleted(doc5);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
+    messenger.sendForIndexing(doc5);
     indexer.run(5);
 
-    List<Event> events = messenger.getSavedEvents();
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals(5, events.size());
     for (int i = 1; i <= events.size(); i++) {
       Assert.assertEquals("doc" + i, events.get(i - 1).getDocumentId());
@@ -145,11 +145,11 @@ public class WeaviateIndexerTest {
     Document doc4 = Document.create("doc4", "test_run");
     Document doc5 = Document.create("doc5", "test_run");
 
-    messenger.sendCompleted(doc);
-    messenger.sendCompleted(doc2);
-    messenger.sendCompleted(doc3);
-    messenger.sendCompleted(doc4);
-    messenger.sendCompleted(doc5);
+    messenger.sendForIndexing(doc);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    messenger.sendForIndexing(doc4);
+    messenger.sendForIndexing(doc5);
     indexer.run(5);
 
     // the batcher will be run 3 times
@@ -165,8 +165,8 @@ public class WeaviateIndexerTest {
     WeaviateObject object = bulkRequestArgumentCaptor.getValue();
     assertEquals(WeaviateIndexer.generateDocumentUUID(doc5), object.getId());
 
-    Assert.assertEquals(5, messenger.getSavedEvents().size());
-    List<Event> events = messenger.getSavedEvents();
+    Assert.assertEquals(5, messenger.getSentEvents().size());
+    List<Event> events = messenger.getSentEvents();
     Assert.assertEquals("doc1", events.get(0).getDocumentId());
     Assert.assertEquals(Event.Type.FINISH, events.get(0).getType());
   }


### PR DESCRIPTION
This PR renames 5 methods as follows:

- WorkerMessenger: sendCompleted() -> sendForIndexing() 
  - this is consistent with PublisherMessenger.sendForProcessing()
- IndexerMessenger: pollCompleted() -> pollDocToIndex() 
  - this is consistent with WorkerMessenger.pollDocToProcess()
- TestMessenger: getSavedEvents() ->  getSentEvents()
- TestMessenger: getSavedDocumentsSentForProcessing() -> getDocsSentForProcessing()
- TestMessenger: getSavedCompletedDocuments() -> getDocsSentForIndexing()