### PR TITLE
adding a unix timestamp date formatter

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  */
 public class DateYearOnlyFormatter implements Function<String, LocalDate> {
 
-  private static final Pattern datePattern = Pattern.compile("\\d{1,4}");
+  private static final Pattern datePattern = Pattern.compile("^\\d{2,4}$");
 
   @Override
   public LocalDate apply(String value) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/UnixTimestampFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/UnixTimestampFormatter.java
@@ -1,0 +1,24 @@
+package com.kmwllc.lucille.stage.dateformatters;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Formatter for parsing a unix timestamp provided as the number of milliseconds since the epoch.
+ */
+public class UnixTimestampFormatter implements Function<String, LocalDate> {
+  
+  @Override
+  public LocalDate apply(String value) {
+	  // TODO: what about malformed values?
+	  Long ms = Long.valueOf(value);
+	  Instant instant = Instant.ofEpochMilli(ms) ;
+	  LocalDate ld = instant.atOffset(ZoneOffset.UTC).toLocalDate();
+	  return ld;
+  }
+
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
@@ -45,6 +45,12 @@ public class ParseDateTest {
     stage.processDocument(doc3);
     assertEquals("1990-07-17T00:00:00Z", doc3.getStringList("output1").get(0));
     assertEquals("2023-06-21T00:00:00Z", doc3.getStringList("output2").get(0));
+
+    Document doc4 = Document.create("doc4");
+    doc4.setField("date1", "1696109846000");
+    stage.processDocument(doc4);
+    assertEquals("2023-09-30T00:00:00Z", doc4.getStringList("output1").get(0));
+
   }
 
   @Test

--- a/lucille-core/src/test/resources/ParseDateTest/config.conf
+++ b/lucille-core/src/test/resources/ParseDateTest/config.conf
@@ -7,6 +7,7 @@
     {class = "com.kmwllc.lucille.stage.dateformatters.DateMonthStrFormatter"}
     {class = "com.kmwllc.lucille.stage.dateformatters.DateTwoYearsFormatter"}
     {class = "com.kmwllc.lucille.stage.dateformatters.DateYearOnlyFormatter"}
+    {class = "com.kmwllc.lucille.stage.dateformatters.UnixTimestampFormatter"}
   ]
 
   format_strs = ["yy/MMM/dd", "yyyy-MM-dd"]

--- a/lucille-plugins/lucille-parquet/src/main/java/com/kmwllc/lucille/parquet/connector/ParquetConnector.java
+++ b/lucille-plugins/lucille-parquet/src/main/java/com/kmwllc/lucille/parquet/connector/ParquetConnector.java
@@ -152,8 +152,9 @@ public class ParquetConnector extends AbstractConnector {
   private static void setDocField(Document doc, Type field, SimpleGroup simpleGroup, int j) {
 
     // check if we have a field value before setting it.
-    if (simpleGroup.getFieldRepetitionCount(j) == 0)
+    if (simpleGroup.getFieldRepetitionCount(j) == 0) {
       return;
+    }
 
     String fieldName = field.getName();
 


### PR DESCRIPTION
this improvement does 2 things.
1. it adds a unix timestamp date formatter that can parse a field that contains the milliseconds since the epoch into a date.
2. it tightens up the regular expression that is used for parsing a year.  (we may want to make it even tighter)