### PR TITLE
LC-389 - support multiple field values in the SplitFieldValues stage.

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/SplitFieldValues.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/SplitFieldValues.java
@@ -41,15 +41,18 @@ public class SplitFieldValues extends Stage {
   public Iterator<Document> processDocument(Document doc) throws StageException {
     // operates only on the first value in the field at the moment?
     if (doc.has(inputField)) {
-      String[] values = doc.getString(inputField).split(delimiter);
+      List<String> fieldValues = doc.getStringList(inputField);
       if (inputField.equals(outputField)) {
         doc.removeField(outputField);
       }
-      for (String val : values) {
-        if (trimWhitespace) {
-          val = val.trim();
+      for (String value : fieldValues) {
+        String[] values = value.split(delimiter);
+        for (String val : values) {
+          if (trimWhitespace) {
+            val = val.trim();
+          }
+          doc.addToField(outputField, val);
         }
-        doc.addToField(outputField, val);
       }
     }
     return null;

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SplitFieldValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SplitFieldValuesTest.java
@@ -28,9 +28,30 @@ public class SplitFieldValuesTest {
     assertEquals("the", doc.getStringList("data").get(2));
     assertEquals("other", doc.getStringList("data").get(3));
 
+  }
+
+  @Test
+  public void testMultiValuedField() throws Exception {
+    Stage stage = factory.get("SplitFieldValuesTest/config.conf");
+
+    Document doc = Document.create("doc");
+    doc.setField("data", "this,that, the ,other");
+    doc.addToField("data", "value2");
+    doc.addToField("data", "value3, value4");
+    stage.processDocument(doc);
+    
+    assertEquals(7, doc.getStringList("data").size());
+    assertEquals("this", doc.getStringList("data").get(0));
+    assertEquals("that", doc.getStringList("data").get(1));
+    assertEquals("the", doc.getStringList("data").get(2));
+    assertEquals("other", doc.getStringList("data").get(3));
+    assertEquals("value2", doc.getStringList("data").get(4));
+    assertEquals("value3", doc.getStringList("data").get(5));
+    assertEquals("value4", doc.getStringList("data").get(6));
 
   }
 
+  
   @Test
   public void testGetLegalProperties() throws StageException {
     Stage stage = factory.get("SplitFieldValuesTest/config.conf");


### PR DESCRIPTION
making split field values operate on all of the values of the input field, not just the first one.