### PR TITLE
LC-390 - making the formatters in the parse date stage be aware of hours/minutes/seconds.  

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -10,20 +10,20 @@ import java.util.regex.Pattern;
  *  * Formatter for parsing infobox data into Dates. Attempts to find dates of the form "January 1, 2000" and extract
  *  the values into a Java date. Will return null of the there are no dates formatted in it's style within the String.
  */
-public class DateMonthStrFormatter implements Function<String, LocalDate> {
+public class DateMonthStrFormatter implements Function<String, LocalDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\w+ \\d{1,2}, \\d{1,4}");
   private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("LLLL d, u");
 
   @Override
-  public LocalDate apply(String value) {
+  public LocalDateTime apply(String value) {
     Matcher matcher = datePattern.matcher(value);
 
     if (!matcher.find()) {
       return null;
     } else {
       String dateStr = matcher.group();
-      return LocalDate.parse(dateStr, formatter);
+      return LocalDateTime.parse(dateStr, formatter);
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
@@ -1,5 +1,6 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
@@ -23,7 +24,7 @@ public class DateMonthStrFormatter implements Function<String, LocalDateTime> {
       return null;
     } else {
       String dateStr = matcher.group();
-      return LocalDateTime.parse(dateStr, formatter);
+      return LocalDate.parse(dateStr, formatter).atStartOfDay();
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DatePipeFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DatePipeFormatter.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -9,12 +9,12 @@ import java.util.regex.Pattern;
  * Formatter for parsing infobox data into Dates. Attempts to find dates of the form "YYYY|MM|DD" and extract the values
  * into a Java date. Will return null of the there are no dates formatted in it's style within the String.
  */
-public class DatePipeFormatter implements Function<String, LocalDate> {
+public class DatePipeFormatter implements Function<String, LocalDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\d{1,4}\\|\\d{1,2}\\|\\d{1,2}");
 
   @Override
-  public LocalDate apply(String value) {
+  public LocalDateTime apply(String value) {
     Matcher matcher = datePattern.matcher(value);
 
     if (!matcher.find()) {
@@ -23,8 +23,8 @@ public class DatePipeFormatter implements Function<String, LocalDate> {
       String dateStr = matcher.group();
       String[] dateParts = dateStr.split("\\|");
 
-      return LocalDate.of(Integer.parseInt(dateParts[0].substring(0, 4)), Integer.parseInt(dateParts[1]),
-          Integer.parseInt(dateParts[2]));
+      return LocalDateTime.of(Integer.parseInt(dateParts[0].substring(0, 4)), Integer.parseInt(dateParts[1]),
+          Integer.parseInt(dateParts[2]),0,0,0);
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateTwoYearsFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateTwoYearsFormatter.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -11,12 +11,12 @@ import java.util.regex.Pattern;
  *  Since no month or date are specified, they will default to January 1 of the given year.
  *  Will return null of the there are no dates formatted in it's style within the String.
  */
-public class DateTwoYearsFormatter implements Function<String, LocalDate> {
+public class DateTwoYearsFormatter implements Function<String, LocalDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\d{1,4}\\W\\d{1,4}");
 
   @Override
-  public LocalDate apply(String value) {
+  public LocalDateTime apply(String value) {
     Matcher matcher = datePattern.matcher(value);
 
     if (!matcher.find()) {
@@ -25,7 +25,7 @@ public class DateTwoYearsFormatter implements Function<String, LocalDate> {
       String dateStr = matcher.group();
       String firstYear = dateStr.substring(0, 4);
 
-      return LocalDate.of(Integer.parseInt(firstYear), 1, 1);
+      return LocalDateTime.of(Integer.parseInt(firstYear), 1, 1,0,0,0);
     }
 
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -10,17 +10,17 @@ import java.util.regex.Pattern;
  *  the values into a Java date. Since no month or date are specified, they will default to January 1 of the given year.
  *  Will return null of the there are no dates formatted in it's style within the String.
  */
-public class DateYearOnlyFormatter implements Function<String, LocalDate> {
+public class DateYearOnlyFormatter implements Function<String, LocalDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("^\\d{2,4}$");
 
   @Override
-  public LocalDate apply(String value) {
+  public LocalDateTime apply(String value) {
     Matcher matcher = datePattern.matcher(value);
 
     if (matcher.find()) {
       String dateStr = matcher.group();
-      return LocalDate.of(Integer.parseInt(dateStr), 1, 1);
+      return LocalDateTime.of(Integer.parseInt(dateStr), 1, 1, 0, 0, 0);
     } else {
       return null;
     }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/UnixTimestampFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/UnixTimestampFormatter.java
@@ -1,7 +1,8 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
 import java.time.Instant;
-import java.time.LocalDate;
+
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -10,14 +11,14 @@ import java.util.regex.Pattern;
 /**
  * Formatter for parsing a unix timestamp provided as the number of milliseconds since the epoch.
  */
-public class UnixTimestampFormatter implements Function<String, LocalDate> {
+public class UnixTimestampFormatter implements Function<String, LocalDateTime> {
   
   @Override
-  public LocalDate apply(String value) {
+  public LocalDateTime apply(String value) {
 	  // TODO: what about malformed values?
 	  Long ms = Long.valueOf(value);
 	  Instant instant = Instant.ofEpochMilli(ms) ;
-	  LocalDate ld = instant.atOffset(ZoneOffset.UTC).toLocalDate();
+	  LocalDateTime ld = instant.atOffset(ZoneOffset.UTC).toLocalDateTime();
 	  return ld;
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
@@ -43,13 +43,13 @@ public class ParseDateTest {
     doc3.setField("date1", "90/Jul/17");
     doc3.setField("date2", "2023-06-21");
     stage.processDocument(doc3);
-    assertEquals("1990-07-17T00:00:00Z", doc3.getStringList("output1").get(0));
-    assertEquals("2023-06-21T00:00:00Z", doc3.getStringList("output2").get(0));
+    assertEquals("1990-07-17T04:00:00Z", doc3.getStringList("output1").get(0));
+    assertEquals("2023-06-21T04:00:00Z", doc3.getStringList("output2").get(0));
 
     Document doc4 = Document.create("doc4");
     doc4.setField("date1", "1696109846000");
     stage.processDocument(doc4);
-    assertEquals("2023-09-30T00:00:00Z", doc4.getStringList("output1").get(0));
+    assertEquals("2023-09-30T21:37:26Z", doc4.getStringList("output1").get(0));
 
   }
 
@@ -90,10 +90,10 @@ public class ParseDateTest {
 
     // create a map of time zones to expected formatted dates
     Map<String, String> timeZoneToFormattedDate = Map.of(
-        "EST", "2021-02-02T00:00:00Z",
+        "EST", "2021-02-02T05:00:00Z",
         "Universal", "2021-02-02T00:00:00Z",
-        "Europe/Rome", "2021-02-01T00:00:00Z",
-        "Australia/Brisbane", "2021-02-01T00:00:00Z"
+        "Europe/Rome", "2021-02-01T23:00:00Z",
+        "Australia/Brisbane", "2021-02-01T14:00:00Z"
     );
 
     for (Map.Entry<String, String> entry: timeZoneToFormattedDate.entrySet()) {
@@ -134,16 +134,16 @@ public class ParseDateTest {
 
     // for date with no timezone the time zone is set to the default time zone
     factory.get(configValues).processDocument(doc);
-    assertEquals("2021-02-01T00:00:00Z", doc.getString("output1"));
-    assertEquals("2021-02-02T00:00:00Z", doc.getString("output2"));
+    assertEquals("2021-02-01T23:00:00Z", doc.getString("output1"));
+    assertEquals("2021-02-02T05:00:00Z", doc.getString("output2"));
 
     // switch the order of format strings
     configValues.put("format_strs", List.of("yyyy-MM-dd", "yyyy-MM-dd z"));
 
     // notice that the time zone is set to the default for a date that has a timezone because a more general format string is used
     factory.get(configValues).processDocument(doc);
-    assertEquals("2021-02-01T00:00:00Z", doc.getString("output1"));
-    assertEquals("2021-02-01T00:00:00Z", doc.getString("output2"));
+    assertEquals("2021-02-01T23:00:00Z", doc.getString("output1"));
+    assertEquals("2021-02-01T23:00:00Z", doc.getString("output2"));
   }
 
   /* Examples of parsing date step by step based on a string and timezone


### PR DESCRIPTION
I found that the LocalDate returned by the formatters in the ParseDate stage don't contain the time of day, so this is a PR to update the formatters to return a LocalDateTime instead.

This PR updates the unit test, so we should make sure that the test cases are updated in a reasonable way here.