### PR TITLE
LC-390 use ZonedDateTime in ParseDate instead of LocalDate

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
@@ -1,29 +1,31 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- *  * Formatter for parsing infobox data into Dates. Attempts to find dates of the form "January 1, 2000" and extract
+ *  Attempts to find dates of the form "January 1, 2000" and extract
  *  the values into a Java date. Will return null of the there are no dates formatted in it's style within the String.
  */
-public class DateMonthStrFormatter implements Function<String, LocalDate> {
+public class DateMonthStrFormatter implements BiFunction<String, ZoneId, ZonedDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\w+ \\d{1,2}, \\d{1,4}");
   private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("LLLL d, u");
 
   @Override
-  public LocalDate apply(String value) {
+  public ZonedDateTime apply(String value, ZoneId zone) {
     Matcher matcher = datePattern.matcher(value);
 
     if (!matcher.find()) {
       return null;
     } else {
       String dateStr = matcher.group();
-      return LocalDate.parse(dateStr, formatter);
+      return LocalDate.parse(dateStr, formatter).atStartOfDay(zone);
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DatePipeFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DatePipeFormatter.java
@@ -1,20 +1,21 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
-import java.time.LocalDate;
-import java.util.function.Function;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Formatter for parsing infobox data into Dates. Attempts to find dates of the form "YYYY|MM|DD" and extract the values
+ * Attempts to find dates of the form "YYYY|MM|DD" and extract the values
  * into a Java date. Will return null of the there are no dates formatted in it's style within the String.
  */
-public class DatePipeFormatter implements Function<String, LocalDate> {
+public class DatePipeFormatter implements BiFunction<String, ZoneId, ZonedDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\d{1,4}\\|\\d{1,2}\\|\\d{1,2}");
 
   @Override
-  public LocalDate apply(String value) {
+  public ZonedDateTime apply(String value, ZoneId zone) {
     Matcher matcher = datePattern.matcher(value);
 
     if (!matcher.find()) {
@@ -23,8 +24,8 @@ public class DatePipeFormatter implements Function<String, LocalDate> {
       String dateStr = matcher.group();
       String[] dateParts = dateStr.split("\\|");
 
-      return LocalDate.of(Integer.parseInt(dateParts[0].substring(0, 4)), Integer.parseInt(dateParts[1]),
-          Integer.parseInt(dateParts[2]));
+      return ZonedDateTime.of(Integer.parseInt(dateParts[0].substring(0, 4)), Integer.parseInt(dateParts[1]),
+          Integer.parseInt(dateParts[2]), 0, 0, 0, 0, zone);
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateTwoYearsFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateTwoYearsFormatter.java
@@ -1,22 +1,23 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
-import java.time.LocalDate;
-import java.util.function.Function;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- *  * Formatter for parsing infobox data into Dates. Attempts to find dates which only contain two years only and extract
+ *  Attempts to find dates which only contain two years only and extract
  *  the values into a Java date. The first year specified will be the year we save, the other year will be discarded.
  *  Since no month or date are specified, they will default to January 1 of the given year.
- *  Will return null of the there are no dates formatted in it's style within the String.
+ *  Will return null of the there are no dates formatted in this style within the String.
  */
-public class DateTwoYearsFormatter implements Function<String, LocalDate> {
+public class DateTwoYearsFormatter implements BiFunction<String, ZoneId, ZonedDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\d{1,4}\\W\\d{1,4}");
 
   @Override
-  public LocalDate apply(String value) {
+  public ZonedDateTime apply(String value, ZoneId zone) {
     Matcher matcher = datePattern.matcher(value);
 
     if (!matcher.find()) {
@@ -25,8 +26,7 @@ public class DateTwoYearsFormatter implements Function<String, LocalDate> {
       String dateStr = matcher.group();
       String firstYear = dateStr.substring(0, 4);
 
-      return LocalDate.of(Integer.parseInt(firstYear), 1, 1);
+      return ZonedDateTime.of(Integer.parseInt(firstYear), 1, 1, 0, 0, 0, 0, zone);
     }
-
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
@@ -1,26 +1,27 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
-import java.time.LocalDate;
-import java.util.function.Function;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- *  * Formatter for parsing infobox data into Dates. Attempts to find dates which only contain a year and extract
+ *  Attempts to find dates which only contain a year and extract
  *  the values into a Java date. Since no month or date are specified, they will default to January 1 of the given year.
  *  Will return null of the there are no dates formatted in it's style within the String.
  */
-public class DateYearOnlyFormatter implements Function<String, LocalDate> {
+public class DateYearOnlyFormatter implements BiFunction<String, ZoneId, ZonedDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("^\\d{2,4}$");
 
   @Override
-  public LocalDate apply(String value) {
+  public ZonedDateTime apply(String value, ZoneId zone) {
     Matcher matcher = datePattern.matcher(value);
 
     if (matcher.find()) {
       String dateStr = matcher.group();
-      return LocalDate.of(Integer.parseInt(dateStr), 1, 1);
+      return ZonedDateTime.of(Integer.parseInt(dateStr), 1, 1, 0, 0, 0, 0, zone);
     } else {
       return null;
     }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/UnixTimestampFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/UnixTimestampFormatter.java
@@ -1,24 +1,21 @@
 package com.kmwllc.lucille.stage.dateformatters;
 
 import java.time.Instant;
-import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.time.ZonedDateTime;
+import java.util.function.BiFunction;
 
 /**
  * Formatter for parsing a unix timestamp provided as the number of milliseconds since the epoch.
  */
-public class UnixTimestampFormatter implements Function<String, LocalDate> {
-  
+public class UnixTimestampFormatter implements BiFunction<String, ZoneId, ZonedDateTime> {
+
   @Override
-  public LocalDate apply(String value) {
-	  // TODO: what about malformed values?
+  public ZonedDateTime apply(String value, ZoneId zone) {
 	  Long ms = Long.valueOf(value);
 	  Instant instant = Instant.ofEpochMilli(ms) ;
-	  LocalDate ld = instant.atOffset(ZoneOffset.UTC).toLocalDate();
-	  return ld;
+	  return instant.atZone(ZoneOffset.UTC);
   }
 
 }

--- a/lucille-core/src/test/resources/ParseDateTest/config.conf
+++ b/lucille-core/src/test/resources/ParseDateTest/config.conf
@@ -11,4 +11,5 @@
   ]
 
   format_strs = ["yy/MMM/dd", "yyyy-MM-dd"]
+  time_zone_id = "Universal"
 }


### PR DESCRIPTION
This PR updates the formatters used in the ParseDate stage so that they always return a ZonedDateTime (as opposed to a LocalDate or LocalDateTime without zone information).

The zone is identified in this order: 1) use the zone info in the date itself, if present and if the format string supports it, 2) use time_zone_id from the stage config, if present, 3) use the system default otherwise.

This PR is against main; however it builds on ideas from https://github.com/kmwtechnology/lucille/pull/70. It goes a bit further to make sure zone information is captured during parsing or as close to parsing as possible, so that there is no room for confusion later.

