### PR TITLE
LC-392: update counters in publisher to be longs instead of ints

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorResult.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorResult.java
@@ -9,8 +9,8 @@ public class ConnectorResult {
   // true indicates success, false indicates failure
   private final boolean status;
 
-  private final int numFailed;
-  private final int numSucceeded;
+  private final long numFailed;
+  private final long numSucceeded;
 
   private String message;
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Publisher.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Publisher.java
@@ -30,7 +30,7 @@ public interface Publisher {
    * Returns the number of documents published so far.
    *
    */
-  int numPublished();
+  long numPublished();
 
   /**
    * Returns the number of documents for which we are still awaiting a terminal event.
@@ -38,31 +38,31 @@ public interface Publisher {
    * This number includes documents published via publish() as well as child documents generated
    * during pipeline execution.
    */
-  int numPending();
+  long numPending();
 
   /**
    * Returns the number of child documents that the publisher did not publish but was notified about via
    * a CREATE event passed to handleEvent().
    */
-  int numCreated();
+  long numCreated();
 
   /**
    * Returns the number of documents for which the publisher has been notified of successful completion.
    *
    */
-  int numSucceeded();
+  long numSucceeded();
 
   /**
    * Returns the number of documents for which the publisher has been notified of a failure.
    *
    */
-  int numFailed();
+  long numFailed();
 
   /**
    * Returns the number of documents for which the publisher has received a drop notification.
    *
    */
-  int numDropped();
+  long numDropped();
 
   /**
    * Returns true if there are published documents or generated children than have not yet reached an

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
@@ -45,12 +45,12 @@ public class PublisherImpl implements Publisher {
 
   // the actual number of documents sent for processing, which may be smaller
   // than the number of calls to publish() if isCollapsing==true
-  private int numPublished = 0;
+  private long numPublished = 0;
 
-  private int numCreated = 0;
-  private int numFailed = 0;
-  private int numSucceeded = 0;
-  private int numDropped = 0;
+  private long numCreated = 0;
+  private long numFailed = 0;
+  private long numSucceeded = 0;
+  private long numDropped = 0;
 
   private Instant start;
   private final Timer timer;
@@ -269,32 +269,32 @@ public class PublisherImpl implements Publisher {
   }
 
   @Override
-  public int numPending() {
+  public long numPending() {
     return docIdsToTrack.size();
   }
 
   @Override
-  public int numPublished() {
+  public long numPublished() {
     return numPublished;
   }
 
   @Override
-  public int numCreated() {
+  public long numCreated() {
     return numCreated;
   }
 
   @Override
-  public int numSucceeded() {
+  public long numSucceeded() {
     return numSucceeded;
   }
 
   @Override
-  public int numFailed() {
+  public long numFailed() {
     return numFailed;
   }
 
   @Override
-  public int numDropped() {
+  public long numDropped() {
     return numDropped;
   }
 }


### PR DESCRIPTION
This is to prevent overflow issues if 2.1B+ documents are published.