### PR TITLE
Address error handling when SolrIndexer sends batch of documents to multiple collections

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -22,6 +22,7 @@ import org.apache.solr.client.solrj.response.SolrPingResponse;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.eclipse.jetty.util.MultiException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.misc.Signal;
@@ -110,6 +111,10 @@ public class SolrIndexer extends Indexer {
 
   @Override
   protected void sendToIndex(List<Document> documents) throws Exception {
+    //when sending updates/deletes to separate collections we do not want an error sending to a particular collection to
+    //prevent us from sending to other collections in the batch. collect any errors that occur in this multiexception and
+    //then use it to throw the error(s) at the end.
+    MultiException errorsSending = new MultiException();
 
     if (solrClient == null) {
       log.debug("sendToSolr bypassed for documents: " + documents);
@@ -146,7 +151,12 @@ public class SolrIndexer extends Indexer {
             && doc.has(deleteByFieldField)
             && deleteByFieldValue != null
             && doc.has(deleteByFieldValue))) {
-          sendAddUpdateBatch(collection, solrDocRequests.getAddUpdateDocs());
+          try {
+            sendAddUpdateBatch(collection, solrDocRequests.getAddUpdateDocs());
+          } catch (Exception e) {
+            errorsSending.add(e);
+          }
+
           solrDocRequests.resetAddUpdates();
         }
 
@@ -164,22 +174,35 @@ public class SolrIndexer extends Indexer {
         SolrInputDocument solrDoc = toSolrDoc(doc, idOverride, collection);
 
         // if the delete requests contain the ID of this document, send the deletes immediately so
-        // the delete is
-        // processed before this document.
+        // the delete is processed before this document.
 
         if (solrDocRequests.containsIdForDeletion(solrId)
             || solrDocRequests.containsAnyDeleteByField()) {
-          sendDeletionBatch(collection, solrDocRequests);
+          try {
+            sendDeletionBatch(collection, solrDocRequests);
+          } catch (Exception e) {
+            errorsSending.add(e);
+          }
+
           solrDocRequests.resetDeletes();
         }
         solrDocRequests.addDocForAddUpdate(solrDoc);
       }
     }
     for (String collection : solrDocRequestsByCollection.keySet()) {
-      sendAddUpdateBatch(
-          collection, solrDocRequestsByCollection.get(collection).getAddUpdateDocs());
-      sendDeletionBatch(collection, solrDocRequestsByCollection.get(collection));
+      try {
+        sendAddUpdateBatch(
+            collection, solrDocRequestsByCollection.get(collection).getAddUpdateDocs());
+      } catch (Exception e) {
+        errorsSending.add(e);
+      }
+      try {
+        sendDeletionBatch(collection, solrDocRequestsByCollection.get(collection));
+      } catch (Exception e) {
+        errorsSending.add(e);
+      }
     }
+    errorsSending.ifExceptionThrow();
   }
 
   private void sendAddUpdateBatch(String collection, List<SolrInputDocument> solrDocs)


### PR DESCRIPTION
The SolrIndexer when configured to use a collection field will send documents to multiple collections as determined by the collection field on each document. If one of the collections is down, or doesn't exist, or some other error occurs we do not want this to prevent the other documents in the batch to the collections that they are routed to. This PR defers the throwing of any exceptions from calling sendAddUpdateBatch or sendDeletionBatch by collecting them in a MultiException and throwing the error(s) collectively at the end of batch processing.

This PR does not address false reporting of failures. When an error occurs while processing a batch it is still the case that every document in the batch will be marked as a failure. 