### PR TITLE
update Indexer.sendToIndex to return a list of failed docs

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -67,10 +67,11 @@ public class CSVIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
     for (Document doc : documents) {
       writer.writeNext(getLine(doc), true);
     }
+    return null;
   }
 
   private String[] getLine(Document doc) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -85,10 +85,10 @@ public class ElasticsearchIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
-      return;
+      return null;
     }
 
     BulkRequest.Builder br = new BulkRequest.Builder();
@@ -160,6 +160,7 @@ public class ElasticsearchIndexer extends Indexer {
         }
       }
     }
+    return null;
   }
 
   @Override

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -90,10 +90,10 @@ public class OpenSearchIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
-      return;
+      return null;
     }
 
     BulkRequest.Builder br = new BulkRequest.Builder();
@@ -151,6 +151,7 @@ public class OpenSearchIndexer extends Indexer {
         }
       }
     }
+    return null;
   }
 
   private void addChildren(Document doc, Map<String, Object> indexerDoc) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -109,11 +109,11 @@ public class SolrIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
 
     if (solrClient == null) {
       log.debug("sendToSolr bypassed for documents: " + documents);
-      return;
+      return null;
     }
 
     Map<String, SolrDocRequests> solrDocRequestsByCollection = new HashMap<>();
@@ -180,6 +180,7 @@ public class SolrIndexer extends Indexer {
           collection, solrDocRequestsByCollection.get(collection).getAddUpdateDocs());
       sendDeletionBatch(collection, solrDocRequestsByCollection.get(collection));
     }
+    return null;
   }
 
   private void sendAddUpdateBatch(String collection, List<SolrInputDocument> solrDocs)

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -424,7 +424,7 @@ public class ElasticsearchIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -384,7 +384,7 @@ public class OpenSearchIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
@@ -867,7 +867,7 @@ public class SolrIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to Solr are correctly handled");
     }
   }

--- a/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
+++ b/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
@@ -63,7 +63,7 @@ public class PineconeIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) {
+  protected List<Document> sendToIndex(List<Document> documents) {
 
     for (int i = 0; i < namespaces.size(); i++) {
       final int index = i;
@@ -101,6 +101,7 @@ public class PineconeIndexer extends Indexer {
       }
     }
 
+    return null;
   }
 
   @Override

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -93,7 +93,7 @@ public class WeaviateIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
 
     try (ObjectsBatcher batcher = client.batch().objectsBatcher()) {
       for (Document doc : documents) {
@@ -140,6 +140,7 @@ public class WeaviateIndexer extends Indexer {
     } catch (Exception e) {
       throw new IndexerException(e.toString());
     }
+    return null;
   }
 
   public static String generateDocumentUUID(Document document) {

--- a/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
+++ b/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
@@ -179,7 +179,7 @@ public class WeaviateIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }


### PR DESCRIPTION
Draft PR to sketch out a way make error reporting in Indexer more granular. Currently, if any document in a batch fails, all documents are treated as having failed. We want to allow some docs to fail while others succeed. 

- the abstract Indexer.sendToIndex(List<Document) method now returns a list of documents that failed, which may be null if there were no failures. Eventually, a dedicated class like BatchResult would be a better return value -- the current code is a sketch
- an indexer implementation may still throw an exception from sendToIndex, in which case all docs in the batch will treated as failed (this is the old/existing behavior)
- an indexer implementation may now choose to NOT throw an exception from sendToIndex but instead return a list of the specific documents in the batch that failed (assuming all other documents succeeded). In this case, the indexer base class will only generate error events for the specific documents that are known to have failed, while all other documents in the batch will be treated as having succeeded
- TODO: change the return value of sendToIndex to a BatchResult that contains a list of succeeded documents and a list of failed documents along with specific exceptions encountered. Note that there may be some documents in the batch that don't fall into either list because an attempt was not made to send them (i.e. after an error was encountered with a previous document so indexing was aborted).