### PR TITLE
LC-278 ComputeFieldSize stage

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
@@ -26,10 +26,10 @@ public class ComputeFieldSize extends Stage {
   private final String destination;
 
   public ComputeFieldSize(Config config) {
-    super(config, new StageSpec().withRequiredProperties("source", "destination"));
+    super(config, new StageSpec().withRequiredProperties("source", "dest"));
 
     this.source = config.getString("source");
-    this.destination = config.getString("destination");
+    this.destination = config.getString("dest");
   }
 
   /**

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
@@ -5,6 +5,7 @@ import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
 import com.typesafe.config.Config;
+import com.amazonaws.services.s3.model.SelectObjectContentEvent.ContinuationEvent;
 import com.kmwllc.lucille.core.*;
 
 /**
@@ -41,10 +42,14 @@ public class ComputeFieldSize extends Stage {
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     if (!doc.has(source)) {
-      throw new StageException(String.format("Document does not have source field: %s", source));
+      return null;
     }
 
-    doc.update(destination, UpdateMode.OVERWRITE, doc.getBytes(source).length);
+    try {
+      doc.update(destination, UpdateMode.OVERWRITE, doc.getBytes(source).length);
+    } catch (NullPointerException e) {
+      throw new StageException(String.format("Field: {} is not a byte array", source));
+    }
     return null;
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
@@ -1,0 +1,45 @@
+package com.kmwllc.lucille.stage;
+
+import java.util.Iterator;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Stage;
+import com.kmwllc.lucille.core.StageException;
+import com.typesafe.config.Config;
+import com.kmwllc.lucille.core.*;
+
+/**
+ * Computes sizes of given byte array field and adds a field with that size
+ *
+ * Config Paramters:
+ *   - sourceField (String) : The field containing the byte array 
+ *   - outputField (String) : The name of the field which will be added to store the size. Will overwrite value if field already 
+ *                            exists
+ */
+public class ComputeFieldSize extends Stage {
+
+  private final String sourceField;
+  private final String outputField;
+
+  public ComputeFieldSize(Config config) {
+    super(config, new StageSpec().withRequiredProperties("sourceField", "outputField"));
+
+    this.sourceField = config.getString("sourceField");
+    this.outputField = config.getString("outputField");
+  }
+
+  /**
+   * {@inheritDoc}
+   * Here it processes document by computing and adding the correct field. 
+   * @throws StageException If {@link ComputeFieldSize#sourceField} does not exist in document
+   * @throws NullPointerException If {@link ComputeFieldSize#sourceField} is not a byte array in document
+   */
+  @Override
+  public Iterator<Document> processDocument(Document doc) throws StageException {
+    if (!doc.has(sourceField)) {
+      throw new StageException(String.format("Document does not have source field: %s", sourceField));
+    }
+
+    doc.update(outputField, UpdateMode.OVERWRITE, doc.getBytes(sourceField).length);
+    return null;
+  }
+}

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
@@ -4,9 +4,8 @@ import java.util.Iterator;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
+import com.kmwllc.lucille.core.UpdateMode;
 import com.typesafe.config.Config;
-import com.amazonaws.services.s3.model.SelectObjectContentEvent.ContinuationEvent;
-import com.kmwllc.lucille.core.*;
 
 /**
  * Computes size of given byte array field and adds a field with that size
@@ -45,11 +44,12 @@ public class ComputeFieldSize extends Stage {
       return null;
     }
 
-    try {
-      doc.update(destination, UpdateMode.OVERWRITE, doc.getBytes(source).length);
-    } catch (NullPointerException e) {
+    byte[] bytes = doc.getBytes(source);
+    if(bytes == null) {
       throw new StageException(String.format("Field: {} is not a byte array", source));
     }
+
+    doc.update(destination, UpdateMode.OVERWRITE, doc.getBytes(source).length);
     return null;
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
@@ -45,11 +45,11 @@ public class ComputeFieldSize extends Stage {
     }
 
     byte[] bytes = doc.getBytes(source);
-    if(bytes == null) {
+    if (bytes == null) {
       throw new StageException(String.format("Field: {} is not a byte array", source));
     }
 
-    doc.update(destination, UpdateMode.OVERWRITE, doc.getBytes(source).length);
+    doc.update(destination, UpdateMode.OVERWRITE, bytes.length);
     return null;
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
@@ -8,38 +8,43 @@ import com.typesafe.config.Config;
 import com.kmwllc.lucille.core.*;
 
 /**
- * Computes sizes of given byte array field and adds a field with that size
- *
- * Config Paramters:
- *   - sourceField (String) : The field containing the byte array 
- *   - outputField (String) : The name of the field which will be added to store the size. Will overwrite value if field already 
- *                            exists
+ * Computes size of given byte array field and adds a field with that size
+ * <br>
+ * Config Parameters -
+ * <br>
+ * <p>
+ * <b>source</b> (String) : The field containing the byte array
+ * </p>
+ * <p>
+ * <b>destination</b> (String) : The name of the field which will be added to store the size. Will overwrite value if field already
+ * exists
+ * </p>
  */
 public class ComputeFieldSize extends Stage {
 
-  private final String sourceField;
-  private final String outputField;
+  private final String source;
+  private final String destination;
 
   public ComputeFieldSize(Config config) {
-    super(config, new StageSpec().withRequiredProperties("sourceField", "outputField"));
+    super(config, new StageSpec().withRequiredProperties("source", "destination"));
 
-    this.sourceField = config.getString("sourceField");
-    this.outputField = config.getString("outputField");
+    this.source = config.getString("source");
+    this.destination = config.getString("destination");
   }
 
   /**
    * {@inheritDoc}
    * Here it processes document by computing and adding the correct field. 
-   * @throws StageException If {@link ComputeFieldSize#sourceField} does not exist in document
-   * @throws NullPointerException If {@link ComputeFieldSize#sourceField} is not a byte array in document
+   * @throws StageException If {@link ComputeFieldSize#source} does not exist in document
+   * @throws NullPointerException If {@link ComputeFieldSize#source} is not a byte array in document
    */
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
-    if (!doc.has(sourceField)) {
-      throw new StageException(String.format("Document does not have source field: %s", sourceField));
+    if (!doc.has(source)) {
+      throw new StageException(String.format("Document does not have source field: %s", source));
     }
 
-    doc.update(outputField, UpdateMode.OVERWRITE, doc.getBytes(sourceField).length);
+    doc.update(destination, UpdateMode.OVERWRITE, doc.getBytes(source).length);
     return null;
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ComputeFieldSizeTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ComputeFieldSizeTest.java
@@ -19,7 +19,7 @@ public class ComputeFieldSizeTest {
       factory.get("ComputeFieldSizeTest/no-source.conf");
     });
     assertThrows(StageException.class, () -> {
-      factory.get("ComputeFieldSizeTest/no-output.conf");
+      factory.get("ComputeFieldSizeTest/no-destination.conf");
     });
   }
 
@@ -37,7 +37,7 @@ public class ComputeFieldSizeTest {
   public void testSourceNotByteArray() throws StageException {
     Stage stage = factory.get("ComputeFieldSizeTest/basic.conf");
     Document doc1 = Document.create("doc1");
-    doc1.update("sourceField", UpdateMode.OVERWRITE, "string");
+    doc1.update("source", UpdateMode.OVERWRITE, "string");
 
     assertThrows(NullPointerException.class, () -> {
       stage.processDocument(doc1);
@@ -51,17 +51,17 @@ public class ComputeFieldSizeTest {
     Document doc2 = Document.create("doc2");
     Document doc3 = Document.create("doc3");
 
-    doc1.update("sourceField", UpdateMode.OVERWRITE, new byte[0]);
-    doc2.update("sourceField", UpdateMode.OVERWRITE, new byte[5]);
-    doc3.update("sourceField", UpdateMode.OVERWRITE, new byte[10]);
+    doc1.update("source", UpdateMode.OVERWRITE, new byte[0]);
+    doc2.update("source", UpdateMode.OVERWRITE, new byte[5]);
+    doc3.update("source", UpdateMode.OVERWRITE, new byte[10]);
 
     for (Document doc : Arrays.asList(doc1, doc2, doc3)) {
       stage.processDocument(doc);
     }
 
-    assertEquals(0, doc1.getInt("outputField").intValue());
-    assertEquals(5, doc2.getInt("outputField").intValue());
-    assertEquals(10, doc3.getInt("outputField").intValue());
+    assertEquals(0, doc1.getInt("destination").intValue());
+    assertEquals(5, doc2.getInt("destination").intValue());
+    assertEquals(10, doc3.getInt("destination").intValue());
   }
 
   @Test
@@ -69,11 +69,11 @@ public class ComputeFieldSizeTest {
     Stage stage = factory.get("ComputeFieldSizeTest/basic.conf");
     Document doc1 = Document.create("doc1");
 
-    doc1.update("sourceField", UpdateMode.OVERWRITE, new byte[10]);
-    doc1.update("outputField", UpdateMode.OVERWRITE, "default");
+    doc1.update("source", UpdateMode.OVERWRITE, new byte[10]);
+    doc1.update("destination", UpdateMode.OVERWRITE, "default");
 
     stage.processDocument(doc1);
 
-    assertEquals(10, doc1.getInt("outputField").intValue());
+    assertEquals(10, doc1.getInt("destination").intValue());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ComputeFieldSizeTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ComputeFieldSizeTest.java
@@ -27,10 +27,10 @@ public class ComputeFieldSizeTest {
   public void testSourceFieldDoesNotExist() throws StageException {
     Stage stage = factory.get("ComputeFieldSizeTest/basic.conf");
     Document doc1 = Document.create("doc1");
+    stage.processDocument(doc1);
 
-    assertThrows(StageException.class, () -> {
-      stage.processDocument(doc1);
-    });
+    assertEquals(1, doc1.getFieldNames().size());
+    assertEquals("doc1", doc1.getString("id"));
   }
 
   @Test
@@ -39,7 +39,7 @@ public class ComputeFieldSizeTest {
     Document doc1 = Document.create("doc1");
     doc1.update("source", UpdateMode.OVERWRITE, "string");
 
-    assertThrows(NullPointerException.class, () -> {
+    assertThrows(StageException.class, () -> {
       stage.processDocument(doc1);
     });
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ComputeFieldSizeTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ComputeFieldSizeTest.java
@@ -1,0 +1,79 @@
+package com.kmwllc.lucille.stage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import java.util.Arrays;
+import org.junit.Test;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Stage;
+import com.kmwllc.lucille.core.StageException;
+import com.kmwllc.lucille.core.UpdateMode;
+
+public class ComputeFieldSizeTest {
+
+  private final StageFactory factory = StageFactory.of(ComputeFieldSize.class);
+
+  @Test
+  public void testNotAllRequiredFields() throws StageException {
+    assertThrows(StageException.class, () -> {
+      factory.get("ComputeFieldSizeTest/no-source.conf");
+    });
+    assertThrows(StageException.class, () -> {
+      factory.get("ComputeFieldSizeTest/no-output.conf");
+    });
+  }
+
+  @Test
+  public void testSourceFieldDoesNotExist() throws StageException {
+    Stage stage = factory.get("ComputeFieldSizeTest/basic.conf");
+    Document doc1 = Document.create("doc1");
+
+    assertThrows(StageException.class, () -> {
+      stage.processDocument(doc1);
+    });
+  }
+
+  @Test
+  public void testSourceNotByteArray() throws StageException {
+    Stage stage = factory.get("ComputeFieldSizeTest/basic.conf");
+    Document doc1 = Document.create("doc1");
+    doc1.update("sourceField", UpdateMode.OVERWRITE, "string");
+
+    assertThrows(NullPointerException.class, () -> {
+      stage.processDocument(doc1);
+    });
+  }
+
+  @Test
+  public void testNormalComputeFields() throws StageException {
+    Stage stage = factory.get("ComputeFieldSizeTest/basic.conf");
+    Document doc1 = Document.create("doc1");
+    Document doc2 = Document.create("doc2");
+    Document doc3 = Document.create("doc3");
+
+    doc1.update("sourceField", UpdateMode.OVERWRITE, new byte[0]);
+    doc2.update("sourceField", UpdateMode.OVERWRITE, new byte[5]);
+    doc3.update("sourceField", UpdateMode.OVERWRITE, new byte[10]);
+
+    for (Document doc : Arrays.asList(doc1, doc2, doc3)) {
+      stage.processDocument(doc);
+    }
+
+    assertEquals(0, doc1.getInt("outputField").intValue());
+    assertEquals(5, doc2.getInt("outputField").intValue());
+    assertEquals(10, doc3.getInt("outputField").intValue());
+  }
+
+  @Test
+  public void testOverwriteField() throws StageException {
+    Stage stage = factory.get("ComputeFieldSizeTest/basic.conf");
+    Document doc1 = Document.create("doc1");
+
+    doc1.update("sourceField", UpdateMode.OVERWRITE, new byte[10]);
+    doc1.update("outputField", UpdateMode.OVERWRITE, "default");
+
+    stage.processDocument(doc1);
+
+    assertEquals(10, doc1.getInt("outputField").intValue());
+  }
+}

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/basic.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/basic.conf
@@ -1,0 +1,6 @@
+{
+  name: "ComputeFieldSize",
+  class: "com.kmwllc.lucille.stage.ComputeFieldSize",
+  sourceField: "sourceField",
+  outputField: "outputField"
+}

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/basic.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/basic.conf
@@ -1,6 +1,6 @@
 {
   name: "ComputeFieldSize",
   class: "com.kmwllc.lucille.stage.ComputeFieldSize",
-  sourceField: "sourceField",
-  outputField: "outputField"
+  source: "source",
+  destination: "destination"
 }

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/basic.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/basic.conf
@@ -2,5 +2,5 @@
   name: "ComputeFieldSize",
   class: "com.kmwllc.lucille.stage.ComputeFieldSize",
   source: "source",
-  destination: "destination"
+  dest: "destination"
 }

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/no-destination.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/no-destination.conf
@@ -1,5 +1,5 @@
 {
   name: "ComputeFieldSize",
   class: "com.kmwllc.lucille.stage.ComputeFieldSize",
-  sourceField: "sourceField"
+  source: "source"
 }

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/no-output.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/no-output.conf
@@ -1,0 +1,5 @@
+{
+  name: "ComputeFieldSize",
+  class: "com.kmwllc.lucille.stage.ComputeFieldSize",
+  sourceField: "sourceField"
+}

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/no-source.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/no-source.conf
@@ -1,5 +1,5 @@
 {
   name: "ComputeFieldSize",
   class: "com.kmwllc.lucille.stage.ComputeFieldSize",
-  outputField: "outputField"
+  destination: "destination"
 }

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/no-source.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/no-source.conf
@@ -1,5 +1,5 @@
 {
   name: "ComputeFieldSize",
   class: "com.kmwllc.lucille.stage.ComputeFieldSize",
-  destination: "destination"
+  dest: "destination"
 }

--- a/lucille-core/src/test/resources/ComputeFieldSizeTest/no-source.conf
+++ b/lucille-core/src/test/resources/ComputeFieldSizeTest/no-source.conf
@@ -1,0 +1,5 @@
+{
+  name: "ComputeFieldSize",
+  class: "com.kmwllc.lucille.stage.ComputeFieldSize",
+  outputField: "outputField"
+}


### PR DESCRIPTION
one of the tests logs an "error accessing bye[] field" but that is intentional. The JsonDocument implementation of Document getBytes() method logs this to notify users that they are incorrectly interpreting a field as a byte[], but allows the program to keep running by returning null.