### PR TITLE
LC-281 truncate field stage

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/TruncateField.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/TruncateField.java
@@ -1,0 +1,65 @@
+package com.kmwllc.lucille.stage;
+
+import java.util.Iterator;
+import com.kmwllc.lucille.core.ConfigUtils;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Stage;
+import com.kmwllc.lucille.core.StageException;
+import com.kmwllc.lucille.core.UpdateMode;
+import com.typesafe.config.Config;
+
+/**
+ * Truncates a string field to a given number of characters. Can be inplace or return the result to a 
+ * seperate field
+ * <br>
+ * Config Parameters -
+ * <br>
+ * <p>
+ * <b>source</b> (String) : The field to be truncated. If this is not a string it is still parsed as a string to generate a result
+ * </p>
+ * <p>
+ * <b>max_size</b> (int) : The maximum number of characters to truncate the input to. If this is negative a StageException 
+ * is thrown. 
+ *  </p>
+ * <p>
+ * <p>
+ * <b>destination</b> (String, Optional) : The field where the truncated data should be placed. If this is not provided the 
+ * operation is done inplace. If this field already exists it is overwritten.
+ * </p>
+ */
+public class TruncateField extends Stage {
+
+  private final String source;
+  private final int maxSize;
+  private final String destination;
+
+  public TruncateField(Config config) {
+    super(config, new StageSpec().withRequiredProperties("source", "max_size").withOptionalProperties("destination"));
+
+
+    this.source = config.getString("source");
+    this.maxSize = config.getInt("max_size");
+    this.destination = ConfigUtils.getOrDefault(config, "destination", null);
+  }
+
+  @Override
+  public void start() throws StageException {
+    if(maxSize < 0) {
+      throw new StageException("max_size cannot be negative");
+    }
+  }
+
+  @Override
+  public Iterator<Document> processDocument(Document doc) throws StageException {
+    if (doc.has(source)) {
+      String string = doc.getString(source);
+      if (string == null) {
+        throw new StageException(String.format("Field: {} does not contain a string", source));
+      }
+
+      String newString = string.length() <= maxSize ? string : string.substring(0, maxSize);
+      doc.update(destination != null ? destination : source, UpdateMode.OVERWRITE, newString);
+    }
+    return null;
+  }
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/TruncateFieldTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/TruncateFieldTest.java
@@ -1,0 +1,63 @@
+package com.kmwllc.lucille.stage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import org.junit.Test;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Stage;
+import com.kmwllc.lucille.core.StageException;
+
+public class TruncateFieldTest {
+
+  StageFactory factory = StageFactory.of(TruncateField.class);
+
+  @Test 
+  public void testRequiredPropertiesNotProvided() {
+   assertThrows(StageException.class, () -> {factory.get("TruncateFieldTest/no-source.conf");});
+   assertThrows(StageException.class, () -> {factory.get("TruncateFieldTest/no-max-size.conf");});
+  }
+
+  @Test 
+  public void testIncorrectConfigTypes() {
+   assertThrows(StageException.class, () -> {factory.get("TruncateFieldTest/source-config-not-string.conf");});
+   assertThrows(StageException.class, () -> {factory.get("TruncateFieldTest/max-size-not-int.conf");});
+   assertThrows(StageException.class, () -> {factory.get("TruncateFieldTest/destination-not-string.conf");});
+   assertThrows(StageException.class, () -> {factory.get("TruncateFieldTest/negative-size.conf");});
+  }
+
+  @Test 
+  public void testInPlace() throws StageException {
+    Stage stage = factory.get("TruncateFieldTest/in-place.conf");
+    Document doc = Document.create("doc1");
+    doc.setField("source", "some string");
+
+    stage.processDocument(doc);
+    assertEquals("some ", doc.getString("source"));
+    assertEquals("doc1", doc.getString("id"));
+  }
+  
+  @Test 
+  public void testDestinationField() throws StageException {
+    Stage stage = factory.get("TruncateFieldTest/destination-field.conf");
+    Document doc = Document.create("doc1");
+    doc.setField("source", "some string");
+
+    stage.processDocument(doc);
+    assertEquals("some string", doc.getString("source"));
+    assertEquals("some ", doc.getString("destination"));
+    assertEquals("doc1", doc.getString("id"));
+  }
+
+  @Test 
+  public void testOverwritesDesinationField() throws StageException {
+    Stage stage = factory.get("TruncateFieldTest/destination-field.conf");
+    Document doc = Document.create("doc1");
+    doc.setField("source", "some string");
+    doc.setField("destination", "random content");
+
+    stage.processDocument(doc);
+    assertEquals("some string", doc.getString("source"));
+    assertEquals("some ", doc.getString("destination"));
+    assertEquals("doc1", doc.getString("id"));
+  }
+}

--- a/lucille-core/src/test/resources/TruncateFieldTest/destination-field.conf
+++ b/lucille-core/src/test/resources/TruncateFieldTest/destination-field.conf
@@ -1,0 +1,7 @@
+{
+  name: "destination-field",
+  class: com.kmwllc.lucille.stage.TruncateField
+  source: "source",
+  destination: "destination",
+  max_size: 5
+}

--- a/lucille-core/src/test/resources/TruncateFieldTest/destination-not-string.conf
+++ b/lucille-core/src/test/resources/TruncateFieldTest/destination-not-string.conf
@@ -1,0 +1,7 @@
+{
+  name: "maxSizeNotInt",
+  class: com.kmwllc.lucille.stage.TruncateField
+  source: "source",
+  destination: 1000L,
+  max_size: "this is not number"
+}

--- a/lucille-core/src/test/resources/TruncateFieldTest/in-place.conf
+++ b/lucille-core/src/test/resources/TruncateFieldTest/in-place.conf
@@ -1,0 +1,6 @@
+{
+  name: "in-place",
+  class: com.kmwllc.lucille.stage.TruncateField
+  source: "source",
+  max_size: 5
+}

--- a/lucille-core/src/test/resources/TruncateFieldTest/max-size-not-int.conf
+++ b/lucille-core/src/test/resources/TruncateFieldTest/max-size-not-int.conf
@@ -1,0 +1,7 @@
+{
+  name: "maxSizeNotInt",
+  class: com.kmwllc.lucille.stage.TruncateField
+  source: "source",
+  destination: "destination",
+  max_size: "this is not number"
+}

--- a/lucille-core/src/test/resources/TruncateFieldTest/negative-size.conf
+++ b/lucille-core/src/test/resources/TruncateFieldTest/negative-size.conf
@@ -1,0 +1,7 @@
+{
+  name: "negativeSize.conf",
+  class: com.kmwllc.lucille.stage.TruncateField
+  source: "source",
+  destination: "destination",
+  max_size: -5
+}

--- a/lucille-core/src/test/resources/TruncateFieldTest/no-maxSize.conf
+++ b/lucille-core/src/test/resources/TruncateFieldTest/no-maxSize.conf
@@ -1,0 +1,6 @@
+{
+  name: "no-maxSize",
+  class: com.kmwllc.lucille.stage.TruncateField
+  source: "source",
+  destination: "destination",
+}

--- a/lucille-core/src/test/resources/TruncateFieldTest/source-config-not-string.conf
+++ b/lucille-core/src/test/resources/TruncateFieldTest/source-config-not-string.conf
@@ -1,0 +1,7 @@
+{
+  name: "source-config-not-string",
+  class: com.kmwllc.lucille.stage.TruncateField
+  source: 1000L,
+ destination: "destination",
+  max_size: 5
+}


### PR DESCRIPTION
Truncates a string field to a given number of characters. Can be inplace or return the result to a seperate field.