### PR TITLE
LC-412 restore ability to start Indexer in fully distributed mode

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -97,5 +97,4 @@ public class CSVIndexer extends Indexer {
     }
   }
 
-
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -268,29 +268,4 @@ public class ElasticsearchIndexer extends Indexer {
     }
   }
 
-  public static void main(String[] args) throws Exception {
-    Config config = ConfigFactory.load();
-    String pipelineName = args.length > 0 ? args[0] : config.getString("indexer.pipeline");
-    log.info("Starting Indexer for pipeline: " + pipelineName);
-    IndexerMessenger messenger = new KafkaIndexerMessenger(config, pipelineName);
-    Indexer indexer = new ElasticsearchIndexer(config, messenger, false, pipelineName);
-    if (!indexer.validateConnection()) {
-      log.error("Indexer could not connect");
-      System.exit(1);
-    }
-
-    Thread indexerThread = new Thread(indexer);
-    indexerThread.start();
-
-    Signal.handle(new Signal("INT"), signal -> {
-      indexer.terminate();
-      log.info("Indexer shutting down");
-      try {
-        indexerThread.join();
-      } catch (InterruptedException e) {
-        log.error("Interrupted", e);
-      }
-      System.exit(0);
-    });
-  }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -173,30 +173,4 @@ public class OpenSearchIndexer extends Indexer {
     }
   }
 
-  public static void main(String[] args) throws Exception {
-    Config config = ConfigFactory.load();
-    String pipelineName = args.length > 0 ? args[0] : config.getString("indexer.pipeline");
-    log.info("Starting Indexer for pipeline: " + pipelineName);
-    IndexerMessenger messenger = new KafkaIndexerMessenger(config, pipelineName);
-    Indexer indexer = new OpenSearchIndexer(config, messenger, false, pipelineName);
-    if (!indexer.validateConnection()) {
-      log.error("Indexer could not connect");
-      System.exit(1);
-    }
-
-    Thread indexerThread = new Thread(indexer);
-    indexerThread.start();
-
-    Signal.handle(new Signal("INT"), signal -> {
-      indexer.terminate();
-      log.info("Indexer shutting down");
-      try {
-        indexerThread.join();
-      } catch (InterruptedException e) {
-        log.error("Interrupted", e);
-      }
-      System.exit(0);
-    });
-  }
-
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -305,32 +305,4 @@ public class SolrIndexer extends Indexer {
       solrDoc.addChildDocument(solrChild);
     }
   }
-
-  public static void main(String[] args) throws Exception {
-    Config config = ConfigFactory.load();
-    String pipelineName = args.length > 0 ? args[0] : config.getString("indexer.pipeline");
-    log.info("Starting Indexer for pipeline: " + pipelineName);
-    IndexerMessenger messenger = new KafkaIndexerMessenger(config, pipelineName);
-    Indexer indexer = new SolrIndexer(config, messenger, false, pipelineName);
-    if (!indexer.validateConnection()) {
-      log.error("Indexer could not connect");
-      System.exit(1);
-    }
-
-    Thread indexerThread = new Thread(indexer);
-    indexerThread.start();
-
-    Signal.handle(
-        new Signal("INT"),
-        signal -> {
-          indexer.terminate();
-          log.info("Indexer shutting down");
-          try {
-            indexerThread.join();
-          } catch (InterruptedException e) {
-            log.error("Interrupted", e);
-          }
-          System.exit(0);
-        });
-  }
 }


### PR DESCRIPTION
This PR removes the duplicated main() methods from some of the Indexer subclasses and places it back on the Indexer base class. The aim is that a user wishing to run Lucille in fully-distributed mode should be able to run com.kmwllc.lucille.core.Indexer at the command line and have the appropriate kind of indexer be started based on the configuration.

Note: We don't yet have test coverage for the main() methods on Indexer, WorkerIndexer, or Worker. I tested this PR manually. The manual test involved starting kafka+zookeeper, starting a lucille Indexer, Worker, and then launching a run via Runner. I confirmed that the run succeeded. In my case, I was using a config file that specified a CSVIndexer. I checked that the csv file that the run should have generated was indeed created and properly populated after the run.