### PR TITLE
LC-399 make sure Worker and WorkerIndexer terminate when a startup exception is encountered

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
@@ -56,11 +56,11 @@ public class WorkerIndexerPool {
         workerIndexer.start(config, pipelineName, bypassSearchEngine, idSet);
         workerIndexers.add(workerIndexer);
       } catch (Exception e) {
-        log.error("Exception caught when starting WorkerIndexer thread {}; aborting", i+1, e);
+        log.error("Exception caught when starting WorkerIndexer thread {}; aborting", i+1);
         try {
           stop();
         } catch (Exception e2) {
-          log.error("Exception caught when attempting to stop WorkerIndexer threads because of a startup problem", e);
+          log.error("Exception caught when attempting to stop WorkerIndexer threads because of a startup problem", e2);
         }
         throw e;
       }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
@@ -84,7 +84,9 @@ public class WorkerIndexerPool {
 
   public void stop() throws Exception {
     log.debug("Stopping " + workerIndexers.size() + " worker threads");
-    logTimer.cancel();
+    if (logTimer != null) {
+      logTimer.cancel();
+    }
     for (WorkerIndexer workerIndexer : workerIndexers) {
       // stop each WorkerIndexer, one at a time;
       // make sure the indexer is stopped before the worker, so that the

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
@@ -62,7 +62,7 @@ public class WorkerIndexerPool {
         } catch (Exception e2) {
           log.error("Exception caught when attempting to stop WorkerIndexer threads because of a startup problem", e);
         }
-        return;
+        throw e;
       }
     }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexerPool.java
@@ -22,7 +22,7 @@ public class WorkerIndexerPool {
   private Integer numWorkers = null;
   private boolean started = false;
   private final int logSeconds;
-  private final Timer logTimer = new Timer();
+  private Timer logTimer;
   private final boolean bypassSearchEngine;
   private final Set<String> idSet;
 
@@ -67,6 +67,8 @@ public class WorkerIndexerPool {
     }
 
     // Timer to log a status message every minute
+    // the Timer should use a daemon thread so it doesn't prevent the jvm from exiting
+    logTimer = new Timer("WorkerIndexerPoolTimer", true);
     logTimer.schedule(new TimerTask() {
       private final MetricRegistry metrics = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
       private final com.codahale.metrics.Timer timer = metrics.timer(pipelineName + Worker.METRICS_SUFFIX);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -63,7 +63,7 @@ public class WorkerPool {
         try {
           stop();
         } catch (Exception e2) {
-          log.error("Exception caught when attempting to stop Worker threads because of a startup problem", e);
+          log.error("Exception caught when attempting to stop Worker threads because of a startup problem", e2);
         }
         throw e;
       }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -87,7 +87,9 @@ public class WorkerPool {
 
   public void stop() {
     log.debug("Stopping " + threads.size() + " worker threads");
-    logTimer.cancel();
+    if (logTimer != null) {
+      logTimer.cancel();
+    }
     for (WorkerThread workerThread : threads) {
       workerThread.terminate();
     }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -59,13 +59,13 @@ public class WorkerPool {
         WorkerMessenger messenger = workerMessengerFactory.create();
         threads.add(Worker.startThread(config, messenger, pipelineName, metricsPrefix));
       } catch (Exception e) {
-        log.error("Exception caught when starting Worker thread {}; aborting", i+1, e);
+        log.error("Exception caught when starting Worker thread {}; aborting", i+1);
         try {
           stop();
         } catch (Exception e2) {
           log.error("Exception caught when attempting to stop Worker threads because of a startup problem", e);
         }
-        return;
+        throw e;
       }
     }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -28,7 +28,7 @@ public class WorkerPool {
   private WorkerMessengerFactory workerMessengerFactory;
   private boolean started = false;
   private final int logSeconds;
-  private final Timer logTimer = new Timer();
+  private Timer logTimer;
   private final String metricsPrefix;
 
   public WorkerPool(Config config, String pipelineName, WorkerMessengerFactory factory, String metricsPrefix) {
@@ -70,6 +70,8 @@ public class WorkerPool {
     }
 
     // Timer to log a status message every minute
+    // the Timer should use a daemon thread so it doesn't prevent the jvm from exiting
+    logTimer = new Timer("WorkerPoolTimer", true);
     logTimer.schedule(new TimerTask() {
       private final MetricRegistry metrics = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
       private final com.codahale.metrics.Timer timer = metrics.timer(metricsPrefix + Worker.METRICS_SUFFIX);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
@@ -1,0 +1,56 @@
+package com.kmwllc.lucille.core;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.Collection;
+import org.apache.commons.lang3.ThreadUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests WorkerIndexerPool.
+ *
+ * Note: There is additional coverage in HybridKafkaTest.testWorkerIndexerPool();
+ * that test is in a separate class because it depends on an embedded test environment
+ */
+@RunWith(JUnit4.class)
+public class WorkerIndexerPoolTest {
+
+  @Test
+  public void testParseConfig() throws Exception {
+    // reuse basic config from WorkerPoolTest
+    Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
+
+    WorkerIndexerPool pool1 = new WorkerIndexerPool(config, "pipeline1", true, null);
+    WorkerIndexerPool pool2 = new WorkerIndexerPool(config, "pipeline2", true, null);
+    WorkerIndexerPool pool3 = new WorkerIndexerPool(config, "pipeline3", true, null);
+    WorkerIndexerPool pool4 = new WorkerIndexerPool(ConfigFactory.empty(), "pipeline4", true, null);
+
+    assertEquals(14, pool1.getNumWorkers());
+    assertEquals(23, pool2.getNumWorkers());
+    assertEquals(7, pool3.getNumWorkers());
+    assertEquals(WorkerPool.DEFAULT_POOL_SIZE, pool4.getNumWorkers());
+  }
+
+  @Test
+  public void testThreadCleanupUponEncounteringConfigProblem() throws Exception {
+    Collection<Thread> nonSystemThreadsBefore =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+
+    // simulate a config error by passing an empty config to WorkerIndexerPool
+    Config config = ConfigFactory.empty();
+    WorkerIndexerPool pool = new WorkerIndexerPool(config, "pipeline12345", true, null);
+
+    assertThrows(Exception.class, () -> { pool.start(); });
+
+    Collection<Thread> nonSystemThreadsAfter =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+    assertArrayEquals(nonSystemThreadsBefore.toArray(), nonSystemThreadsAfter.toArray());
+  }
+
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -65,11 +65,9 @@ public class WorkerPoolTest {
     WorkerMessengerFactory factory = WorkerMessengerFactory.getConstantFactory(messenger);
     Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
     // pipeline12345 is not present in config.conf
-    WorkerPool pool1 = new WorkerPool(config, "pipeline12345", factory, "");
+    WorkerPool pool = new WorkerPool(config, "pipeline12345", factory, "");
 
-    // no exception should be thrown here;
-    // errors should be logged and any new threads including timers should be stopped
-    pool1.start();
+    assertThrows(Exception.class, () -> { pool.start(); });
 
     Collection<Thread> nonSystemThreadsAfter =
         ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
@@ -81,11 +79,9 @@ public class WorkerPoolTest {
     Collection<Thread> nonSystemThreadsBefore =
         ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
     Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
-    WorkerPool pool1 = new WorkerPool(config, "pipeline1", null, "");
+    WorkerPool pool = new WorkerPool(config, "pipeline1", null, "");
 
-    // no exception should be thrown here;
-    // errors should be logged and any new threads including timers should be stopped
-    pool1.start();
+    assertThrows(Exception.class, () -> { pool.start(); });
 
     Collection<Thread> nonSystemThreadsAfter =
         ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -4,12 +4,19 @@ import com.kmwllc.lucille.message.TestMessenger;
 import com.kmwllc.lucille.message.WorkerMessengerFactory;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.commons.lang3.ThreadUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -49,4 +56,39 @@ public class WorkerPoolTest {
     verify(messenger, times(1)).close();
   }
 
+  @Test
+  public void testThreadCleanupUponEncounteringConfigProblem() throws Exception {
+    Collection<Thread> nonSystemThreadsBefore =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+
+    TestMessenger messenger = Mockito.spy(new TestMessenger());
+    WorkerMessengerFactory factory = WorkerMessengerFactory.getConstantFactory(messenger);
+    Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
+    // pipeline12345 is not present in config.conf
+    WorkerPool pool1 = new WorkerPool(config, "pipeline12345", factory, "");
+
+    // no exception should be thrown here;
+    // errors should be logged and any new threads including timers should be stopped
+    pool1.start();
+
+    Collection<Thread> nonSystemThreadsAfter =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+    assertArrayEquals(nonSystemThreadsBefore.toArray(), nonSystemThreadsAfter.toArray());
+  }
+
+  @Test
+  public void testThreadCleanupUponEncounteringNullMessenger() throws Exception {
+    Collection<Thread> nonSystemThreadsBefore =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+    Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
+    WorkerPool pool1 = new WorkerPool(config, "pipeline1", null, "");
+
+    // no exception should be thrown here;
+    // errors should be logged and any new threads including timers should be stopped
+    pool1.start();
+
+    Collection<Thread> nonSystemThreadsAfter =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+    assertArrayEquals(nonSystemThreadsBefore.toArray(), nonSystemThreadsAfter.toArray());
+  }
 }


### PR DESCRIPTION
When starting Worker or WorkerIndexer at the command line, the java process would not terminate if there was an error in certain parts of the config file, including the pipeline section and/or the kafka section. This was happening because at least one thread had been started before attempting to parse those sections of the config. When the parse error was encountered, there was no logic in place to cleanly stop all threads that might have been started. The lingering threads were preventing the process from terminating. This PR addresses that issue by catching exceptions encountered while starting Worker and WorkerIndexer threads and, in case an exception is encountered, calling stop() on the corresponding thread pool.

Update: after a closer look, it turned out the issue with WorkerIndexer not terminating was being caused by a lingering thread that got created by instantiating a java.util.Timer as an instance variable, and in some error, cases not calling cancel() on the timer. This problem was fixed by delaying timer instantiation to the WorkerIndexer.start() method and passing a flag to make the timer threads "daeomon threads" that won't prevent JVM termination. The earlier code changes in this PR to call stop() in error scenarios are still beneficial.