### PR TITLE
LC-419 added tests for ParseFloats stage

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
@@ -7,10 +7,8 @@ import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
 import com.typesafe.config.Config;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -31,7 +29,7 @@ public class ParseFloats extends Stage {
       List<Float> floats;
       try {
         ObjectMapper mapper = new ObjectMapper();
-        floats = mapper.readValue(value, new TypeReference<List<Float>>(){});
+        floats = mapper.readValue(value, new TypeReference<List<Float>>() {});
       } catch (Exception e) {
         log.warn("String: {} cannot be parsed.", value, e);
         return null;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
@@ -1,5 +1,7 @@
 package com.kmwllc.lucille.stage;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
@@ -28,8 +30,8 @@ public class ParseFloats extends Stage {
       String value = doc.getString(this.field);
       List<Float> floats;
       try {
-        floats = Arrays.stream(value.replaceAll("\\[", "").replaceAll("\\]", "").replaceAll(",", "").split(" "))
-            .map(v -> Float.parseFloat(v)).collect(Collectors.toList());
+        ObjectMapper mapper = new ObjectMapper();
+        floats = mapper.readValue(value, new TypeReference<List<Float>>(){});
       } catch (Exception e) {
         log.warn("String: {} cannot be parsed.", value, e);
         return null;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
@@ -16,6 +16,8 @@ public class ParseFloats extends Stage {
 
   private final String field;
   private static final Logger log = LogManager.getLogger(ParseFloats.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final TypeReference<List<Float>> TYPE_REFERENCE = new TypeReference<List<Float>>() {};
 
   public ParseFloats(Config config) {
     super(config, new StageSpec().withRequiredProperties("field"));
@@ -28,8 +30,7 @@ public class ParseFloats extends Stage {
       String value = doc.getString(this.field);
       List<Float> floats;
       try {
-        ObjectMapper mapper = new ObjectMapper();
-        floats = mapper.readValue(value, new TypeReference<List<Float>>() {});
+        floats = MAPPER.readValue(value, TYPE_REFERENCE);
       } catch (Exception e) {
         log.warn("String: {} cannot be parsed.", value, e);
         return null;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
@@ -9,10 +9,13 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ParseFloats extends Stage {
 
   private final String field;
+  private static final Logger log = LogManager.getLogger(ParseFloats.class);
 
   public ParseFloats(Config config) {
     super(config, new StageSpec().withRequiredProperties("field"));
@@ -28,6 +31,7 @@ public class ParseFloats extends Stage {
         floats = Arrays.stream(value.replaceAll("\\[", "").replaceAll("\\]", "").replaceAll(",", "").split(" "))
             .map(v -> Float.parseFloat(v)).collect(Collectors.toList());
       } catch (Exception e) {
+        log.warn("String: {} cannot be parsed.", value, e);
         return null;
       }
       doc.removeField(this.field);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
@@ -23,8 +23,13 @@ public class ParseFloats extends Stage {
   public Iterator<Document> processDocument(Document doc) throws StageException {
     if (doc.has(field)) {
       String value = doc.getString(this.field);
-      List<Float> floats = Arrays.stream(value.replaceAll("\\[", "").replaceAll("\\]", "").replaceAll(",", "").split(" "))
-          .map(v -> Float.parseFloat(v)).collect(Collectors.toList());
+      List<Float> floats;
+      try {
+        floats = Arrays.stream(value.replaceAll("\\[", "").replaceAll("\\]", "").replaceAll(",", "").split(" "))
+            .map(v -> Float.parseFloat(v)).collect(Collectors.toList());
+      } catch (Exception e) {
+        return null;
+      }
       doc.removeField(this.field);
       for (Float d : floats) {
         doc.addToField(this.field, d);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseFloats.java
@@ -2,6 +2,7 @@ package com.kmwllc.lucille.stage;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kmwllc.lucille.core.ConfigUtils;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
@@ -15,13 +16,15 @@ import org.apache.logging.log4j.Logger;
 public class ParseFloats extends Stage {
 
   private final String field;
+  private final String dest;
   private static final Logger log = LogManager.getLogger(ParseFloats.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final TypeReference<List<Float>> TYPE_REFERENCE = new TypeReference<List<Float>>() {};
 
   public ParseFloats(Config config) {
-    super(config, new StageSpec().withRequiredProperties("field"));
+    super(config, new StageSpec().withRequiredProperties("field").withOptionalProperties("dest"));
     this.field = config.getString("field");
+    this.dest = ConfigUtils.getOrDefault(config, "dest", null);
   }
 
   @Override
@@ -35,9 +38,9 @@ public class ParseFloats extends Stage {
         log.warn("String: {} cannot be parsed.", value, e);
         return null;
       }
-      doc.removeField(this.field);
+      doc.removeField(dest != null ? dest : field);
       for (Float d : floats) {
-        doc.addToField(this.field, d);
+        doc.addToField(dest != null ? dest : field, d);
       }
     }
     return null;

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
@@ -39,8 +39,7 @@ public class ParseFloatsTest {
     assertEquals("not a float", bad.getString("source"));
     assertEquals("doc1", bad.getId());
 
-    assertEquals(2, empty.getFieldNames().size());
-    assertEquals("[]", empty.getString("source"));
+    assertEquals(1, empty.getFieldNames().size());
     assertEquals("doc2", empty.getId());
 
     assertEquals(2, simple.getFieldNames().size());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
@@ -1,20 +1,53 @@
 package com.kmwllc.lucille.stage;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import java.util.List;
 import org.junit.Test;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
 
 public class ParseFloatsTest {
 
-  StageFactory factory = StageFactory.of(ParseFloats.class);
+  private StageFactory factory = StageFactory.of(ParseFloats.class);
 
-  @Test 
+  @Test
   public void testMalformedConfig() {
     assertThrows(StageException.class, () -> factory.get("ParseFloatsTest/bad.conf"));
   }
 
-  @Test 
-  public void testProcessDocument() {
-    
+  @Test
+  public void testProcessDocument() throws StageException {
+    Stage stage = factory.get("ParseFloatsTest/basic.conf");
+
+    Document bad = Document.create("doc1");
+    Document empty = Document.create("doc2");
+    Document simple = Document.create("doc3");
+    Document noField = Document.create("doc4");
+
+    bad.setOrAdd("source", "not a float");
+    empty.setOrAdd("source", "[]");
+    simple.setOrAdd("source", "[1, 2, 3]");
+
+    stage.processDocument(bad);
+    stage.processDocument(empty);
+    stage.processDocument(simple);
+    stage.processDocument(noField);
+
+    assertEquals(2, bad.getFieldNames().size());
+    assertEquals("not a float", bad.getString("source"));
+    assertEquals("doc1", bad.getId());
+
+    assertEquals(2, empty.getFieldNames().size());
+    assertEquals("[]", empty.getString("source"));
+    assertEquals("doc2", empty.getId());
+
+    assertEquals(2, simple.getFieldNames().size());
+    assertEquals(List.of(1f, 2f, 3f), simple.getFloatList("source"));
+    assertEquals("doc3", simple.getId());
+
+    assertEquals(1, noField.getFieldNames().size());
+    assertEquals("doc4", noField.getId());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
@@ -25,15 +25,21 @@ public class ParseFloatsTest {
     Document empty = Document.create("doc2");
     Document simple = Document.create("doc3");
     Document noField = Document.create("doc4");
+    Document floats = Document.create("doc5");
+    Document badList = Document.create("doc6");
 
     bad.setOrAdd("source", "not a float");
     empty.setOrAdd("source", "[]");
     simple.setOrAdd("source", "[1, 2, 3]");
+    floats.setOrAdd("source", "[1.2, 2.5, 3.1]");
+    badList.setOrAdd("source", "[1, a, 3]");
 
     stage.processDocument(bad);
     stage.processDocument(empty);
     stage.processDocument(simple);
     stage.processDocument(noField);
+    stage.processDocument(floats);
+    stage.processDocument(badList);
 
     assertEquals(2, bad.getFieldNames().size());
     assertEquals("not a float", bad.getString("source"));
@@ -48,5 +54,13 @@ public class ParseFloatsTest {
 
     assertEquals(1, noField.getFieldNames().size());
     assertEquals("doc4", noField.getId());
+
+    assertEquals(2, floats.getFieldNames().size());
+    assertEquals(List.of(1.2f, 2.5f, 3.1f), floats.getFloatList("source"));
+    assertEquals("doc5", floats.getId());
+
+    assertEquals(2, badList.getFieldNames().size());
+    assertEquals("[1, a, 3]", badList.getString("source"));
+    assertEquals("doc6", badList.getId());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
@@ -20,6 +20,7 @@ public class ParseFloatsTest {
   @Test
   public void testProcessDocument() throws StageException {
     Stage stage = factory.get("ParseFloatsTest/basic.conf");
+    Stage stageDest = factory.get("ParseFloatsTest/dest.conf");
 
     Document bad = Document.create("doc1");
     Document empty = Document.create("doc2");
@@ -27,12 +28,14 @@ public class ParseFloatsTest {
     Document noField = Document.create("doc4");
     Document floats = Document.create("doc5");
     Document badList = Document.create("doc6");
+    Document dest = Document.create("doc7");
 
     bad.setOrAdd("source", "not a float");
     empty.setOrAdd("source", "[]");
     simple.setOrAdd("source", "[1, 2, 3]");
     floats.setOrAdd("source", "[1.2, 2.5, 3.1]");
-    badList.setOrAdd("source", "[1, a, 3]");
+    badList.setOrAdd("source", "[1, \"a\", 3]");
+    dest.setOrAdd("source", "[1, 2, 3]");
 
     stage.processDocument(bad);
     stage.processDocument(empty);
@@ -40,6 +43,7 @@ public class ParseFloatsTest {
     stage.processDocument(noField);
     stage.processDocument(floats);
     stage.processDocument(badList);
+    stageDest.processDocument(dest);
 
     assertEquals(2, bad.getFieldNames().size());
     assertEquals("not a float", bad.getString("source"));
@@ -60,7 +64,12 @@ public class ParseFloatsTest {
     assertEquals("doc5", floats.getId());
 
     assertEquals(2, badList.getFieldNames().size());
-    assertEquals("[1, a, 3]", badList.getString("source"));
+    assertEquals("[1, \"a\", 3]", badList.getString("source"));
     assertEquals("doc6", badList.getId());
+
+    assertEquals(3, dest.getFieldNames().size());
+    assertEquals(List.of(1f, 2f, 3f), dest.getFloatList("dest"));
+    assertEquals("[1, 2, 3]", dest.getString("source"));
+    assertEquals("doc7", dest.getId());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseFloatsTest.java
@@ -1,0 +1,20 @@
+package com.kmwllc.lucille.stage;
+
+import static org.junit.Assert.assertThrows;
+import org.junit.Test;
+import com.kmwllc.lucille.core.StageException;
+
+public class ParseFloatsTest {
+
+  StageFactory factory = StageFactory.of(ParseFloats.class);
+
+  @Test 
+  public void testMalformedConfig() {
+    assertThrows(StageException.class, () -> factory.get("ParseFloatsTest/bad.conf"));
+  }
+
+  @Test 
+  public void testProcessDocument() {
+    
+  }
+}

--- a/lucille-core/src/test/resources/ParseFloatsTest/bad.conf
+++ b/lucille-core/src/test/resources/ParseFloatsTest/bad.conf
@@ -1,0 +1,4 @@
+{
+  name: test,
+  class: com.kmwllc.lucille.stage.ParseFloats,
+}

--- a/lucille-core/src/test/resources/ParseFloatsTest/basic.conf
+++ b/lucille-core/src/test/resources/ParseFloatsTest/basic.conf
@@ -1,0 +1,5 @@
+{
+  name: test,
+  class: com.kmwllc.lucille.stage.ParseFloats,
+  field: "source"
+}

--- a/lucille-core/src/test/resources/ParseFloatsTest/dest.conf
+++ b/lucille-core/src/test/resources/ParseFloatsTest/dest.conf
@@ -1,0 +1,6 @@
+{
+  name: test,
+  class: com.kmwllc.lucille.stage.ParseFloats,
+  field: "source"
+  dest: "dest"
+}


### PR DESCRIPTION
one "bug" I found was that the stage would throw an exception if the input string could not correctly be parsed to a float list. Since the design philosophy of lucille is to ingest as many documents as possible without crashing, I changed this to just log a warning and skip the document instead. 

NOTE: the stage currently will consider the empty list ("[]") as non-parsable and skip rather than treating it as an empty list of floats and removing the field. Let me know if I should change this behavior. 
FIXED ABOVE: the stage now will parse the empty list and since its behavior is to remove the source field and replace it, it effectively just deletes the source field since there is no way to add an empty list.