### PR TITLE
LC-416 added json logging for elk and setting mdc values

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -53,7 +53,12 @@
       </exclusions>
     </dependency>
 
-
+  <!-- dependency to allow json logging for log4j -->
+  <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+      <version>2.22.1</version>
+  </dependency>
 
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -183,7 +183,7 @@ public abstract class Indexer implements Runnable {
       sendToIndexWithAccounting(batch.flushIfExpired());
       return;
     }
-
+    log.debug("Indexing Doc {}", doc.getId());
     sendToIndexWithAccounting(batch.add(doc));
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
@@ -113,7 +113,7 @@ public class PublisherImpl implements Publisher {
   }
 
   private void publishInternal(Document document) throws Exception {
-    log.info("Publishing document with id {}", document.getId());
+    log.debug("Publishing document with id {}", document.getId());
     if (!isCollapsing) {
       sendForProcessing(document);
       return;
@@ -125,7 +125,7 @@ public class PublisherImpl implements Publisher {
     }
 
     if (previousDoc.getId().equals(document.getId())) {
-      log.info("Sending document.");
+      log.debug("Sending document.");
       previousDoc.setOrAddAll(document);
     } else {
       sendForProcessing(previousDoc);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.MDC;
 
 /**
  * Publisher implementation that maintains an in-memory list of pending documents.
@@ -93,6 +94,7 @@ public class PublisherImpl implements Publisher {
 
   @Override
   public void publish(Document document) throws Exception {
+    MDC.put("docId", document.getId());
     if (firstDocStopWatch.isStarted()) {
       firstDocStopWatch.stop();
       log.info("First doc published after " + firstDocStopWatch.getTime(TimeUnit.MILLISECONDS) + " ms");
@@ -111,6 +113,7 @@ public class PublisherImpl implements Publisher {
   }
 
   private void publishInternal(Document document) throws Exception {
+    log.info("Publishing document with id {}", document.getId());
     if (!isCollapsing) {
       sendForProcessing(document);
       return;
@@ -122,6 +125,7 @@ public class PublisherImpl implements Publisher {
     }
 
     if (previousDoc.getId().equals(document.getId())) {
+      log.info("Sending document.");
       previousDoc.setOrAddAll(document);
     } else {
       sendForProcessing(previousDoc);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.MDC;
 
 /**
  * Executes a Lucille run. A run is a sequential execution of one or more Connectors.
@@ -219,6 +220,7 @@ public class Runner {
    */
   public static RunResult run(Config config, RunType type) throws Exception {
     String runId = UUID.randomUUID().toString();
+    MDC.put("runId", runId);
     log.info("Starting run with id " + runId);
 
     List<Connector> connectors = Connector.fromConfig(config);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
@@ -14,6 +14,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.slf4j.MDC;
 
 /**
  * An operation that can be performed on a Document.<br>
@@ -287,6 +288,7 @@ public abstract class Stage {
     if (name == null) {
       this.name = "stage_" + position;
     }
+    MDC.put("stage", this.name);
 
     MetricRegistry metrics = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
     this.timer = metrics.timer(metricsPrefix + ".stage." + name + ".processDocumentTime");

--- a/lucille-core/src/main/resources/log4j2.xml
+++ b/lucille-core/src/main/resources/log4j2.xml
@@ -18,12 +18,22 @@
             </Policies>
             <DefaultRolloverStrategy max="4" />
         </RollingFile>
+        <RollingFile name="elk" fileName="./log/com.kmwllc.lucille-json.log" filePattern="./log/com.kmwllc.lucille-json-%i.log">
+            <JsonTemplateLayout eventTemplateUri="classpath:EcsLayout.json"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 KB" />
+            </Policies>
+            <DefaultRolloverStrategy max="20" />
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="console" />
             <AppenderRef ref="file" />
         </Root>
+<!--        <Root level="DEBUG">-->
+<!--            <AppenderRef ref="elk" />-->
+<!--        </Root>-->
         <Logger name="com.kmwllc.com.kmwllc.lucille.core.Heartbeat" level="INFO" additivity="false">
             <AppenderRef ref="heartbeat" />
         </Logger>

--- a/lucille-core/src/test/resources/EcsLayout.json
+++ b/lucille-core/src/test/resources/EcsLayout.json
@@ -1,0 +1,49 @@
+{
+  "@timestamp": {
+    "$resolver": "timestamp",
+    "pattern": {
+      "format": "yy/MM/dd'T'HH:mm:ss'Z'",
+      "timeZone": "UTC"
+    }
+  },
+  "ecs.version": "1.2.0",
+  "log.level": {
+    "$resolver": "level",
+    "field": "name"
+  },
+  "message": {
+    "$resolver": "message",
+    "stringified": true
+  },
+  "process.thread.name": {
+    "$resolver": "thread",
+    "field": "name"
+  },
+  "log.logger": {
+    "$resolver": "logger",
+    "field": "name"
+  },
+  "labels": {
+    "$resolver": "mdc",
+    "flatten": true,
+    "stringified": true
+  },
+  "tags": {
+    "$resolver": "ndc"
+  },
+  "error.type": {
+    "$resolver": "exception",
+    "field": "className"
+  },
+  "error.message": {
+    "$resolver": "exception",
+    "field": "message"
+  },
+  "error.stack_trace": {
+    "$resolver": "exception",
+    "field": "stackTrace",
+    "stackTrace": {
+      "stringified": true
+    }
+  }
+}


### PR DESCRIPTION
We are adding more logging to be able to be ingested by Elasticsearch. We decided that what would make the most sense is to create a separate json log file so it can easily be indexed and would not require any GROK. In addition, we want to know some values for everything single log so we are setting mdc values for run id, doc id, and stage name at the moment.