### PR TITLE
LC-423 added tests for ZKRetryCounter

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/ZKRetryCounter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/ZKRetryCounter.java
@@ -58,6 +58,6 @@ public class ZKRetryCounter implements RetryCounter {
       return retryCounterPrefix + doc.getTopic() + "/" + doc.getRunId() + "/" + doc.getKey() + "___" + doc.getPartition() + "_"
           + doc.getOffset();
     }
-    return retryCounterPrefix + "/NON_KAFKA/" + document.getRunId() + "/" + document.getId();
+    return retryCounterPrefix + "NON_KAFKA/" + document.getRunId() + "/" + document.getId();
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
@@ -47,12 +47,13 @@ public class ZKRetryCounterTest {
 
       KafkaDocument kafkaDoc = spy(new KafkaDocument(Document.create("kafkaDoc"), "topic", 1, 2, "key"));
       when(kafkaDoc.getRunId()).thenReturn("runId");
-      JsonDocument jsonDoc = new JsonDocument("jsonDoc", "runId2");
+      Document doc = Document.create("jsonDoc", "runId2");
+      assertTrue(!(doc instanceof KafkaDocument));
 
       ZKRetryCounter retry3 = new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/config.conf"));
       ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
-      retry3.remove(jsonDoc);
+      retry3.remove(doc);
       retry3.remove(kafkaDoc);
 
       verify(backgroundVersionable, times(2)).forPath(captor.capture());
@@ -75,14 +76,15 @@ public class ZKRetryCounterTest {
 
       KafkaDocument kafkaDoc = spy(new KafkaDocument(Document.create("kafkaDoc"), "topic", 1, 2, "key"));
       when(kafkaDoc.getRunId()).thenReturn("runId");
-      JsonDocument jsonDoc = new JsonDocument("jsonDoc", "runId2");
+      Document doc = Document.create("jsonDoc", "runId2");
+      assertTrue(!(doc instanceof KafkaDocument));
 
       ZKRetryCounter retry3 = new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/config.conf"));
       ZKRetryCounter retry10 = new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/retry10.conf"));
 
       assertTrue(retry3.add(kafkaDoc));
-      assertTrue(retry3.add(jsonDoc));
-      assertFalse(retry10.add(jsonDoc));
+      assertTrue(retry3.add(doc));
+      assertFalse(retry10.add(doc));
 
       assertEquals(3, sharedCount.constructed().size());
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
@@ -1,0 +1,35 @@
+package com.kmwllc.lucille.core;
+
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.any;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+public class ZKRetryCounterTest {
+
+  @Test
+  public void testConstruct() {
+
+  }
+
+  @Test
+  public void testAdd() {
+    try (MockedConstruction<ExponentialBackoffRetry> policyConstruction = mockConstruction(ExponentialBackoffRetry.class);
+         MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class)) {
+      when(policyConstruction.equals(any())).thenReturn(true);
+      CuratorFramework curatorFramework = mock(CuratorFramework.class);
+      curatorStatic.when(() -> CuratorFrameworkFactory.newClient("foo", new ExponentialBackoffRetry(1000, 3))).thenReturn(curatorFramework);
+      verify(curatorFramework, times(1)).start();
+    }
+  }
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
@@ -62,16 +62,6 @@ public class ZKRetryCounterTest {
     }
   }
 
-  @Test 
-  public void testConstructor() {
-    try (MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class)) {
-      CuratorFramework curatorFramework = mock(CuratorFramework.class);
-      curatorStatic.when(() -> CuratorFrameworkFactory.newClient(eq("foo"), any())).thenReturn(curatorFramework);
-      new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/config.conf"));
-      verify(curatorFramework, times(1)).start();
-    }
-  }
-
   @Test
   public void testAdd() throws Exception {
     Map<SharedCount, List<Object>> arguments = new HashMap<>();
@@ -113,8 +103,8 @@ public class ZKRetryCounterTest {
       assertEquals(curatorFramework, arguments.get(constructedThird).get(0));
 
       assertEquals("/LucilleCounters/bar/topic/runId/key___1_2", arguments.get(constructedFirst).get(1));
-      assertEquals("/LucilleCounters/bar//NON_KAFKA/runId2/jsonDoc", arguments.get(constructedSecond).get(1));
-      assertEquals("/LucilleCounters/bar//NON_KAFKA/runId2/jsonDoc", arguments.get(constructedThird).get(1));
+      assertEquals("/LucilleCounters/bar/NON_KAFKA/runId2/jsonDoc", arguments.get(constructedSecond).get(1));
+      assertEquals("/LucilleCounters/bar/NON_KAFKA/runId2/jsonDoc", arguments.get(constructedThird).get(1));
 
       assertEquals(0, arguments.get(constructedFirst).get(2));
       assertEquals(0, arguments.get(constructedSecond).get(2));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
@@ -1,35 +1,145 @@
 package com.kmwllc.lucille.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.any;
-import org.apache.curator.RetryPolicy;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.framework.api.BackgroundVersionable;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.DeleteBuilderMain;
+import org.apache.curator.framework.recipes.shared.SharedCount;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
+import com.typesafe.config.ConfigFactory;
 
 public class ZKRetryCounterTest {
 
   @Test
-  public void testConstruct() {
+  public void testRemove() throws Exception {
+    String jsonCounterString = "/LucilleCounters/bar//NON_KAFKA/runId2/jsonDoc";
+    String kafkaCounterString = "/LucilleCounters/bar/topic/runId/key___1_2";
+    try (MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class)) {
+      BackgroundVersionable backgroundVersionable = mock(BackgroundVersionable.class);
+      doThrow(Exception.class).when(backgroundVersionable).forPath(kafkaCounterString);
+      DeleteBuilderMain deleteBuilderMain = mock(DeleteBuilderMain.class);
+      when(deleteBuilderMain.deletingChildrenIfNeeded()).thenReturn(backgroundVersionable);
+      DeleteBuilder deleteBuilder = mock(DeleteBuilder.class);
+      when(deleteBuilder.quietly()).thenReturn(deleteBuilderMain);
+      CuratorFramework curatorFramework = mock(CuratorFramework.class);
+      when(curatorFramework.delete()).thenReturn(deleteBuilder);
+      curatorStatic.when(() -> CuratorFrameworkFactory.newClient(eq("foo"), any())).thenReturn(curatorFramework);
 
+      KafkaDocument kafkaDoc = spy(new KafkaDocument(Document.create("kafkaDoc"), "topic", 1, 2, "key"));
+      when(kafkaDoc.getRunId()).thenReturn("runId");
+      JsonDocument jsonDoc = new JsonDocument("jsonDoc", "runId2");
+
+      ZKRetryCounter retry3 = new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/config.conf"));
+      ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+      retry3.remove(jsonDoc);
+      retry3.remove(kafkaDoc);
+
+      verify(backgroundVersionable, times(2)).forPath(captor.capture());
+
+      assertEquals(jsonCounterString, captor.getAllValues().get(0));
+      assertEquals(kafkaCounterString, captor.getAllValues().get(1));
+    }
+  }
+
+  @Test 
+  public void testConstructor() {
+    try (MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class)) {
+      CuratorFramework curatorFramework = mock(CuratorFramework.class);
+      curatorStatic.when(() -> CuratorFrameworkFactory.newClient(eq("foo"), any())).thenReturn(curatorFramework);
+      new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/config.conf"));
+      verify(curatorFramework, times(1)).start();
+    }
   }
 
   @Test
-  public void testAdd() {
-    try (MockedConstruction<ExponentialBackoffRetry> policyConstruction = mockConstruction(ExponentialBackoffRetry.class);
-         MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class)) {
-      when(policyConstruction.equals(any())).thenReturn(true);
+  public void testAdd() throws Exception {
+    Map<SharedCount, List<Object>> arguments = new HashMap<>();
+    try (MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class);
+         MockedConstruction<SharedCount> sharedCount = mockConstruction(SharedCount.class, (mock, context) -> {
+          arguments.put(mock, (List<Object>)context.arguments());
+          when(mock.getCount()).thenReturn(5);
+    })) {
       CuratorFramework curatorFramework = mock(CuratorFramework.class);
-      curatorStatic.when(() -> CuratorFrameworkFactory.newClient("foo", new ExponentialBackoffRetry(1000, 3))).thenReturn(curatorFramework);
-      verify(curatorFramework, times(1)).start();
+      curatorStatic.when(() -> CuratorFrameworkFactory.newClient(eq("foo"), any())).thenReturn(curatorFramework);
+
+      KafkaDocument kafkaDoc = spy(new KafkaDocument(Document.create("kafkaDoc"), "topic", 1, 2, "key"));
+      when(kafkaDoc.getRunId()).thenReturn("runId");
+      JsonDocument jsonDoc = new JsonDocument("jsonDoc", "runId2");
+
+      ZKRetryCounter retry3 = new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/config.conf"));
+      ZKRetryCounter retry10 = new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/retry10.conf"));
+
+      assertTrue(retry3.add(kafkaDoc));
+      assertTrue(retry3.add(jsonDoc));
+      assertFalse(retry10.add(jsonDoc));
+
+      assertEquals(3, sharedCount.constructed().size());
+
+      SharedCount constructedFirst = sharedCount.constructed().get(0);
+      SharedCount constructedSecond = sharedCount.constructed().get(1);
+      SharedCount constructedThird = sharedCount.constructed().get(2);
+
+      verify(constructedFirst, times(1)).start();
+      verify(constructedSecond, times(1)).start();
+      verify(constructedThird, times(1)).start();
+      
+      verify(constructedFirst, times(1)).setCount(6);
+      verify(constructedSecond, times(1)).setCount(6);
+      verify(constructedThird, times(1)).setCount(6);
+
+      assertEquals(curatorFramework, arguments.get(constructedFirst).get(0));
+      assertEquals(curatorFramework, arguments.get(constructedSecond).get(0));
+      assertEquals(curatorFramework, arguments.get(constructedThird).get(0));
+
+      assertEquals("/LucilleCounters/bar/topic/runId/key___1_2", arguments.get(constructedFirst).get(1));
+      assertEquals("/LucilleCounters/bar//NON_KAFKA/runId2/jsonDoc", arguments.get(constructedSecond).get(1));
+      assertEquals("/LucilleCounters/bar//NON_KAFKA/runId2/jsonDoc", arguments.get(constructedThird).get(1));
+
+      assertEquals(0, arguments.get(constructedFirst).get(2));
+      assertEquals(0, arguments.get(constructedSecond).get(2));
+      assertEquals(0, arguments.get(constructedThird).get(2));
+    }
+  }
+
+  @Test
+  public void testAddThrows() throws Exception {
+    Map<SharedCount, List<Object>> arguments = new HashMap<>();
+    try (MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class);
+         MockedConstruction<SharedCount> sharedCount = mockConstruction(SharedCount.class, (mock, context) -> {
+          arguments.put(mock, (List<Object>)context.arguments());
+          when(mock.getCount()).thenReturn(5);
+          doThrow(Exception.class).when(mock).start();
+    })) {
+      CuratorFramework curatorFramework = mock(CuratorFramework.class);
+      curatorStatic.when(() -> CuratorFrameworkFactory.newClient(eq("foo"), any())).thenReturn(curatorFramework);
+
+      KafkaDocument kafkaDoc = spy(new KafkaDocument(Document.create("kafkaDoc"), "topic", 1, 2, "key"));
+      when(kafkaDoc.getRunId()).thenReturn("runId");
+
+      ZKRetryCounter retry3 = new ZKRetryCounter(ConfigFactory.load("ZKRetryCounterTest/config.conf"));
+
+      assertFalse(retry3.add(kafkaDoc));
     }
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/ZKRetryCounterTest.java
@@ -32,7 +32,7 @@ public class ZKRetryCounterTest {
 
   @Test
   public void testRemove() throws Exception {
-    String jsonCounterString = "/LucilleCounters/bar//NON_KAFKA/runId2/jsonDoc";
+    String docCounterString = "/LucilleCounters/bar/NON_KAFKA/runId2/jsonDoc";
     String kafkaCounterString = "/LucilleCounters/bar/topic/runId/key___1_2";
     try (MockedStatic<CuratorFrameworkFactory> curatorStatic = mockStatic(CuratorFrameworkFactory.class)) {
       BackgroundVersionable backgroundVersionable = mock(BackgroundVersionable.class);
@@ -58,7 +58,7 @@ public class ZKRetryCounterTest {
 
       verify(backgroundVersionable, times(2)).forPath(captor.capture());
 
-      assertEquals(jsonCounterString, captor.getAllValues().get(0));
+      assertEquals(docCounterString, captor.getAllValues().get(0));
       assertEquals(kafkaCounterString, captor.getAllValues().get(1));
     }
   }

--- a/lucille-core/src/test/resources/ZKRetryCounterTest/config.conf
+++ b/lucille-core/src/test/resources/ZKRetryCounterTest/config.conf
@@ -1,0 +1,8 @@
+zookeeper {
+  connectString: foo
+
+}
+
+kafka {
+  consumerGroupId: bar
+}

--- a/lucille-core/src/test/resources/ZKRetryCounterTest/retry10.conf
+++ b/lucille-core/src/test/resources/ZKRetryCounterTest/retry10.conf
@@ -1,0 +1,12 @@
+zookeeper {
+  connectString: foo
+
+}
+
+kafka {
+  consumerGroupId: bar,
+}
+
+worker {
+  maxRetries: 10
+}


### PR DESCRIPTION
found one "bug" which is not really a functional bug but seems to be unintended behavior.

for non-kafka documents, the "counterPath" which is generated has two backslashes in it rather than one (check line 116 of the tests). It seems as though this is supposed to be a path-like representation in which case the double backslash would not typically be intended.