### PR TITLE
LC-406 - Upgrade vulnerable Lucille dependencies.

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.1-jre</version>
+      <version>33.1.0-jre</version>
     </dependency>
     <!-- language detection -->
     <dependency>
@@ -275,7 +275,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.2.220</version>
+      <version>2.2.224</version>
       <scope>test</scope>
     </dependency>
 

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
+      <version>32.0.1-jre</version>
     </dependency>
     <!-- language detection -->
     <dependency>
@@ -178,7 +178,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.6.0</version>
+      <version>2.9.0</version>
     </dependency>
 
     <!-- TODO remove if not using fastcsv -->
@@ -275,7 +275,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.200</version>
+      <version>2.2.220</version>
       <scope>test</scope>
     </dependency>
 

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.1.0</version>
+      <version>3.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -267,7 +267,7 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>3.1.0</version>
+      <version>3.6.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/SolrUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/SolrUtilsTest.java
@@ -31,6 +31,7 @@ public class SolrUtilsTest {
     Http2SolrClient client = SolrUtils.getHttpClient(config);
     // would like to inspect the solr client to confirm credentials are configured, but can’t do that so just checking it’s non-null
     assertNotNull(client);
+    client.close();
   }
 
   @Test

--- a/lucille-core/src/test/resources/db-test-start.sql
+++ b/lucille-core/src/test/resources/db-test-start.sql
@@ -34,6 +34,6 @@ CREATE TABLE mixed(id VARCHAR, int_field INT, bool_field BIT);
 INSERT INTO mixed VALUES ('1', 3, 1);
 INSERT INTO mixed VALUES ('2', 4, 0);
 
-create table table_with_id_column(id int, value int, other_id varchar(10));
+create table table_with_id_column(id int, `value` int, other_id varchar(10));
 insert into table_with_id_column values (1, 1, 'id1');
 insert into table_with_id_column values (2, 2, 'id2');

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -44,7 +44,7 @@
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <jackson.version>2.13.5</jackson.version>
     <!-- todo if updated to version 9 will need to add solr-solrj-zookeeper dependency -->
-    <lucene.version>9.7.0</lucene.version>
+    <lucene.version>9.8.0</lucene.version>
     <solr.version>9.4.1</solr.version>
     <opensearch-rest-client.version>1.2.0</opensearch-rest-client.version>
     <opensearch.version>0.1.0</opensearch.version>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -42,10 +42,10 @@
     <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <jackson.version>2.12.2</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
     <!-- todo if updated to version 9 will need to add solr-solrj-zookeeper dependency -->
     <lucene.version>9.7.0</lucene.version>
-    <solr.version>9.3.0</solr.version>
+    <solr.version>9.4.1</solr.version>
     <opensearch-rest-client.version>1.2.0</opensearch-rest-client.version>
     <opensearch.version>0.1.0</opensearch.version>
     <opensearch-java.version>2.6.0</opensearch-java.version>
@@ -60,8 +60,8 @@
     <slf4j.version>2.0.7</slf4j.version>
     <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
     <apache-commons-text.version>1.10.0</apache-commons-text.version>
-    <protobuf.version>3.19.2</protobuf.version>
-    <netty.version>4.1.89.Final</netty.version>
+    <protobuf.version>3.19.6</protobuf.version>
+    <netty.version>4.1.108.Final</netty.version>
     <grpc.version>1.53.0</grpc.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -42,10 +42,10 @@
     <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <jackson.version>2.13.5</jackson.version>
+    <jackson.version>2.17.0</jackson.version>
     <!-- todo if updated to version 9 will need to add solr-solrj-zookeeper dependency -->
-    <lucene.version>9.8.0</lucene.version>
-    <solr.version>9.4.1</solr.version>
+    <lucene.version>9.9.2</lucene.version>
+    <solr.version>9.5.0</solr.version>
     <opensearch-rest-client.version>1.2.0</opensearch-rest-client.version>
     <opensearch.version>0.1.0</opensearch.version>
     <opensearch-java.version>2.6.0</opensearch-java.version>
@@ -60,7 +60,7 @@
     <slf4j.version>2.0.7</slf4j.version>
     <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
     <apache-commons-text.version>1.10.0</apache-commons-text.version>
-    <protobuf.version>3.19.6</protobuf.version>
+    <protobuf.version>3.25.3</protobuf.version>
     <netty.version>4.1.108.Final</netty.version>
     <grpc.version>1.53.0</grpc.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lucille-plugins/lucille-ocr/pom.xml
+++ b/lucille-plugins/lucille-ocr/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
-        <version>2.0.22</version>
+        <version>2.0.24</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/lucille-plugins/lucille-ocr/pom.xml
+++ b/lucille-plugins/lucille-ocr/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
-        <version>2.0.24</version>
+        <version>2.0.31</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
After the 0.2.0 release, we found some vulnerable dependencies in Lucille. Here we are upgrading the following:
- org.apache.kafka/kafka-clients
- com.google.guava/guava
- com.jayway.jsonpath/json-path
- net.mguenther.kafka/kafka-junit
- com.h2database/h2 (updated test for new version)
- com.fasterxml.jackson.core/jackson-annotations, jackson-databind, jackson-core
- com.fasterxml.jackson.datatype/jackson-datatype-jsr310
- org.apache.solr/solr-test-framework, solr-solrj, solr-solrj-zookeeper, solr-solrj-streaming, solr-core
- com.google.protobuf/protobuf-bom
- io.netty/netty-bom
- org.apache.pdfbox/pdfbox

The vulnerable dependencies are listed in the ticket: https://kmwllc.atlassian.net/browse/LC-406