### PR TITLE
LC-462: stage conditions paradigm asserts that provided operator is valid

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Condition.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Condition.java
@@ -11,15 +11,27 @@ public class Condition implements Predicate<Document> {
 
   private final List<String> fields;
   private final Set<String> values;
-  private final String operator;
+  private final Operator operator;
+
+  private enum Operator {
+    MUST, MUST_NOT;
+
+    public static Operator getOperator(String op) {
+      switch(op) {
+        case "must": return Operator.MUST;
+        case "must_not": return Operator.MUST_NOT;
+        default: throw new IllegalArgumentException(op + " is not a legal value for operator");
+      }
+    }
+  }
 
   public Condition(Config config) {
     this(config.getStringList("fields"),
         new HashSet<>(config.getStringList("values")),
-        config.hasPath("operator") ? config.getString("operator") : "must");
+        config.hasPath("operator") ? Operator.getOperator(config.getString("operator")) : Operator.MUST);
   }
 
-  public Condition(List<String> fields, Set<String> values, String operator) {
+  public Condition(List<String> fields, Set<String> values, Operator operator) {
     this.fields = fields;
     this.values = values;
     this.operator = operator;
@@ -31,7 +43,7 @@ public class Condition implements Predicate<Document> {
 
   @Override
   public boolean test(Document doc) {
-    boolean resultWhenValueFound = operator.equalsIgnoreCase("must");
+    boolean resultWhenValueFound = operator.equals(Operator.MUST);
 
     if (fields.isEmpty()) {
       return true;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Condition.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Condition.java
@@ -1,9 +1,11 @@
 package com.kmwllc.lucille.core;
 
 import com.typesafe.config.Config;
-
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -14,21 +16,26 @@ public class Condition implements Predicate<Document> {
   private final Operator operator;
 
   private enum Operator {
-    MUST, MUST_NOT;
+    MUST("must"), MUST_NOT("must_not");
 
-    public static Operator getOperator(String op) {
-      switch(op) {
-        case "must": return Operator.MUST;
-        case "must_not": return Operator.MUST_NOT;
-        default: throw new IllegalArgumentException(op + " is not a legal value for operator");
+    private final String val;
+
+    Operator(String val) {
+      this.val = val;
+    }
+
+    public static Operator get(String operator) {
+      Optional<Operator> temp = Arrays.stream(Operator.values()).filter(other -> other.val.equals(operator)).findFirst();
+      if (temp.isPresent()) {
+        return temp.get();
       }
+      throw new IllegalArgumentException("operator is invalid. It must take the value of `must` or `must_not`");
     }
   }
 
   public Condition(Config config) {
-    this(config.getStringList("fields"),
-        new HashSet<>(config.getStringList("values")),
-        config.hasPath("operator") ? Operator.getOperator(config.getString("operator")) : Operator.MUST);
+    this(config.getStringList("fields"), new HashSet<>(config.getStringList("values")),
+        config.hasPath("operator") ? Operator.get(config.getString("operator")) : Operator.MUST);
   }
 
   public Condition(List<String> fields, Set<String> values, Operator operator) {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ConfigValidationTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ConfigValidationTest.java
@@ -20,7 +20,6 @@ public class ConfigValidationTest {
 
   @Test
   public void testConditions() {
-
     testException(NoopStage.class, "conditions-field-missing.conf");
     testException(NoopStage.class, "conditions-field-renamed.conf");
 
@@ -29,6 +28,8 @@ public class ConfigValidationTest {
 
     testException(NoopStage.class, "conditions-optional-unknown.conf");
     testException(NoopStage.class, "conditions-optional-renamed.conf");
+
+    testException(NoopStage.class, "conditions-optional-wrong.conf");
   }
 
   @Test

--- a/lucille-core/src/test/resources/ConfigValidationTest/conditions-optional-wrong.conf
+++ b/lucille-core/src/test/resources/ConfigValidationTest/conditions-optional-wrong.conf
@@ -1,0 +1,7 @@
+conditions = [
+  {
+    fields = ["user_id", "state", "country"]
+    values = ["MA", "1234", "US", "Russia", "4567"]
+    operator = "must not"
+  }
+]

--- a/lucille-core/src/test/resources/StageTest/multipleConditions.conf
+++ b/lucille-core/src/test/resources/StageTest/multipleConditions.conf
@@ -7,6 +7,6 @@ conditions = [
   {
     fields = ["state"],
     values = ["MA", "CA"]
-    operator = "must not"
+    operator = "must_not"
   }
 ]


### PR DESCRIPTION
The Conditions constructor now requires the provided operator to be valid and throws a runtime exception otherwise. Since the condition object is created at validation time (before a run) this validates the conditions clauses "statically"