### PR TITLE
LC-314: add Document support for JSON getters and setters

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
@@ -70,6 +70,7 @@ public interface Document {
 
   byte[] getBytes(String name);
 
+  JsonNode getJson(String name);
 
   /* --- LIST GETTERS --- */
 
@@ -95,6 +96,7 @@ public interface Document {
 
   List<byte[]> getBytesList(String name);
 
+  List<JsonNode> getJsonList(String name);
 
   /* --- SINGLE-VALUE SETTERS --- */
 
@@ -147,6 +149,8 @@ public interface Document {
       setField(name, (Instant) value);
     } else if (value instanceof byte[]) {
       setField(name, (byte[]) value);
+    } else if (value instanceof JsonNode) {
+      setField(name, (JsonNode) value);
     } else {
       throw new IllegalArgumentException(String.format("Type %s is not supported", value.getClass().getName()));
     }
@@ -175,6 +179,8 @@ public interface Document {
 
   void addToField(String name, byte[] value);
 
+  void addToField(String name, JsonNode value);
+
   /**
    * Adds the given value to the designated field, converting the field to multivalued (i.e. a list)
    * if it was not multivalued already.
@@ -197,6 +203,8 @@ public interface Document {
       addToField(name, (Instant) value);
     } else if (value instanceof byte[]) {
       addToField(name, (byte[]) value);
+    } else if (value instanceof JsonNode) {
+      addToField(name, (JsonNode) value);
     } else {
       throw new IllegalArgumentException(String.format("Type %s is not supported", value.getClass().getName()));
     }
@@ -228,6 +236,8 @@ public interface Document {
 
   void setOrAdd(String name, byte[] value);
 
+  void setOrAdd(String name, JsonNode value);
+
   /**
    * @throws IllegalArgumentException if value is not of a supported type
    **/
@@ -246,6 +256,8 @@ public interface Document {
       setOrAdd(name, (Instant) value);
     } else if (value instanceof byte[]) {
       setOrAdd(name, (byte[]) value);
+    } else if (value instanceof JsonNode) {
+      setOrAdd(name, (JsonNode) value);
     } else {
       throw new IllegalArgumentException(String.format("Type %s is not supported", value.getClass().getName()));
     }
@@ -310,6 +322,10 @@ public interface Document {
 
   default void update(String name, UpdateMode mode, byte[]... values) {
     update(name, mode, v -> setField(name, (byte[]) v), v -> setOrAdd(name, (byte[]) v), values);
+  }
+
+  default void update(String name, UpdateMode mode, JsonNode... values) {
+    update(name, mode, v -> setField(name, (JsonNode) v), v -> setOrAdd(name, (JsonNode) v), values);
   }
 
   /**

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
@@ -368,6 +368,11 @@ public class HashMapDocument implements Document, Serializable {
   }
 
   @Override
+  public JsonNode getJson(String name) {
+    return getValue(name, value -> (JsonNode) value);
+  }
+
+  @Override
   public List<Instant> getInstantList(String name) {
     return getValues(name, value -> (Instant) value);
   }
@@ -375,6 +380,11 @@ public class HashMapDocument implements Document, Serializable {
   @Override
   public List<byte[]> getBytesList(String name) {
     return getValues(name, value -> (byte[]) value);
+  }
+
+  @Override
+  public List<JsonNode> getJsonList(String name) {
+    return getValues(name, value -> (JsonNode) value);
   }
 
   @Override
@@ -456,6 +466,11 @@ public class HashMapDocument implements Document, Serializable {
     addToFieldGeneric(name, value);
   }
 
+  @Override
+  public void addToField(String name, JsonNode value) {
+    addToFieldGeneric(name, value);
+  }
+
   private <T> void setOrAddGeneric(String name, T value) {
     validateFieldNames(name);
     data.setOrAdd(name, value);
@@ -498,6 +513,11 @@ public class HashMapDocument implements Document, Serializable {
 
   @Override
   public void setOrAdd(String name, byte[] value) {
+    setOrAddGeneric(name, value);
+  }
+
+  @Override
+  public void setOrAdd(String name, JsonNode value) {
     setOrAddGeneric(name, value);
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
@@ -1146,31 +1146,17 @@ public abstract class DocumentTest {
     JsonNode node = mapper.readTree("{\"a\":1, \"b\":2}");
     Document d = createDocument("id1");
     d.setField("myField", node);
+    assertEquals(node, d.getJson("myField"));
+    //assertFalse(d.isMultiValued("myField"));
 
     assertEquals(d, createDocumentFromJson(d.toString()));
-    assertEquals(d.toString(), createDocumentFromJson(d.toString()).toString());
+    Document reconstructed = createDocumentFromJson(d.toString());
+    assertEquals(d.toString(), reconstructed.toString());
+    assertEquals(node, reconstructed.getJson("myField"));
+
+    assertEquals(node, reconstructed.getJson("myField"));
 
     JsonNode node2 = mapper.readTree("{\"a\":1, \"b\":3}");
-    Document d2 = createDocument("id1");
-    d2.setField("myField", node2);
-    assertNotEquals(d, d2);
-
-    d2.setField("myField", node.deepCopy());
-    assertEquals(d, d2);
-  }
-
-  @Test
-  public void testJsonMultivaluedField() throws Exception {
-    ObjectMapper mapper = new ObjectMapper();
-
-    JsonNode node = mapper.readTree("{\"a\": [{\"aa\":1}, {\"aa\": 2}] }");
-    Document d = createDocument("id1");
-    d.setField("myField", node);
-
-    assertEquals(d, createDocumentFromJson(d.toString()));
-    assertEquals(d.toString(), createDocumentFromJson(d.toString()).toString());
-
-    JsonNode node2 = mapper.readTree("{\"a\": [{\"aa\":1}, {\"aa\": 3}] }");
     Document d2 = createDocument("id1");
     d2.setField("myField", node2);
     assertNotEquals(d, d2);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
@@ -176,10 +176,10 @@ public class JsonDocumentTest extends DocumentTest.NodeDocumentTest {
     d.addToField("jsonArray1", jsonObject2);
     assertEquals(jsonArray1WithObject2Added, d.getJson("jsonArray1"));
 
-    JsonNode arrayOfOjbect1AndObject2 = mapper.readTree("[{\"a\":1, \"b\": 2}, {\"c\":3, \"d\": 4}]");
+    JsonNode arrayOfObject1AndObject2 = mapper.readTree("[{\"a\":1, \"b\": 2}, {\"c\":3, \"d\": 4}]");
     d.setField("jsonObject1", jsonObject1);
     d.addToField("jsonObject1", jsonObject2);
-    assertEquals(arrayOfOjbect1AndObject2, d.getJson("jsonObject1"));
+    assertEquals(arrayOfObject1AndObject2, d.getJson("jsonObject1"));
     assertEquals(List.of(jsonObject1, jsonObject2), d.getJsonList("jsonObject1"));
 
     assertEquals(d, createDocumentFromJson(d.toString()));


### PR DESCRIPTION
The Document interface has a single-value json setter, but not corresponding getters or updaters.
There's `void setField(String name, JsonNode value)` but no corresponding `JsonNode getJson(String name)`
This PR fleshes out Document's support for JSON values by adding the standard getters and updaters.

The complication with Json values is that JsonDocument internally stores multivalued fields as JsonArrays. For example, if you add 1, 2, 3, 4 to a multivalued int field, JsonDocument will represent this as a JsonArray containing those ints. But what should happen if someone _adds_ a JsonArray containing ints 1, 2, 3,4 via setField(String name, JsonNode value)? Should JsonDocument treat this as a multivalued field containing 4 ints, or should it treat this as a single-valued field containing one JsonArray? 

The key decisions in this PR are that 
   1) getJson(name) will always return the actual json that JsonDocument keeps internally to represent that field value or values, without doing any transformation to figure out whether there's one value, or multiple values -- getJson just gives you back whatever's there in the JsonDocument's internal storage
  2) if JsonDocument document is storing a JsonArray in a field, it will always report true for isMultiValued, no matter whether that JsonArray got added directly (via a json setter) or indirectly (by calling addToField several times to store multiple values in the field)

One thing to note is that the test coverage in this PR has been added in JsonDocumentTest, not in the generic DocumentTest that runs with both a JsonDocument and a HashMapDocument. The semantics of json-handling in HashMapDocument are different as of this PR, and not yet tested. HashMapDocument isn't currently used, and we have to decide what to do with it...

