### PR TITLE
LC-479 ParseJson stage should not delete the src field

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseJson.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseJson.java
@@ -62,10 +62,6 @@ public class ParseJson extends Stage {
     this.jsonParseCtx = JsonPath.using(this.jsonPathConf);
   }
 
-  /**
-   * @param doc
-   * @return
-   */
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     DocumentContext ctx;
@@ -80,12 +76,10 @@ public class ParseJson extends Stage {
       ctx = this.jsonParseCtx.parse(doc.getString(this.src));
     }
     for (Entry<String, Object> entry : this.jsonFieldPaths.entrySet()) {
-      //JsonNode val = srcNode.at((String) entry.getValue());
       JsonNode val = ctx.read((String) entry.getValue(), JsonNode.class);
-
       doc.setField(entry.getKey(), val);
     }
-    doc.removeField(this.src);
+
     return null;
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ParseJsonTest {
 
@@ -29,7 +30,10 @@ public class ParseJsonTest {
     try (InputStream in = ParseJsonTest.class.getClassLoader().getResourceAsStream("ParseJson/test.json")) {
       doc.setField("json", IOUtils.toString(in, StandardCharsets.UTF_8));
       stage.processDocument(doc);
-      //Get the map so we can assert on type
+
+      assertTrue(doc.has("json")); // ParseJson should not delete the designated src field
+
+      // Get the map so we can assert on type
       Map<String, Object> docMap = doc.asMap();
 
       assertThat(doc.getString("aNumber"), equalTo("1"));
@@ -41,7 +45,7 @@ public class ParseJsonTest {
       assertThat(doc.getString("menuValue"), equalTo("File"));
       assertThat(docMap.get("menuValue"), equalTo("File"));
 
-      //defer to ParseDate stage
+      // defer to ParseDate stage
       assertThat(doc.getString("aDate"), equalTo("2021-12-10"));
       assertThat(doc.getString("aTime"), equalTo("2021-12-10T14:05:26Z"));
       assertThat(docMap.get("aDate"), equalTo("2021-12-10"));
@@ -111,8 +115,6 @@ public class ParseJsonTest {
       // "/items/6" and "/items".get(6) should be equivalent
       assertThat(item7, equalTo(docMap.get("item7")));
     }
-
-
   }
 
   @Test
@@ -122,7 +124,10 @@ public class ParseJsonTest {
     try (InputStream in = ParseJsonTest.class.getClassLoader().getResourceAsStream("ParseJson/test.json")) {
       doc.setField("file_content", Base64.getEncoder().encodeToString(IOUtils.toByteArray(in)));
       stage.processDocument(doc);
-      //Get the map so we can assert on type
+
+      assertTrue(doc.has("file_content")); // ParseJson should not delete the designated src field
+
+      // Get the map so we can assert on type
       Map<String, Object> docMap = doc.asMap();
 
       assertThat(doc.getString("aNumber"), equalTo("1"));


### PR DESCRIPTION
ParseJson currently deletes the src field after parsing the json contained in it. If a user wants to remove src, they can do it with a DeleteFields stage. This PR updates ParseJson so it leaves the src field in place. This leaves the choice up to the user re: whether to delete src later via DeleteFields. 