### PR TITLE
LC-482: dockerized distributed test attached to maven verify

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaUtils.java
@@ -175,9 +175,12 @@ public class KafkaUtils {
       CreateTopicsResult result = kafkaAdminClient.createTopics(List.of(eventTopic), new CreateTopicsOptions());
       KafkaFuture<Void> future = result.all();
       future.get();
-    } catch (Exception e) {
-      log.warn("Event topic {} already exists.", eventTopicName);
-      return false;
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof TopicExistsException) {
+        log.warn("Event topic {} already exists.", eventTopicName);
+        return false;
+      }
+      throw e;
     }
 
     return true;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaUtils.java
@@ -175,7 +175,7 @@ public class KafkaUtils {
       CreateTopicsResult result = kafkaAdminClient.createTopics(List.of(eventTopic), new CreateTopicsOptions());
       KafkaFuture<Void> future = result.all();
       future.get();
-    } catch (TopicExistsException e) {
+    } catch (Exception e) {
       log.warn("Event topic {} already exists.", eventTopicName);
       return false;
     }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/message/KafkaUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/message/KafkaUtilsTest.java
@@ -2,6 +2,7 @@ package com.kmwllc.lucille.message;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.concurrent.ExecutionException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
@@ -52,8 +53,9 @@ public class KafkaUtilsTest {
   public void testCreateEventTopicWhenExists() throws Exception {
     try (MockedStatic<Admin> admin = Mockito.mockStatic(Admin.class)) {
       KafkaFuture future = Mockito.mock(KafkaFuture.class);
-      TopicExistsException exception = new TopicExistsException("test");
-      Mockito.doThrow(exception).when(future).get();
+      TopicExistsException topicExistsException = new TopicExistsException("test");
+      ExecutionException executionException = new ExecutionException(topicExistsException);
+      Mockito.doThrow(executionException).when(future).get();
 
       CreateTopicsResult result = Mockito.mock(CreateTopicsResult.class);
       Mockito.doReturn(future).when(result).all();
@@ -63,7 +65,7 @@ public class KafkaUtilsTest {
 
       admin.when(() -> Admin.create((Properties)Mockito.any())).thenReturn(adminClient);
 
-;     Config directConfig = ConfigFactory.load("KafkaUtilsTest/producer-conf/direct.conf");
+      Config directConfig = ConfigFactory.load("KafkaUtilsTest/producer-conf/direct.conf");
       assertFalse(KafkaUtils.createEventTopic(directConfig, "pipeline1", "run1"));
     }
   }

--- a/lucille-examples/lucille-distributed-example/conf/main.conf
+++ b/lucille-examples/lucille-distributed-example/conf/main.conf
@@ -28,19 +28,6 @@ pipelines: [
         }
       }
     ]
-  },
-  {
-    name: "simple_pipeline2"
-    stages: [
-      {
-        class: "com.kmwllc.lucille.stage.RenameFields"
-        fieldMapping {
-          "name" : "my_name_2"
-          "price" : "my_price_2"
-          "country" : "my_country_2"
-        }
-      }
-    ]
   }
 ]
 

--- a/lucille-examples/lucille-distributed-example/pom.xml
+++ b/lucille-examples/lucille-distributed-example/pom.xml
@@ -16,30 +16,69 @@
   <packaging>jar</packaging>
   <name>Lucille Examples: Distributed Example</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.kmwllc</groupId>
-        <artifactId>lucille-bom</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
   <dependencies>
     <dependency>
-      <groupId>com.kmwllc</groupId>
-      <artifactId>lucille-core</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+      <groupId>com.kmwllc</groupId>
+      <artifactId>lucille-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>nightly</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>3.2.5</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <executable>docker</executable>
+              <arguments>
+                <argument>compose</argument>
+                <argument>up</argument>
+                <argument>--abort-on-container-exit</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>

--- a/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/DistributedIT.java
+++ b/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/DistributedIT.java
@@ -2,6 +2,7 @@ package com.kmwllc.lucille.distributed;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -12,57 +13,49 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DistributedIT {
 
-  @Test 
+  @Test
   public void distributedIT() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
     String fileName = "runner/output/dest.json";
     int numDocs = 6;
-    String output = Files.readString(Paths.get(fileName));
-    JsonNode json = mapper.readTree(output);
+    try {
+      String output = Files.readString(Paths.get(fileName));
+      JsonNode json = mapper.readTree(output);
 
-    assertEquals(numDocs, json.get("response").get("numFound").asInt());
+      assertEquals(numDocs, json.get("response").get("numFound").asInt());
 
-    List<JsonNode> docs = new ArrayList<>();
-    for (int i = 0; i < numDocs; i++) {
-      docs.add(json.get("response").get(i));
+      List<JsonNode> docs = new ArrayList<>();
+      for (int i = 0; i < numDocs; i++) {
+        docs.add(json.get("response").get("docs").get(i));
+      }
+
+      assertTrue(docs.stream()
+          .anyMatch(doc -> doc.get("id").asText().equals("source.csv-1")
+              && doc.get("source").get(0).asText().equals("conf/source.csv")
+              && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Italy")
+              && doc.get("my_price").get(0).asInt() == 30 && doc.get("my_name").get(0).asText().equals("Carbonara")));
+      assertTrue(docs.stream()
+          .anyMatch(doc -> doc.get("id").asText().equals("source.csv-2")
+              && doc.get("source").get(0).asText().equals("conf/source.csv")
+              && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Italy")
+              && doc.get("my_price").get(0).asInt() == 10 && doc.get("my_name").get(0).asText().equals("Pizza")));
+      assertTrue(docs.stream()
+          .anyMatch(doc -> doc.get("id").asText().equals("source.csv-3")
+              && doc.get("source").get(0).asText().equals("conf/source.csv")
+              && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Korea")
+              && doc.get("my_price").get(0).asInt() == 12 && doc.get("my_name").get(0).asText().equals("Tofu Soup")));
+
+      assertTrue(
+          docs.stream().anyMatch(doc -> doc.get("id").asText().equals("3") && doc.get("my_country").get(0).asText().equals("USA")
+              && doc.get("my_price").get(0).asInt() == 30 && doc.get("my_name").get(0).asText().equals("Burger")));
+      assertTrue(
+          docs.stream().anyMatch(doc -> doc.get("id").asText().equals("4") && doc.get("my_country").get(0).asText().equals("USA")
+              && doc.get("my_price").get(0).asInt() == 10 && doc.get("my_name").get(0).asText().equals("Salad")));
+      assertTrue(
+          docs.stream().anyMatch(doc -> doc.get("id").asText().equals("5") && doc.get("my_country").get(0).asText().equals("France")
+              && doc.get("my_price").get(0).asInt() == 12 && doc.get("my_name").get(0).asText().equals("Wine")));
+    } finally {
+      new File(fileName).delete();
     }
-
-    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.csv-1") && 
-      doc.get("source").get(0).asText().equals("conf/source.csv") && 
-      doc.get("filename").get(0).asText().equals("source.csv") &&
-      doc.get("my_country").get(0).asText().equals("Italy") && 
-      doc.get("my_price").get(0).asInt() == 30 && 
-      doc.get("my_name").get(0).asText().equals("Carbonara")));
-    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.csv-2") && 
-      doc.get("source").get(0).asText().equals("conf/source.csv") && 
-      doc.get("filename").get(0).asText().equals("source.csv") &&
-      doc.get("my_country").get(0).asText().equals("Italy") && 
-      doc.get("my_price").get(0).asInt() == 10 && 
-      doc.get("my_name").get(0).asText().equals("Pizza")));
-    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.csv-3") && 
-      doc.get("source").get(0).asText().equals("conf/source.csv") && 
-      doc.get("filename").get(0).asText().equals("source.csv") &&
-      doc.get("my_country").get(0).asText().equals("Korea") && 
-      doc.get("my_price").get(0).asInt() == 12 && 
-      doc.get("my_name").get(0).asText().equals("Tofu Soup")));
-
-    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.ndjson-3") && 
-      doc.get("source").get(0).asText().equals("conf/source.csv") && 
-      doc.get("filename").get(0).asText().equals("source.csv") &&
-      doc.get("my_country").get(0).asText().equals("USA") && 
-      doc.get("my_price").get(0).asInt() == 30 && 
-      doc.get("my_name").get(0).asText().equals("Burger")));
-    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.ndjson-4") && 
-      doc.get("source").get(0).asText().equals("conf/source.csv") && 
-      doc.get("filename").get(0).asText().equals("source.csv") &&
-      doc.get("my_country").get(0).asText().equals("USA") && 
-      doc.get("my_price").get(0).asInt() == 10 && 
-      doc.get("my_name").get(0).asText().equals("Salad")));
-    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.ndjson-5") && 
-      doc.get("source").get(0).asText().equals("conf/source.csv") && 
-      doc.get("filename").get(0).asText().equals("source.csv") &&
-      doc.get("my_country").get(0).asText().equals("France") && 
-      doc.get("my_price").get(0).asInt() == 12 && 
-      doc.get("my_name").get(0).asText().equals("Wine")));
   }
 }

--- a/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/DistributedIT.java
+++ b/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/DistributedIT.java
@@ -1,0 +1,68 @@
+package com.kmwllc.lucille.distributed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DistributedIT {
+
+  @Test 
+  public void distributedIT() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String fileName = "runner/output/dest.json";
+    int numDocs = 6;
+    String output = Files.readString(Paths.get(fileName));
+    JsonNode json = mapper.readTree(output);
+
+    assertEquals(numDocs, json.get("response").get("numFound").asInt());
+
+    List<JsonNode> docs = new ArrayList<>();
+    for (int i = 0; i < numDocs; i++) {
+      docs.add(json.get("response").get(i));
+    }
+
+    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.csv-1") && 
+      doc.get("source").get(0).asText().equals("conf/source.csv") && 
+      doc.get("filename").get(0).asText().equals("source.csv") &&
+      doc.get("my_country").get(0).asText().equals("Italy") && 
+      doc.get("my_price").get(0).asInt() == 30 && 
+      doc.get("my_name").get(0).asText().equals("Carbonara")));
+    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.csv-2") && 
+      doc.get("source").get(0).asText().equals("conf/source.csv") && 
+      doc.get("filename").get(0).asText().equals("source.csv") &&
+      doc.get("my_country").get(0).asText().equals("Italy") && 
+      doc.get("my_price").get(0).asInt() == 10 && 
+      doc.get("my_name").get(0).asText().equals("Pizza")));
+    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.csv-3") && 
+      doc.get("source").get(0).asText().equals("conf/source.csv") && 
+      doc.get("filename").get(0).asText().equals("source.csv") &&
+      doc.get("my_country").get(0).asText().equals("Korea") && 
+      doc.get("my_price").get(0).asInt() == 12 && 
+      doc.get("my_name").get(0).asText().equals("Tofu Soup")));
+
+    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.ndjson-3") && 
+      doc.get("source").get(0).asText().equals("conf/source.csv") && 
+      doc.get("filename").get(0).asText().equals("source.csv") &&
+      doc.get("my_country").get(0).asText().equals("USA") && 
+      doc.get("my_price").get(0).asInt() == 30 && 
+      doc.get("my_name").get(0).asText().equals("Burger")));
+    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.ndjson-4") && 
+      doc.get("source").get(0).asText().equals("conf/source.csv") && 
+      doc.get("filename").get(0).asText().equals("source.csv") &&
+      doc.get("my_country").get(0).asText().equals("USA") && 
+      doc.get("my_price").get(0).asInt() == 10 && 
+      doc.get("my_name").get(0).asText().equals("Salad")));
+    assertTrue(docs.stream().anyMatch(doc -> doc.get("id").asText().equals("source.ndjson-5") && 
+      doc.get("source").get(0).asText().equals("conf/source.csv") && 
+      doc.get("filename").get(0).asText().equals("source.csv") &&
+      doc.get("my_country").get(0).asText().equals("France") && 
+      doc.get("my_price").get(0).asInt() == 12 && 
+      doc.get("my_name").get(0).asText().equals("Wine")));
+  }
+}


### PR DESCRIPTION
uses profiles so that the test can be conditionally initiated from the lucille-distributed-example. Running 
```mvn verify -Pnightly``` starts the test. NOTE: must have docker desktop running and make sure to delete all containers volumes in subsequent runs.

KafkfaUtils has to be modified to avoid a TopicAlreadyExistsException. This fixes the issue but may not be the fix we want so this should be reviewed in more detail