### PR TITLE
LC-422: ElasticsearchUtilsTest

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ElasticsearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ElasticsearchUtils.java
@@ -11,10 +11,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.client.RestHighLevelClient;
 
 import java.net.URI;
 
@@ -22,58 +19,6 @@ import java.net.URI;
  * Utility methods for communicating with Elasticsearch.
  */
 public class ElasticsearchUtils {
-
-  /**
-   * Generate a RestHighLevelClient from the given config file. Supports Http ElasticsearchClients.
-   *
-   * @param config The configuration file to generate a client from
-   * @return the RestHighLevelClient client
-   */
-  public static RestHighLevelClient getElasticsearchRestClient(Config config) {
-
-    // get host uri
-    URI hostUri = URI.create(getElasticsearchUrl(config));
-
-    //Establish credentials to use basic authentication.
-    final CredentialsProvider provider = new BasicCredentialsProvider();
-
-    // get user info from URI if present and setup BasicAuth credentials if needed
-    String userInfo = hostUri.getUserInfo();
-    if (userInfo != null) {
-      int pos = userInfo.indexOf(":");
-      String username = userInfo.substring(0, pos);
-      String password = userInfo.substring(pos + 1);
-      provider.setCredentials(AuthScope.ANY,
-          new UsernamePasswordCredentials(username, password));
-    }
-
-    // needed to allow for local testing of HTTPS
-    SSLFactory.Builder sslFactoryBuilder = SSLFactory.builder();
-    boolean allowInvalidCert = getAllowInvalidCert(config);
-    if (allowInvalidCert) {
-      sslFactoryBuilder
-          .withTrustingAllCertificatesWithoutValidation()
-          .withHostnameVerifier((host, session) -> true);
-    } else {
-      sslFactoryBuilder.withDefaultTrustMaterial();
-    }
-
-    SSLFactory sslFactory = sslFactoryBuilder.build();
-
-    RestClientBuilder builder = RestClient.builder(new HttpHost(hostUri.getHost(), hostUri.getPort(),
-            hostUri.getScheme()))
-        .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
-          @Override
-          public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
-            return httpClientBuilder.setDefaultCredentialsProvider(provider).setSSLContext(sslFactory.getSslContext())
-                .setSSLHostnameVerifier(sslFactory.getHostnameVerifier());
-          }
-        });
-
-    RestHighLevelClient client = new RestHighLevelClient(builder);
-
-    return client;
-  }
 
   public static ElasticsearchClient getElasticsearchOfficialClient(Config config) {
     URI hostUri = URI.create(getElasticsearchUrl(config));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
@@ -1,7 +1,5 @@
 package com.kmwllc.lucille.util;
 
-import static com.kmwllc.lucille.util.ElasticsearchUtils.getAllowInvalidCert;
-import static com.kmwllc.lucille.util.ElasticsearchUtils.getElasticsearchUrl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -51,10 +49,10 @@ public class ElasticsearchUtilsTest {
     m = new HashMap<>();
     Config none = ConfigFactory.parseMap(m);
 
-    assertTrue(getAllowInvalidCert(allCaps));
-    assertTrue(getAllowInvalidCert(allLower));
-    assertFalse(getAllowInvalidCert(allLowerFalse));
-    assertFalse(getAllowInvalidCert(allCapsFalse));
+    assertTrue(ElasticsearchUtils.getAllowInvalidCert(allCaps));
+    assertTrue(ElasticsearchUtils.getAllowInvalidCert(allLower));
+    assertFalse(ElasticsearchUtils.getAllowInvalidCert(allLowerFalse));
+    assertFalse(ElasticsearchUtils.getAllowInvalidCert(allCapsFalse));
   }
 
   @Test
@@ -66,8 +64,8 @@ public class ElasticsearchUtilsTest {
     m = new HashMap<>();
     Config nothing = ConfigFactory.parseMap(m);
 
-    assertEquals("foo", getElasticsearchUrl(foo));
-    assertThrows(Exception.class, () -> getElasticsearchUrl(nothing));
+    assertEquals("foo", ElasticsearchUtils.getElasticsearchUrl(foo));
+    assertThrows(Exception.class, () -> ElasticsearchUtils.getElasticsearchUrl(nothing));
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
@@ -1,42 +1,29 @@
 package com.kmwllc.lucille.util;
 
 import static com.kmwllc.lucille.util.ElasticsearchUtils.getAllowInvalidCert;
-import static com.kmwllc.lucille.util.ElasticsearchUtils.getElasticsearchRestClient;
 import static com.kmwllc.lucille.util.ElasticsearchUtils.getElasticsearchUrl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.transport.ElasticsearchTransport;
 import nl.altindag.ssl.SSLFactory;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.impl.client.BasicCredentialsProvider;
 
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import org.apache.http.HttpHost;
 import java.util.Map;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
@@ -1,0 +1,72 @@
+package com.kmwllc.lucille.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+public class ElasticsearchUtilsTest {
+
+  @Test
+  public void testGetAllowInvalidCert() {
+    Map<String, Object> m = new HashMap<>();
+    m.put("elasticsearch.acceptInvalidCert", "TRUE");
+    Config allCaps = ConfigFactory.parseMap(m);
+
+    m = new HashMap<>();
+    m.put("elasticsearch.acceptInvalidCert", "true");
+    Config allLower = ConfigFactory.parseMap(m);
+
+    m = new HashMap<>();
+    m.put("elasticsearch.acceptInvalidCert", "false");
+    Config allLowerFalse = ConfigFactory.parseMap(m);
+
+    m = new HashMap<>();
+    m.put("elasticsearch.acceptInvalidCert", "FALSE");
+    Config allCapsFalse = ConfigFactory.parseMap(m);
+
+    m = new HashMap<>();
+    Config none = ConfigFactory.parseMap(m);
+
+    assertTrue(ElasticsearchUtils.getAllowInvalidCert(allCaps));
+    assertTrue(ElasticsearchUtils.getAllowInvalidCert(allLower));
+    assertFalse(ElasticsearchUtils.getAllowInvalidCert(allLowerFalse));
+    assertFalse(ElasticsearchUtils.getAllowInvalidCert(allCapsFalse));
+  }
+
+  @Test
+  public void testGetElasticsearchUrl() {
+    Map<String, Object> m = new HashMap<>();
+    m.put("elasticsearch.url", "foo");
+    Config foo = ConfigFactory.parseMap(m);
+
+    m = new HashMap<>();
+    Config nothing = ConfigFactory.parseMap(m);
+
+    assertEquals("foo", ElasticsearchUtils.getElasticsearchUrl(foo));
+    assertThrows(Exception.class, () -> ElasticsearchUtils.getElasticsearchUrl(nothing));
+  }
+
+  @Test
+  public void testGetElasticsearchIndex() {
+    Map<String, Object> m = new HashMap<>();
+    m.put("elasticsearch.index", "foo");
+    Config foo = ConfigFactory.parseMap(m);
+
+    m = new HashMap<>();
+    Config nothing = ConfigFactory.parseMap(m);
+
+    assertEquals("foo", ElasticsearchUtils.getElasticsearchIndex(foo));
+    assertThrows(Exception.class, () -> ElasticsearchUtils.getElasticsearchIndex(nothing));
+  }
+  
+  @Test
+  public void testGetElasticsearchRestClient() {
+
+  }
+}


### PR DESCRIPTION
This ticket has not been completed as mockito currently does not allow for argument capture for static methods. The tests can still be made using mockito's ```mockStatic``` method but it will most likely be less precise.