### PR TITLE
Fix: Upgrade OpenSearch Java to 2.8.2 for HttpClient 5.3 Updates

### DIFF
--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -48,9 +48,9 @@
     <solr.version>9.5.0</solr.version>
     <opensearch-rest-client.version>1.2.0</opensearch-rest-client.version>
     <opensearch.version>0.1.0</opensearch.version>
-    <opensearch-java.version>2.6.0</opensearch-java.version>
-    <httpcore5.version>5.1.5</httpcore5.version>
-    <httpclient5.version>5.1.4</httpclient5.version>
+    <opensearch-java.version>2.8.2</opensearch-java.version>
+    <httpcore5.version>5.2.4</httpcore5.version>
+    <httpclient5.version>5.3</httpclient5.version>
     <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
     <elasticsearch.version>7.17.3</elasticsearch.version>
     <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -48,9 +48,9 @@
     <solr.version>9.5.0</solr.version>
     <opensearch-rest-client.version>1.2.0</opensearch-rest-client.version>
     <opensearch.version>0.1.0</opensearch.version>
-    <opensearch-java.version>2.8.2</opensearch-java.version>
+    <opensearch-java.version>2.11.1</opensearch-java.version>
     <httpcore5.version>5.2.4</httpcore5.version>
-    <httpclient5.version>5.3</httpclient5.version>
+    <httpclient5.version>5.3.1</httpclient5.version>
     <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
     <elasticsearch.version>7.17.3</elasticsearch.version>
     <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>


### PR DESCRIPTION
Upgraded to [OpenSearch Java Client 2.11.1](https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.11.1.md) that uses improved [HttpClient 5.3](https://github.com/apache/httpcomponents-client/blob/rel/v5.3.1/RELEASE_NOTES.txt) to fix a **HttpClient** bug ([HTTPCLIENT-2219 Bug](https://issues.apache.org/jira/browse/HTTPCLIENT-2219)) that arises when run within a Kubernetes container.

Older **HttpClient** versions throw odd errors from inside of Kubernetes containers  that were fixed in later versions: 

**Error from older HttpClient that works fine elsewhere but throws an error when run in Kubernetes container**:
```
org.apache.hc.core5.http.ParseException: Invalid protocol version; error at offset 0: <[0x2e][0x2f][0x30][0x31][0x32][0x33][0x34][0x35][0x36][0x37][0x38][0x39][0x3a][0x3b][0x3d][0x3e][0x3f][0x40][0x41][0x42][0x43][0x44][0x45]ÿÿÿ[0x49][0x4a][0x4b][0x4c][0x4d][0x4e][0x4f][0x50][0x51]ÿ[0x54][0x55][0x56][0x57][0x58][0x59][0x5a][0x5b][0x5c][0x5d][0x5e][0x5f][0x60][0x61][0x62][0x63][0x64][0x65][0x66]>
```

Upgrading doesn't appear to require any additional code changes. Tests pass and running pipelines using upgraded packages now work correctly when running within containers. 