### PR TITLE
LC-503: added ignoreFields functionality in Elasticsearch and OpenSearch Indexer

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -98,7 +98,8 @@ public class ElasticsearchIndexer extends Indexer {
       // populate join data to document
       joinData.populateJoinData(doc);
 
-      Map<String, Object> indexerDoc = doc.asMap();
+      // removing the fields mentioned in the ignoreFields setting in configurations
+      Map<String, Object> indexerDoc = getIndexerDoc(doc);
 
       // remove children documents field from indexer doc (processed from doc by addChildren method call below)
       indexerDoc.remove(Document.CHILDREN_FIELD);

--- a/lucille-core/src/test/resources/ElasticsearchIndexerTest/ignoreFields.conf
+++ b/lucille-core/src/test/resources/ElasticsearchIndexerTest/ignoreFields.conf
@@ -1,0 +1,14 @@
+indexer {
+  type : "Elasticsearch"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+  ignoreFields: ["ignoreField1", "ignoreField2"]
+}
+
+elasticsearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+}

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/ignoreFields.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/ignoreFields.conf
@@ -1,0 +1,14 @@
+indexer {
+  type : "OpenSearch"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+  ignoreFields : ["ignoreField1", "ignoreField2"]
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+}

--- a/lucille-core/src/test/resources/SolrIndexerTest/ignoreFields.conf
+++ b/lucille-core/src/test/resources/SolrIndexerTest/ignoreFields.conf
@@ -1,0 +1,6 @@
+indexer {
+  batchSize : 100
+  batchTimeout : 1000
+  ignoreFields: ["ignoreField1", "ignoreField2"]
+  logRate : 1000
+}


### PR DESCRIPTION
- edited testRouting method in ElasticsearchTest and OpenSearchTest. Previously routing field was not deleted due to ignoreFields not implemented in both indexers.
- ignoreFields now allows routing to be appropriately set even though routing is in ignoreFields. The final document will not contain the routing field.