### PR TITLE
LC-532: fix leak of threads in TextExtractor stage

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/FileUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/FileUtils.java
@@ -68,7 +68,8 @@ public class FileUtils {
   /**
    * Takes a path and fsManager to retrieve the FileObject
    *
-   * @param path the path as a String
+   * @param path the path to file as a String
+   * @param fsManager the fileSystem manager instance
    * @return the FileObject to retrieve content from
    */
   public static FileObject getFileObject(String path, FileSystemManager fsManager) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/FileUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/FileUtils.java
@@ -66,50 +66,20 @@ public class FileUtils {
   }
 
   /**
-   * Takes a path and returns the correct InputStream depending on whether the path is a URI or URL.
+   * Takes a path and fsManager to retrieve the FileObject
    *
    * @param path the path as a String
-   * @return the correct InputStream
+   * @return the FileObject to retrieve content from
    */
-  public static InputStream getInputStream(String path, FileSystemManager fsManager) {
-    InputStream is;
-
-    // setting up VFS
-    if (isValidURI(path)) {
-      FileObject file;
-      try {
-        file = fsManager.resolveFile(path);
-
-        if (file == null) {
-          log.warn("File object is null for path: {}", path);
-          return null;
-        }
-
-        if (!file.exists()) {
-          log.warn("File not found at: {}", path);
-          return null;
-        }
-
-        FileContent content = file.getContent();
-        try {
-          is = content.getInputStream();
-          return is;
-        } catch (FileSystemException e) {
-          log.warn("Error opening input stream for file: {}", path, e);
-          return null;
-        }
-      } catch (FileSystemException e) {
-        log.warn("Error retrieving file contents: {}", path, e);
-        return null;
-      }
-    }
-
-    // setting up local file system manager
+  public static FileObject getFileObject(String path, FileSystemManager fsManager) {
     try {
-      is = new FileInputStream(path);
-      return is;
-    } catch (FileNotFoundException e) {
-      log.warn("File not found at: {}", path, e);
+      // transforming non-absolute path to absolute path if path is no absolute
+      if (!isValidURI(path)) {
+        path = Paths.get(path).toAbsolutePath().toString();
+      }
+      return fsManager.resolveFile(path);
+    } catch (FileSystemException e) {
+      log.warn("Error retrieving file contents: {}", path, e);
       return null;
     }
   }

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -77,15 +77,18 @@ public class TextExtractor extends Stage {
       throw new StageException("Provided neither a file_path_field nor byte_array_field to the TextExtractor stage");
     }
     parseCtx = new ParseContext();
-    fsManager = new StandardFileSystemManager();
   }
 
   @Override
   public void start() throws StageException {
-    try {
-      fsManager.init();
-    } catch (FileSystemException e) {
-      throw new StageException("Could not initialize FileSystem in TextExtractor Stage", e);
+    // initialize fsManager only if file_path_field is used
+    if (filePathField != null) {
+      try {
+        fsManager = new StandardFileSystemManager();
+        fsManager.init();
+      } catch (FileSystemException e) {
+        throw new StageException("Could not initialize FileSystem in TextExtractor Stage", e);
+      }
     }
     if (this.tikaConfigPath == null) {
       parser = new AutoDetectParser();

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -144,7 +144,7 @@ public class TextExtractor extends Stage {
 
       parseInputStream(doc, inputStream);
 
-      // close file after, do not need to check if file is null as we have already checked on line 130
+      // close file after, do not need to check if file is null as we have already checked above
       try {
         // closes the file, and its content, including any open stream
         file.close();

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.commons.vfs2.VFS;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tika.config.TikaConfig;
@@ -106,7 +107,7 @@ public class TextExtractor extends Stage {
       String filePath = doc.getString(filePathField);
 
       try {
-        InputStream inputStream = FileUtils.getInputStream(filePath);
+        InputStream inputStream = VFS.getManager().resolveFile(filePath).getContent().getInputStream();
         parseInputStream(doc, inputStream);
       } catch (IOException e) {
         throw new StageException("InputStream cannot be parsed or created", e);

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -134,6 +134,8 @@ public class TextExtractor extends Stage {
       // getting inputStream and catching errors gracefully
       InputStream inputStream;
       try {
+        // file.getContent() never returns null
+        // https://commons.apache.org/proper/commons-vfs/commons-vfs2/apidocs/org/apache/commons/vfs2/FileObject.html#getContent--
         inputStream = file.getContent().getInputStream();
       } catch(FileSystemException e) {
         log.warn("Error getting inputStream from file at: {}", filePath, e);
@@ -144,6 +146,7 @@ public class TextExtractor extends Stage {
 
       // close file after, do not need to check if file is null as we have already checked on line 130
       try {
+        // closes the file, and its content, including any open stream
         file.close();
       } catch (FileSystemException e) {
         log.warn("error closing file");

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -121,7 +121,7 @@ public class TextExtractor extends Stage {
       try (InputStream inputStream = new ByteArrayInputStream(byteArray)) {
         parseInputStream(doc, inputStream);
       } catch (IOException e) {
-        log.warn("Error getting/closing inputStream: ", e);
+        log.warn("Error closing inputStream: ", e);
         return null;
       }
 

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -3,6 +3,7 @@ package com.kmwllc.lucille.tika.stage;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
+import com.kmwllc.lucille.util.FileUtils;
 import com.typesafe.config.Config;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -10,8 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
-import org.apache.commons.vfs2.FileContent;
-import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.logging.log4j.LogManager;
@@ -125,42 +124,16 @@ public class TextExtractor extends Stage {
 
       String filePath = doc.getString(filePathField);
 
-      InputStream inputStream = getFileInputStream(filePath);
+      // logging would be done in getInputStream
+      InputStream inputStream = FileUtils.getInputStream(filePath, fsManager);
+      // if inputStream null, don't process document
       if (inputStream == null) {
-        log.warn("Error getting inputStream for file at : {}", filePath);
         return null;
       }
+
       parseInputStream(doc, inputStream);
     }
     return null;
-  }
-
-  private InputStream getFileInputStream(String filePath) {
-    FileObject file;
-    try {
-      file = fsManager.resolveFile(filePath);
-
-      if (file == null) {
-        log.warn("File object is null for path: {}", filePath);
-        return null;
-      }
-
-      if (!file.exists()) {
-        log.warn("File not found at: {}", filePath);
-        return null;
-      }
-
-      FileContent content = file.getContent();
-      try {
-        return content.getInputStream();
-      } catch (FileSystemException e) {
-        log.warn("Error opening input stream for file: {}", filePath, e);
-        return null;
-      }
-    } catch (FileSystemException e) {
-      log.warn("Error retrieving file contents: {}", filePath, e);
-      return null;
-    }
   }
 
   /**

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import com.kmwllc.lucille.stage.StageFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito.*;
 
@@ -257,4 +258,21 @@ public class TextExtractorTest {
     verify(inputStream, times(1)).close();
   }
 
+
+  /**
+   * Tests the TextExtractor getting inputStream from file method
+   *
+   */
+  @Test
+  public void testGetFileInputStream() throws StageException, IOException {
+    TextExtractor stage = (TextExtractor) factory.get("TextExtractorTest/getFileInputStream.conf");
+
+    // setting document to have a non existent path
+    Document doc = Document.create("doc1");
+    doc.addToField("path", Paths.get("src/test/resources/TextExtractorTest/nonExistentFile").toAbsolutePath().toString());
+
+    // parsing through the document would then be passed through and not parsed with log statements
+    stage.processDocument(doc);
+    Assert.assertNull(doc.getString("text"));
+  }
 }

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import com.kmwllc.lucille.stage.StageFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Test;
 
 public class TextExtractorTest {
@@ -27,7 +29,13 @@ public class TextExtractorTest {
   public void testFilePath() throws StageException {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.txt");
+    
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    // set path as absolute Path
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
     stage.processDocument(doc);
     assertEquals("Hi There!\n", doc.getString("text"));
   }
@@ -57,7 +65,13 @@ public class TextExtractorTest {
   public void testDocx() throws StageException {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.docx");
+
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    // set path as absolute Path
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.docx");
     stage.processDocument(doc);
     assertEquals("Hi There!\n", doc.getString("text"));
     assertEquals("Microsoft Office Word", doc.getString("tika_extended_properties_application"));
@@ -72,7 +86,13 @@ public class TextExtractorTest {
   public void testExcel() throws StageException {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.xlsx");
+
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    // set path as absolute Path
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.xlsx");
     stage.processDocument(doc);
     assertEquals("Sheet1\n" +
         "\tHi There!\n" +
@@ -90,7 +110,13 @@ public class TextExtractorTest {
   public void testCustomTikaConfig() throws StageException {
     Stage stage = factory.get("TextExtractorTest/tika-config.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.txt");
+
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    // set path as absolute Path
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
     stage.processDocument(doc);
     assertEquals("Hi There!\n", doc.getString("text"));
   }
@@ -104,7 +130,13 @@ public class TextExtractorTest {
   public void testCustomTikaConfig2() throws StageException {
     Stage stage = factory.get("TextExtractorTest/tika-config2.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.pdf");
+
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    // set path as absolute Path
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.pdf");
     stage.processDocument(doc);
     // verify that the open parser is what is used on pdfs
     assertTrue(doc.getStringList("mtdata_x_tika_parsed_by").contains("org.apache.tika.parser.EmptyParser"));
@@ -119,7 +151,13 @@ public class TextExtractorTest {
   public void testCustomTikaConfig2ContentType() throws StageException {
     Stage stage = factory.get("TextExtractorTest/tika-config2.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.pdf");
+
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    // set path as absolute Path
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.pdf");
     stage.processDocument(doc);
     // verify that the open parser is what is used on pdfs
     assertTrue(doc.getStringList("mtdata_content_type").contains("application/pdf"));
@@ -134,20 +172,24 @@ public class TextExtractorTest {
   public void testTikaContentType() throws StageException {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
 
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
     Document doc1 = Document.create("doc1");
-    doc1.setField("path", "src/test/resources/TextExtractorTest/tika.xlsx");
+    doc1.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.xlsx");
     stage.processDocument(doc1);
     assertTrue(
         doc1.getStringList("tika_content_type").contains("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
 
     Document doc2 = Document.create("doc2");
-    doc2.setField("path", "src/test/resources/TextExtractorTest/tika.docx");
+    doc2.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.docx");
     stage.processDocument(doc2);
     assertTrue(doc2.getStringList("tika_content_type")
         .contains("application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
 
     Document doc3 = Document.create("doc3");
-    doc3.setField("path", "src/test/resources/TextExtractorTest/tika.txt");
+    doc3.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
     stage.processDocument(doc3);
     assertTrue(doc3.getStringList("tika_content_type").contains("text/plain; charset=ISO-8859-1"));
   }
@@ -161,7 +203,13 @@ public class TextExtractorTest {
   public void testWhiteList() throws StageException {
     Stage stage = factory.get("TextExtractorTest/whitelist.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.txt");
+
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    // set path as absolute Path
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
     stage.processDocument(doc);
     assertEquals("text/plain; charset=ISO-8859-1", doc.getStringList("tika_content_type").get(0));
     assertThrows(NullPointerException.class, () -> doc.getStringList("content_encoding").get(0));
@@ -177,7 +225,12 @@ public class TextExtractorTest {
   public void testBlackList() throws StageException {
     Stage stage = factory.get("TextExtractorTest/blacklist.conf");
     Document doc = Document.create("doc1");
-    doc.setField("path", "src/test/resources/TextExtractorTest/tika.txt");
+
+    // get current directory absolute path
+    Path currentRelativePath = Paths.get("");
+    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+
+    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
     stage.processDocument(doc);
     assertEquals("text/plain; charset=ISO-8859-1", doc.getStringList("tika_content_type").get(0));
     assertEquals("org.apache.tika.parser.DefaultParser", doc.getStringList("tika_x_tika_parsed_by").get(0));

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -29,13 +29,10 @@ public class TextExtractorTest {
   public void testFilePath() throws StageException {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
     Document doc = Document.create("doc1");
-    
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
 
     // set path as absolute Path
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.txt").toAbsolutePath().toString());
+
     stage.processDocument(doc);
     assertEquals("Hi There!\n", doc.getString("text"));
   }
@@ -66,12 +63,9 @@ public class TextExtractorTest {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
     Document doc = Document.create("doc1");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
-
     // set path as absolute Path
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.docx");
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.docx").toAbsolutePath().toString());
+
     stage.processDocument(doc);
     assertEquals("Hi There!\n", doc.getString("text"));
     assertEquals("Microsoft Office Word", doc.getString("tika_extended_properties_application"));
@@ -87,12 +81,9 @@ public class TextExtractorTest {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
     Document doc = Document.create("doc1");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
-
     // set path as absolute Path
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.xlsx");
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.xlsx").toAbsolutePath().toString());
+
     stage.processDocument(doc);
     assertEquals("Sheet1\n" +
         "\tHi There!\n" +
@@ -111,12 +102,9 @@ public class TextExtractorTest {
     Stage stage = factory.get("TextExtractorTest/tika-config.conf");
     Document doc = Document.create("doc1");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
-
     // set path as absolute Path
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.txt").toAbsolutePath().toString());
+
     stage.processDocument(doc);
     assertEquals("Hi There!\n", doc.getString("text"));
   }
@@ -131,12 +119,9 @@ public class TextExtractorTest {
     Stage stage = factory.get("TextExtractorTest/tika-config2.conf");
     Document doc = Document.create("doc1");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
-
     // set path as absolute Path
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.pdf");
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.pdf").toAbsolutePath().toString());
+
     stage.processDocument(doc);
     // verify that the open parser is what is used on pdfs
     assertTrue(doc.getStringList("mtdata_x_tika_parsed_by").contains("org.apache.tika.parser.EmptyParser"));
@@ -152,12 +137,9 @@ public class TextExtractorTest {
     Stage stage = factory.get("TextExtractorTest/tika-config2.conf");
     Document doc = Document.create("doc1");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
-
     // set path as absolute Path
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.pdf");
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.pdf").toAbsolutePath().toString());
+
     stage.processDocument(doc);
     // verify that the open parser is what is used on pdfs
     assertTrue(doc.getStringList("mtdata_content_type").contains("application/pdf"));
@@ -172,24 +154,20 @@ public class TextExtractorTest {
   public void testTikaContentType() throws StageException {
     Stage stage = factory.get("TextExtractorTest/filepath.conf");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
-
     Document doc1 = Document.create("doc1");
-    doc1.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.xlsx");
+    doc1.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.xlsx").toAbsolutePath().toString());
     stage.processDocument(doc1);
     assertTrue(
         doc1.getStringList("tika_content_type").contains("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
 
     Document doc2 = Document.create("doc2");
-    doc2.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.docx");
+    doc2.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.docx").toAbsolutePath().toString());
     stage.processDocument(doc2);
     assertTrue(doc2.getStringList("tika_content_type")
         .contains("application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
 
     Document doc3 = Document.create("doc3");
-    doc3.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
+    doc3.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.txt").toAbsolutePath().toString());
     stage.processDocument(doc3);
     assertTrue(doc3.getStringList("tika_content_type").contains("text/plain; charset=ISO-8859-1"));
   }
@@ -204,12 +182,9 @@ public class TextExtractorTest {
     Stage stage = factory.get("TextExtractorTest/whitelist.conf");
     Document doc = Document.create("doc1");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
-
     // set path as absolute Path
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.txt").toAbsolutePath().toString());
+
     stage.processDocument(doc);
     assertEquals("text/plain; charset=ISO-8859-1", doc.getStringList("tika_content_type").get(0));
     assertThrows(NullPointerException.class, () -> doc.getStringList("content_encoding").get(0));
@@ -226,11 +201,9 @@ public class TextExtractorTest {
     Stage stage = factory.get("TextExtractorTest/blacklist.conf");
     Document doc = Document.create("doc1");
 
-    // get current directory absolute path
-    Path currentRelativePath = Paths.get("");
-    String currentAbsolutePath = currentRelativePath.toAbsolutePath().toString();
+    // set path as absolute Path
+    doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.txt").toAbsolutePath().toString());
 
-    doc.setField("path", currentAbsolutePath + "/src/test/resources/TextExtractorTest/tika.txt");
     stage.processDocument(doc);
     assertEquals("text/plain; charset=ISO-8859-1", doc.getStringList("tika_content_type").get(0));
     assertEquals("org.apache.tika.parser.DefaultParser", doc.getStringList("tika_x_tika_parsed_by").get(0));

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -261,13 +261,12 @@ public class TextExtractorTest {
 
   /**
    * Tests the TextExtractor getting inputStream from file method
-   *
    */
   @Test
-  public void testGetFileInputStream() throws StageException, IOException {
+  public void testGetFileInputStreamError() throws StageException, IOException {
     TextExtractor stage = (TextExtractor) factory.get("TextExtractorTest/getFileInputStream.conf");
 
-    // setting document to have a non existent path
+    // setting document to have a non-existent path
     Document doc = Document.create("doc1");
     doc.addToField("path", Paths.get("src/test/resources/TextExtractorTest/nonExistentFile").toAbsolutePath().toString());
 

--- a/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/getFileInputStream.conf
+++ b/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/getFileInputStream.conf
@@ -1,0 +1,5 @@
+{
+  class = "com.kmwllc.lucille.tika.stage.TextExtractor"
+  text_field = "text"
+  file_path_field = "path"
+}


### PR DESCRIPTION
- closing of inputStream is in a separate branch LC-528. This branch changes how it got inputStream from filepath
- changed test for TextExtractor to use absolute path rather than relative path to reflect the same procedure. (doc.getString(filePathField) would return an absolute path)