### PR TITLE
LC-535: added ability to ignore "id" field in SolrIndexer

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrDocRequests.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrDocRequests.java
@@ -35,9 +35,10 @@ public class SolrDocRequests {
     this.valuesToDeleteByField = valuesToDeleteByField;
   }
 
-  public void addDocForAddUpdate(SolrInputDocument doc) {
+  // we are explicitly using another argument for docId as the SolrInputDocument may no longer have the "id" field
+  public void addDocForAddUpdate(SolrInputDocument doc, String id) {
     docsToAddOrUpdate.add(doc);
-    idsToAddOrUpdate.add((String) doc.getFieldValue(Document.ID_FIELD));
+    idsToAddOrUpdate.add(id);
   }
 
   public void addIdForDeletion(String id) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -296,7 +296,9 @@ public class SolrIndexer extends Indexer {
       return;
     }
     for (Document child : children) {
-      Map<String, Object> map = child.asMap();
+      // remove key:value pair mappings if they appear in ignoreFields
+      Map<String, Object> map = getIndexerDoc(child);
+
       SolrInputDocument solrChild = new SolrInputDocument();
       for (String key : map.keySet()) {
         // we don't support children that contain nested children

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -140,8 +140,8 @@ public class SolrIndexer extends Indexer {
       String solrId = idOverride != null ? idOverride : doc.getId();
 
       // if user provided uniqueKey is in document use that as id, else continue with the original id
-      if (uniqueKey != null) {
-        solrId = doc.has(uniqueKey) ? doc.getString(uniqueKey) : solrId;
+      if (uniqueKey != null && doc.has(uniqueKey)) {
+        solrId = doc.getString(uniqueKey);
       }
 
       if (isDeletion(doc)) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -32,13 +32,10 @@ public class SolrIndexer extends Indexer {
 
   private final SolrClient solrClient;
 
-  private final String uniqueKey;
-
   public SolrIndexer(
       Config config, IndexerMessenger messenger, SolrClient solrClient, String metricsPrefix) {
     super(config, messenger, metricsPrefix);
     this.solrClient = solrClient;
-    uniqueKey = config.hasPath("unique_key") ? config.getString("unique_key") : null;
   }
 
   public SolrIndexer(
@@ -47,7 +44,6 @@ public class SolrIndexer extends Indexer {
     // If the SolrIndexer is creating its own client it needs to happen after the Indexer has validated its config
     // to avoid problems where a client is created with no way to close it.
     this.solrClient = getSolrClient(config, bypass);
-    uniqueKey = config.hasPath("unique_key") ? config.getString("unique_key") : null;
   }
 
   private static SolrClient getSolrClient(Config config, boolean bypass) {
@@ -138,11 +134,6 @@ public class SolrIndexer extends Indexer {
       }
       SolrDocRequests solrDocRequests = solrDocRequestsByCollection.get(collection);
       String solrId = idOverride != null ? idOverride : doc.getId();
-
-      // if user provided uniqueKey is in document use that as id, else continue with the original id
-      if (uniqueKey != null && doc.has(uniqueKey)) {
-        solrId = doc.getString(uniqueKey);
-      }
 
       if (isDeletion(doc)) {
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
@@ -175,6 +175,7 @@ public class SolrIndexerTest {
     TestMessenger messenger = new TestMessenger();
 
     Document doc = Document.create("doc1", "test_run");
+    doc.setField("myid", "my_new_id");
 
     SolrClient solrClient = mock(SolrClient.class);
     Indexer indexer = new SolrIndexer(config, messenger, solrClient, "");
@@ -190,6 +191,7 @@ public class SolrIndexerTest {
     // confirm that the document id has been removed
     SolrInputDocument solrDoc = (SolrInputDocument) captor.getAllValues().get(0).toArray()[0];
     assertNull(solrDoc.getFieldValue("id"));
+    assertEquals("my_new_id", solrDoc.getFieldValue("myid"));
   }
 
   /**

--- a/lucille-core/src/test/resources/SolrIndexerTest/ignoreId.conf
+++ b/lucille-core/src/test/resources/SolrIndexerTest/ignoreId.conf
@@ -2,5 +2,6 @@ indexer {
   batchSize : 100
   batchTimeout : 1000
   ignoreFields: ["id"]
+  idOverride: "myid"
   logRate : 1000
 }

--- a/lucille-core/src/test/resources/SolrIndexerTest/ignoreId.conf
+++ b/lucille-core/src/test/resources/SolrIndexerTest/ignoreId.conf
@@ -1,0 +1,6 @@
+indexer {
+  batchSize : 100
+  batchTimeout : 1000
+  ignoreFields: ["id"]
+  logRate : 1000
+}


### PR DESCRIPTION
- now allows user to place "id" field in ignoreFields config.
- ignoreFields will now apply to Children and Parent Document(s)
- Changed SolrInputRequest to use SolrId instead of Document.ID_FIELD