### PR TITLE
LC-525 increase version of vfs and aws-sdk to the latest to fix CVEs

### DIFF
--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -54,8 +54,8 @@
     <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
     <elasticsearch.version>7.17.3</elasticsearch.version>
     <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>
-    <aws-java-sdk-sts.version>1.12.39</aws-java-sdk-sts.version>
-    <vfs-s3.version>4.3.6</vfs-s3.version>
+    <aws-java-sdk-sts.version>1.12.769</aws-java-sdk-sts.version>
+    <vfs-s3.version>4.4.0</vfs-s3.version>
     <log4j.version>2.20.0</log4j.version>
     <slf4j.version>2.0.7</slf4j.version>
     <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
@@ -117,7 +117,7 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
-        <version>1.12.262</version>
+        <version>${aws-java-sdk-sts.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -54,7 +54,7 @@
     <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
     <elasticsearch.version>7.17.3</elasticsearch.version>
     <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>
-    <aws-java-sdk-sts.version>1.12.769</aws-java-sdk-sts.version>
+    <aws-java-sdk.version>1.12.769</aws-java-sdk.version>
     <vfs-s3.version>4.4.0</vfs-s3.version>
     <log4j.version>2.20.0</log4j.version>
     <slf4j.version>2.0.7</slf4j.version>
@@ -117,7 +117,7 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
-        <version>${aws-java-sdk-sts.version}</version>
+        <version>${aws-java-sdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolves CVEs in `amazon-ion` and `vfs-s3 by upgrading to the latest versions.

NOTE: `amazon-ion` is no longer being imported, since we have upgraded to `aws-java-sdk` version 1.12.769 which does not depend on ion.

Tickets: 
https://kmwllc.atlassian.net/browse/LC-525
https://kmwllc.atlassian.net/browse/LC-531

CVES:
https://nvd.nist.gov/vuln/detail/CVE-2024-21634
https://mvnrepository.com/artifact/com.github.abashev/vfs-s3/4.3.6