### PR TITLE
LC-487: fix transient worker test

### DIFF
--- a/application-example.conf
+++ b/application-example.conf
@@ -195,10 +195,8 @@ worker {
   maxRetries: 2
 
   # tell the worker process to generate a heartbeat.log that can be used to check liveness
+  # the frequency of the heartbeat is controlled by log.seconds
   enableHeartbeat: true
-
-  # time in ms, between successive updates to heartbeat.log
-  period: 6000
 }
 
 zookeeper {
@@ -280,5 +278,5 @@ aws {
 }
 
 log {
-  seconds: 30 # how often components (Publisher, Worker, Indexer) should log a status update
+  seconds: 30 # how often components (Publisher, Worker, Indexer) should log a status update and/or heartbeat
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorThread.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorThread.java
@@ -7,7 +7,8 @@ public class ConnectorThread extends Thread {
 
   private volatile Exception exception;
 
-  public ConnectorThread(Connector connector, Publisher publisher) {
+  public ConnectorThread(Connector connector, Publisher publisher, String name) {
+    this.setName(name);
     this.connector = connector;
     this.publisher = publisher;
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Slf4jReporter;
 import com.kmwllc.lucille.indexer.IndexerFactory;
 import com.kmwllc.lucille.message.*;
 import com.kmwllc.lucille.util.LogUtils;
+import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
@@ -364,7 +365,7 @@ public class Runner {
       }
     } else {
       try {
-        ConnectorThread connectorThread = new ConnectorThread(connector, publisher);
+        ConnectorThread connectorThread = new ConnectorThread(connector, publisher, ThreadNameUtils.getThreadName("ConnectorThread"));
         connectorThread.start();
         final int connectorTimeout = config.hasPath("runner.connectorTimeout") ?
             config.getInt("runner.connectorTimeout") : DEFAULT_CONNECTOR_TIMEOUT;
@@ -444,7 +445,7 @@ public class Runner {
           return new ConnectorResult(connector, publisher, false, msg);
         }
 
-        indexerThread = new Thread(indexer);
+        indexerThread = new Thread(indexer, ThreadNameUtils.getThreadName("IndexerThread"));
         indexerThread.start();
       }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
@@ -363,7 +363,7 @@ public class Runner {
       }
     } else {
       try {
-        ConnectorThread connectorThread = new ConnectorThread(connector, publisher, ThreadNameUtils.setThreadPrefix("Connector"));
+        ConnectorThread connectorThread = new ConnectorThread(connector, publisher, ThreadNameUtils.createName("Connector"));
         connectorThread.start();
         final int connectorTimeout = config.hasPath("runner.connectorTimeout") ?
             config.getInt("runner.connectorTimeout") : DEFAULT_CONNECTOR_TIMEOUT;
@@ -443,7 +443,7 @@ public class Runner {
           return new ConnectorResult(connector, publisher, false, msg);
         }
 
-        indexerThread = new Thread(indexer, ThreadNameUtils.setThreadPrefix("Indexer"));
+        indexerThread = new Thread(indexer, ThreadNameUtils.createName("Indexer"));
         indexerThread.start();
       }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
@@ -9,8 +9,6 @@ import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
-import com.typesafe.config.ConfigValue;
-import java.util.Map.Entry;
 import org.apache.commons.cli.*;
 import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
@@ -365,7 +363,7 @@ public class Runner {
       }
     } else {
       try {
-        ConnectorThread connectorThread = new ConnectorThread(connector, publisher, ThreadNameUtils.getThreadName("ConnectorThread"));
+        ConnectorThread connectorThread = new ConnectorThread(connector, publisher, ThreadNameUtils.setThreadPrefix("Connector"));
         connectorThread.start();
         final int connectorTimeout = config.hasPath("runner.connectorTimeout") ?
             config.getInt("runner.connectorTimeout") : DEFAULT_CONNECTOR_TIMEOUT;
@@ -445,7 +443,7 @@ public class Runner {
           return new ConnectorResult(connector, publisher, false, msg);
         }
 
-        indexerThread = new Thread(indexer, ThreadNameUtils.getThreadName("IndexerThread"));
+        indexerThread = new Thread(indexer, ThreadNameUtils.setThreadPrefix("Indexer"));
         indexerThread.start();
       }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
@@ -51,7 +51,6 @@ class Worker implements Runnable {
 
   @Override
   public void run() {
-    log.info("Starting worker run");
     MetricRegistry metrics = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
     Timer timer = metrics.timer(metricsPrefix + METRICS_SUFFIX);
 
@@ -167,18 +166,11 @@ class Worker implements Runnable {
     }
   }
 
-  public boolean isTerminated() {
-    return !running;
-  }
-
   public AtomicReference<Instant> getPreviousPollInstant() {
     return pollInstant;
   }
 
-  public static WorkerThread startThread(Config config, WorkerMessenger messenger,
-      String pipelineName, String metricsPrefix, String name) throws
-      Exception {
-    Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
+  public static WorkerThread startThread(Config config, Worker worker, String name) {
     WorkerThread workerThread = new WorkerThread(worker, config, name);
     workerThread.start();
     return workerThread;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
@@ -170,8 +170,8 @@ class Worker implements Runnable {
     return pollInstant;
   }
 
-  public static WorkerThread startThread(Config config, Worker worker, String name) {
-    WorkerThread workerThread = new WorkerThread(worker, config, name);
+  public static WorkerThread startThread(Worker worker, String name) {
+    WorkerThread workerThread = new WorkerThread(worker, name);
     workerThread.start();
     return workerThread;
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
@@ -51,6 +51,7 @@ class Worker implements Runnable {
 
   @Override
   public void run() {
+    log.info("Starting worker run");
     MetricRegistry metrics = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
     Timer timer = metrics.timer(metricsPrefix + METRICS_SUFFIX);
 
@@ -166,15 +167,19 @@ class Worker implements Runnable {
     }
   }
 
+  public boolean isTerminated() {
+    return !running;
+  }
+
   public AtomicReference<Instant> getPreviousPollInstant() {
     return pollInstant;
   }
 
   public static WorkerThread startThread(Config config, WorkerMessenger messenger,
-      String pipelineName, String metricsPrefix) throws
+      String pipelineName, String metricsPrefix, String name) throws
       Exception {
     Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
-    WorkerThread workerThread = new WorkerThread(worker, config);
+    WorkerThread workerThread = new WorkerThread(worker, config, name);
     workerThread.start();
     return workerThread;
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
@@ -4,6 +4,7 @@ import com.kmwllc.lucille.indexer.IndexerFactory;
 import com.kmwllc.lucille.message.HybridIndexerMessenger;
 import com.kmwllc.lucille.message.HybridWorkerMessenger;
 import com.kmwllc.lucille.message.LocalMessenger;
+import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -93,13 +94,13 @@ public class WorkerIndexer {
 
     indexerThread = new Thread(indexer);
     indexerThread.start();
-
+    String name = ThreadNameUtils.getThreadName("WorkerIndexer");
     workerThread =
-        Worker.startThread(config, workerMessageManager, pipelineName, pipelineName);
+        Worker.startThread(config, workerMessageManager, pipelineName, pipelineName, name);
   }
 
   public void stop() throws Exception {
-
+    log.info("Stopping WorkerIndexer");
     // it is important to terminate the indexer wait for its thread to stop
     // before we terminate the worker. This allows the worker to process
     // any offsets that the indexer added to the offset queue upon termination

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
@@ -96,8 +96,7 @@ public class WorkerIndexer {
     indexerThread.start();
     String name = ThreadNameUtils.createName("WorkerIndexer");
     Worker worker = new Worker(config, workerMessageManager, pipelineName, pipelineName);
-    workerThread =
-        Worker.startThread(config, worker, name);
+    workerThread = Worker.startThread(worker, name);
   }
 
   public void stop() throws Exception {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
@@ -94,7 +94,7 @@ public class WorkerIndexer {
 
     indexerThread = new Thread(indexer);
     indexerThread.start();
-    String name = ThreadNameUtils.setThreadPrefix("WorkerIndexer");
+    String name = ThreadNameUtils.createName("WorkerIndexer");
     Worker worker = new Worker(config, workerMessageManager, pipelineName, pipelineName);
     workerThread =
         Worker.startThread(config, worker, name);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
@@ -95,12 +95,12 @@ public class WorkerIndexer {
     indexerThread = new Thread(indexer);
     indexerThread.start();
     String name = ThreadNameUtils.getThreadName("WorkerIndexer");
+    Worker worker = new Worker(config, workerMessageManager, pipelineName, pipelineName);
     workerThread =
-        Worker.startThread(config, workerMessageManager, pipelineName, pipelineName, name);
+        Worker.startThread(config, worker, name);
   }
 
   public void stop() throws Exception {
-    log.info("Stopping WorkerIndexer");
     // it is important to terminate the indexer wait for its thread to stop
     // before we terminate the worker. This allows the worker to process
     // any offsets that the indexer added to the offset queue upon termination

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerIndexer.java
@@ -94,7 +94,7 @@ public class WorkerIndexer {
 
     indexerThread = new Thread(indexer);
     indexerThread.start();
-    String name = ThreadNameUtils.getThreadName("WorkerIndexer");
+    String name = ThreadNameUtils.setThreadPrefix("WorkerIndexer");
     Worker worker = new Worker(config, workerMessageManager, pipelineName, pipelineName);
     workerThread =
         Worker.startThread(config, worker, name);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -84,7 +84,7 @@ public class WorkerPool {
       try {
         WorkerMessenger messenger = workerMessengerFactory.create();
 
-        String name = ThreadNameUtils.getThreadName("Worker-" + (i+1));
+        String name = ThreadNameUtils.setThreadPrefix("Worker-" + (i+1));
         // will throw exception if pipeline has errors
         Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -75,29 +75,28 @@ public class WorkerPool {
     started = true;
     log.info("Starting " + numWorkers + " worker threads for pipeline " + pipelineName);
     List<Worker> workers = new ArrayList<>();
-    for (int i = 0; i < numWorkers; i++) {
-      try {
+
+    try {
+      for (int i = 0; i < numWorkers; i++) {
         WorkerMessenger messenger = workerMessengerFactory.create();
 
-        String name = ThreadNameUtils.createName("Worker-" + (i+1));
+        String name = ThreadNameUtils.createName("Worker-" + (i + 1));
         // will throw exception if pipeline has errors
         Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
         workers.add(worker);
         // start workerThread
         threads.add(Worker.startThread(worker, name));
-        // start watcher on last iteration to be within try catch block
-        if (i == numWorkers - 1) {
-          watcherService = startWatcher(workers, maxProcessingSecs);
-        }
-      } catch (Exception e) {
-        log.error("Exception caught when starting Worker thread {}; aborting", i+1);
-        try {
-          stop();
-        } catch (Exception e2) {
-          log.error("Exception caught when attempting to stop Worker threads because of a startup problem", e2);
-        }
-        throw e;
       }
+
+      watcherService = startWatcher(workers, maxProcessingSecs);
+    } catch (Exception e) {
+      log.error("Exception caught when starting Worker threads; aborting");
+      try {
+        stop();
+      } catch (Exception e2) {
+        log.error("Exception caught when attempting to stop Worker threads because of a startup problem", e2);
+      }
+      throw e;
     }
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -61,7 +61,7 @@ public class WorkerPool {
       this.numWorkers = config.hasPath("worker.threads") ? config.getInt("worker.threads") : DEFAULT_POOL_SIZE;
     }
     this.logSeconds = ConfigUtils.getOrDefault(config, "log.seconds", LogUtils.DEFAULT_LOG_SECONDS);
-    this.enableHeartbeat = config.hasPath("worker.heartbeat") ? config.getBoolean("worker.heartbeat") : false;
+    this.enableHeartbeat = config.hasPath("worker.enableHeartbeat") ? config.getBoolean("worker.enableHeartbeat") : false;
     // maxProcessingSecs default should be at least 10 minutes
     this.maxProcessingSecs =
         config.hasPath("worker.maxProcessingSecs") ? config.getInt("worker.maxProcessingSecs") : 10 * 60 * 1000;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -89,7 +89,7 @@ public class WorkerPool {
         Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
         workerList.add(worker);
         // start workerThread
-        threads.add(Worker.startThread(config, worker, name));
+        threads.add(Worker.startThread(worker, name));
         // start timer on last iteration to be within try catch block
         if (i == numWorkers - 1) {
           executorService = startTimer(workerList, maxProcessingSecs, ThreadNameUtils.createName("ExecutorService"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -85,7 +85,7 @@ public class WorkerPool {
         workers.add(worker);
         // start workerThread
         threads.add(Worker.startThread(worker, name));
-        // start timer on last iteration to be within try catch block
+        // start watcher on last iteration to be within try catch block
         if (i == numWorkers - 1) {
           watcherService = startWatcher(workers, maxProcessingSecs);
         }
@@ -106,7 +106,7 @@ public class WorkerPool {
     for (WorkerThread workerThread : threads) {
       workerThread.terminate();
     }
-    // shutdown executorService gracefully
+    // shutdown watcherService gracefully
     if (watcherService != null) {
       stopWatcher(watcherService);
     }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -84,7 +84,7 @@ public class WorkerPool {
       try {
         WorkerMessenger messenger = workerMessengerFactory.create();
 
-        String name = ThreadNameUtils.setThreadPrefix("Worker-" + (i+1));
+        String name = ThreadNameUtils.createName("Worker-" + (i+1));
         // will throw exception if pipeline has errors
         Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
         workerList.add(worker);
@@ -92,7 +92,7 @@ public class WorkerPool {
         threads.add(Worker.startThread(config, worker, name));
         // start timer on last iteration to be within try catch block
         if (i == numWorkers - 1) {
-          executorService = startTimer(workerList, maxProcessingSecs, ThreadNameUtils.setThreadPrefix("ExecutorService"));
+          executorService = startTimer(workerList, maxProcessingSecs, ThreadNameUtils.createName("ExecutorService"));
         }
       } catch (Exception e) {
         log.error("Exception caught when starting Worker thread {}; aborting", i+1);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
 import java.util.TimerTask;
 
 public class WorkerPool {
@@ -29,14 +28,14 @@ public class WorkerPool {
   public static final int DEFAULT_POOL_SIZE = 1;
 
   private static final Logger log = LoggerFactory.getLogger(WorkerPool.class);
+  private static final long WATCHER_PERIOD_SECONDS = 5;
 
   private final List<WorkerThread> threads = new ArrayList<>();
-  private ScheduledExecutorService executorService;
+  private ScheduledExecutorService watcherService;
   public static final String HEARTBEAT_LOG_NAME = "com.kmwllc.lucille.core.Heartbeat";
   private static final Logger heartbeatLog = LoggerFactory.getLogger(HEARTBEAT_LOG_NAME);
 
   private boolean enableHeartbeat;
-  private int period;
   private int maxProcessingSecs;
   private boolean exitOnTimeout;
 
@@ -46,7 +45,6 @@ public class WorkerPool {
   private WorkerMessengerFactory workerMessengerFactory;
   private boolean started = false;
   private final int logSeconds;
-  private Timer logTimer;
   private final String metricsPrefix;
 
   public WorkerPool(Config config, String pipelineName, WorkerMessengerFactory factory, String metricsPrefix) {
@@ -63,10 +61,7 @@ public class WorkerPool {
       this.numWorkers = config.hasPath("worker.threads") ? config.getInt("worker.threads") : DEFAULT_POOL_SIZE;
     }
     this.logSeconds = ConfigUtils.getOrDefault(config, "log.seconds", LogUtils.DEFAULT_LOG_SECONDS);
-
-
     this.enableHeartbeat = config.hasPath("worker.heartbeat") ? config.getBoolean("worker.heartbeat") : false;
-    this.period = config.hasPath("worker.period") ? config.getInt("worker.period") : 1000;
     // maxProcessingSecs default should be at least 10 minutes
     this.maxProcessingSecs =
         config.hasPath("worker.maxProcessingSecs") ? config.getInt("worker.maxProcessingSecs") : 10 * 60 * 1000;
@@ -79,7 +74,7 @@ public class WorkerPool {
     }
     started = true;
     log.info("Starting " + numWorkers + " worker threads for pipeline " + pipelineName);
-    List<Worker> workerList = new ArrayList<>(); // collects all the workers
+    List<Worker> workers = new ArrayList<>();
     for (int i = 0; i < numWorkers; i++) {
       try {
         WorkerMessenger messenger = workerMessengerFactory.create();
@@ -87,12 +82,12 @@ public class WorkerPool {
         String name = ThreadNameUtils.createName("Worker-" + (i+1));
         // will throw exception if pipeline has errors
         Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
-        workerList.add(worker);
+        workers.add(worker);
         // start workerThread
         threads.add(Worker.startThread(worker, name));
         // start timer on last iteration to be within try catch block
         if (i == numWorkers - 1) {
-          executorService = startTimer(workerList, maxProcessingSecs, ThreadNameUtils.createName("ExecutorService"));
+          watcherService = startWatcher(workers, maxProcessingSecs);
         }
       } catch (Exception e) {
         log.error("Exception caught when starting Worker thread {}; aborting", i+1);
@@ -104,34 +99,16 @@ public class WorkerPool {
         throw e;
       }
     }
-
-    // Timer to log a status message every minute
-    // the Timer should use a daemon thread so it doesn't prevent the jvm from exiting
-    logTimer = new Timer("WorkerPoolTimer", true);
-    logTimer.schedule(new TimerTask() {
-      private final MetricRegistry metrics = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
-      private final com.codahale.metrics.Timer timer = metrics.timer(metricsPrefix + Worker.METRICS_SUFFIX);
-
-      @Override
-      public void run() {
-        log.info(String.format("%d docs processed. One minute rate: %.2f docs/sec. Mean pipeline latency: %.2f ms/doc.",
-            timer.getCount(), timer.getOneMinuteRate(), timer.getSnapshot().getMean() / 1000000));
-      }
-    }, logSeconds * 1000, logSeconds * 1000);
-
   }
 
   public void stop() {
     log.debug("Stopping " + threads.size() + " worker threads");
-    if (logTimer != null) {
-      logTimer.cancel();
-    }
     for (WorkerThread workerThread : threads) {
       workerThread.terminate();
     }
     // shutdown executorService gracefully
-    if (executorService != null) {
-      shutdownAndAwaitTermination(executorService);
+    if (watcherService != null) {
+      stopWatcher(watcherService);
     }
     // tell one of the threads to log its metrics;
     // the output should be the same for any thread;
@@ -158,18 +135,33 @@ public class WorkerPool {
     return numWorkers;
   }
 
-  private ScheduledExecutorService startTimer(List<Worker> workers, int maxProcessingSecs, String name) {
+  private ScheduledExecutorService startWatcher(List<Worker> workers, int maxProcessingSecs) {
     TimerTask watcher = new TimerTask() {
+
+      private final MetricRegistry metrics = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
+      private final com.codahale.metrics.Timer timer = metrics.timer(metricsPrefix + Worker.METRICS_SUFFIX);
+      private Instant lastLogInstant = null;
+
       @Override
       public void run() {
-        if (enableHeartbeat) {
-          heartbeatLog.info("Issuing heartbeat");
-          if (heartbeatLog.isDebugEnabled()) {
-            heartbeatLog.debug("Thread Dump:\n{}",
-                Arrays.toString(
-                    ManagementFactory.getThreadMXBean().dumpAllThreads(true, true)));
+        // log statistics about pipeline rate and latency
+        if (lastLogInstant==null || Duration.between(lastLogInstant, Instant.now()).getSeconds() >= logSeconds) {
+          lastLogInstant = Instant.now();
+          log.info(String.format("%d docs processed. One minute rate: %.2f docs/sec. Mean pipeline latency: %.2f ms/doc.",
+              timer.getCount(), timer.getOneMinuteRate(), timer.getSnapshot().getMean() / 1000000));
+
+          // write message to heartbeat log
+          if (enableHeartbeat) {
+            heartbeatLog.info("Issuing heartbeat");
+            if (heartbeatLog.isDebugEnabled()) {
+              heartbeatLog.debug("Thread Dump:\n{}",
+                  Arrays.toString(
+                      ManagementFactory.getThreadMXBean().dumpAllThreads(true, true)));
+            }
           }
         }
+
+        // look for workers that might be "stuck"
         for (Worker worker : workers) {
           if (Duration.between(worker.getPreviousPollInstant().get(), Instant.now()).getSeconds() > maxProcessingSecs) {
             log.error("Worker has not polled in " + maxProcessingSecs + " seconds.");
@@ -184,26 +176,26 @@ public class WorkerPool {
 
     // creating a thread factory for executor to use
     BasicThreadFactory factory = new BasicThreadFactory.Builder()
-        .namingPattern(name + "-" + "ExecutorService")
+        .namingPattern(ThreadNameUtils.createName("WorkerWatcherExecutorService"))
         .daemon(true)
         .priority(Thread.NORM_PRIORITY)
         .build();
 
     ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(factory);
-    long delay = 1000L;
-    executor.scheduleAtFixedRate(watcher, delay, period, TimeUnit.MILLISECONDS);
+    executor.scheduleAtFixedRate(watcher, 1, WATCHER_PERIOD_SECONDS, TimeUnit.SECONDS);
     return executor;
   }
 
-  private void shutdownAndAwaitTermination(ExecutorService executorService) {
+  private void stopWatcher(ExecutorService executorService) {
     executorService.shutdown(); // disable new tasks from being submitted
     try {
       // wait a while for existing tasks to terminate
       if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
         executorService.shutdownNow(); // Cancel currently executing tasks
         // wait a while for tasks to respond to being cancelled
-        if (!executorService.awaitTermination(60, TimeUnit.SECONDS))
-          System.err.println("Pool did not terminate");
+        if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+          log.error("Worker watcher did not terminate.");
+        }
       }
     } catch (InterruptedException ex) {
       // cancel if current thread also interrupted

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
@@ -23,107 +23,22 @@ import java.util.TimerTask;
 public class WorkerThread extends Thread {
 
   private final Worker worker;
-  private ScheduledExecutorService executorService;
-  private static final Logger log = LoggerFactory.getLogger(Worker.class);
-
-  public static final String HEARTBEAT_LOG_NAME = "com.kmwllc.lucille.core.Heartbeat";
-  private static final Logger heartbeatLog = LoggerFactory.getLogger(HEARTBEAT_LOG_NAME);
-
-  private boolean enableHeartbeat;
-  private int period;
-  private int maxProcessingSecs;
-  private boolean exitOnTimeout;
-  private final String name;
 
   public WorkerThread(Worker worker, Config config, String name) {
     this.worker = worker;
-    this.name = name;
     this.setName(name);
-    this.enableHeartbeat = config.hasPath("worker.heartbeat") ? config.getBoolean("worker.heartbeat") : false;
-    this.period = config.hasPath("worker.period") ? config.getInt("worker.period") : 1000;
-    // maxProcessingSecs default should be at least 10 minutes
-    this.maxProcessingSecs =
-        config.hasPath("worker.maxProcessingSecs") ? config.getInt("worker.maxProcessingSecs") : 10 * 60 * 1000;
-    this.exitOnTimeout = config.hasPath("worker.exitOnTimeout") ? config.getBoolean("worker.exitOnTimeout") : false;
   }
 
   @Override
   public void run() {
-    executorService = startTimer(worker, maxProcessingSecs);
-    log.info("started executorService");
     worker.run();
-
-    // Block of code below if error has occurred elsewhere where terminate is executed but run() continues to execute
-    if (worker.isTerminated() && !executorService.isShutdown() && !executorService.isTerminated()) {
-      log.info("Shutting down executorService");
-      shutdownAndAwaitTermination(executorService);
-    }
   }
 
   public void terminate() {
-    if (executorService != null) {
-      log.info("Terminating timer in thread {}", this.getName());
-      shutdownAndAwaitTermination(executorService);
-      log.info("Terminated timer in thread {}", this.getName());
-    }
     worker.terminate();
-  }
-
-  public void shutdownAndAwaitTermination(ExecutorService pool) {
-    pool.shutdown(); // Disable new tasks from being submitted
-    try {
-      // Wait a while for existing tasks to terminate
-      if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
-        pool.shutdownNow(); // Cancel currently executing tasks
-        // Wait a while for tasks to respond to being cancelled
-        if (!pool.awaitTermination(60, TimeUnit.SECONDS))
-          System.err.println("Pool did not terminate");
-      }
-    } catch (InterruptedException ex) {
-      // (Re-)Cancel if current thread also interrupted
-      pool.shutdownNow();
-      // Preserve interrupt status
-      Thread.currentThread().interrupt();
-    }
   }
 
   public void logMetrics() {
     worker.logMetrics();
-  }
-
-  private ScheduledExecutorService startTimer(Worker worker, int maxProcessingSecs) {
-
-    TimerTask watcher = new TimerTask() {
-      @Override
-      public void run() {
-        if (enableHeartbeat) {
-          heartbeatLog.info("Issuing heartbeat");
-          if (heartbeatLog.isDebugEnabled()) {
-            heartbeatLog.debug("Thread Dump:\n{}",
-                Arrays.toString(
-                    ManagementFactory.getThreadMXBean().dumpAllThreads(true, true)));
-          }
-        }
-        if (Duration.between(worker.getPreviousPollInstant().get(), Instant.now()).getSeconds() > maxProcessingSecs) {
-          log.error("Worker has not polled in " + maxProcessingSecs + " seconds.");
-          if (exitOnTimeout) {
-            log.error("Shutting down because maximum allowed time between previous poll is exceeded.");
-            System.exit(1);
-          }
-        }
-      }
-    };
-
-    // creating a thread factory for executor to use
-    BasicThreadFactory factory = new BasicThreadFactory.Builder()
-        .namingPattern(name + "-" + "ExecutorService")
-        .daemon(true)
-        .priority(Thread.NORM_PRIORITY)
-        .build();
-
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(factory);
-    long delay = 1000L;
-    executor.scheduleAtFixedRate(watcher, delay, period, TimeUnit.MILLISECONDS);
-    return executor;
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
@@ -54,27 +54,15 @@ public class WorkerThread extends Thread {
     }
     executorService = startTimer(worker, maxProcessingSecs);
     log.info("started executorService");
-    try {
-      worker.run();
-    } finally {
-      if (executorService != null) {
-        try {
-          executorService.awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-          log.warn("interrupted while waiting for executor service to terminate");
-        }
-      }
-    }
+    worker.run();
   }
 
   public void terminate() {
-    /*
     if (executorService != null) {
       log.info("Terminating timer in thread {}", this.getName());
       shutdownAndAwaitTermination(executorService);
       log.info("Terminated timer in thread {}", this.getName());
     }
-     */
     worker.terminate();
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
@@ -49,12 +49,15 @@ public class WorkerThread extends Thread {
 
   @Override
   public void run() {
-    if (worker.isTerminated()) {
-      return;
-    }
     executorService = startTimer(worker, maxProcessingSecs);
     log.info("started executorService");
     worker.run();
+
+    // Block of code below if error has occurred elsewhere where terminate is executed but run() continues to execute
+    if (worker.isTerminated() && !executorService.isShutdown() && !executorService.isTerminated()) {
+      log.info("Shutting down executorService");
+      shutdownAndAwaitTermination(executorService);
+    }
   }
 
   public void terminate() {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
@@ -1,30 +1,10 @@
 package com.kmwllc.lucille.core;
 
-
-import com.kmwllc.lucille.util.ThreadNameUtils;
-import com.typesafe.config.Config;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.concurrent.BasicThreadFactory;
-import org.apache.solr.common.util.ExecutorUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.management.ManagementFactory;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.Timer;
-import java.util.TimerTask;
-
 public class WorkerThread extends Thread {
 
   private final Worker worker;
 
-  public WorkerThread(Worker worker, Config config, String name) {
+  public WorkerThread(Worker worker, String name) {
     this.worker = worker;
     this.setName(name);
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerThread.java
@@ -1,6 +1,15 @@
 package com.kmwllc.lucille.core;
 
+
+import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.apache.solr.common.util.ExecutorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +23,7 @@ import java.util.TimerTask;
 public class WorkerThread extends Thread {
 
   private final Worker worker;
-  private Timer timer;
+  private ScheduledExecutorService executorService;
   private static final Logger log = LoggerFactory.getLogger(Worker.class);
 
   public static final String HEARTBEAT_LOG_NAME = "com.kmwllc.lucille.core.Heartbeat";
@@ -24,9 +33,12 @@ public class WorkerThread extends Thread {
   private int period;
   private int maxProcessingSecs;
   private boolean exitOnTimeout;
+  private final String name;
 
-  public WorkerThread(Worker worker, Config config) {
+  public WorkerThread(Worker worker, Config config, String name) {
     this.worker = worker;
+    this.name = name;
+    this.setName(name);
     this.enableHeartbeat = config.hasPath("worker.heartbeat") ? config.getBoolean("worker.heartbeat") : false;
     this.period = config.hasPath("worker.period") ? config.getInt("worker.period") : 1000;
     // maxProcessingSecs default should be at least 10 minutes
@@ -37,22 +49,58 @@ public class WorkerThread extends Thread {
 
   @Override
   public void run() {
-    timer = startTimer(worker, maxProcessingSecs);
-    worker.run();
+    if (worker.isTerminated()) {
+      return;
+    }
+    executorService = startTimer(worker, maxProcessingSecs);
+    log.info("started executorService");
+    try {
+      worker.run();
+    } finally {
+      if (executorService != null) {
+        try {
+          executorService.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          log.warn("interrupted while waiting for executor service to terminate");
+        }
+      }
+    }
   }
 
   public void terminate() {
-    if (timer != null) {
-      timer.cancel();
+    /*
+    if (executorService != null) {
+      log.info("Terminating timer in thread {}", this.getName());
+      shutdownAndAwaitTermination(executorService);
+      log.info("Terminated timer in thread {}", this.getName());
     }
+     */
     worker.terminate();
+  }
+
+  public void shutdownAndAwaitTermination(ExecutorService pool) {
+    pool.shutdown(); // Disable new tasks from being submitted
+    try {
+      // Wait a while for existing tasks to terminate
+      if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+        pool.shutdownNow(); // Cancel currently executing tasks
+        // Wait a while for tasks to respond to being cancelled
+        if (!pool.awaitTermination(60, TimeUnit.SECONDS))
+          System.err.println("Pool did not terminate");
+      }
+    } catch (InterruptedException ex) {
+      // (Re-)Cancel if current thread also interrupted
+      pool.shutdownNow();
+      // Preserve interrupt status
+      Thread.currentThread().interrupt();
+    }
   }
 
   public void logMetrics() {
     worker.logMetrics();
   }
 
-  private Timer startTimer(Worker worker, int maxProcessingSecs) {
+  private ScheduledExecutorService startTimer(Worker worker, int maxProcessingSecs) {
 
     TimerTask watcher = new TimerTask() {
       @Override
@@ -75,9 +123,16 @@ public class WorkerThread extends Thread {
       }
     };
 
-    Timer timer = new Timer("Timer");
+    // creating a thread factory for executor to use
+    BasicThreadFactory factory = new BasicThreadFactory.Builder()
+        .namingPattern(name + "-" + "ExecutorService")
+        .daemon(true)
+        .priority(Thread.NORM_PRIORITY)
+        .build();
+
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(factory);
     long delay = 1000L;
-    timer.scheduleAtFixedRate(watcher, delay, period);
-    return timer;
+    executor.scheduleAtFixedRate(watcher, delay, period, TimeUnit.MILLISECONDS);
+    return executor;
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
@@ -1,0 +1,10 @@
+package com.kmwllc.lucille.util;
+
+public class ThreadNameUtils {
+  public static final String THREAD_NAME_PREFIX = "Lucille";
+
+
+  public static String getThreadName(String name) {
+    return THREAD_NAME_PREFIX + "-" + name;
+  }
+}

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
@@ -4,7 +4,7 @@ public class ThreadNameUtils {
   public static final String THREAD_NAME_PREFIX = "Lucille";
 
 
-  public static String setThreadPrefix(String name) {
+  public static String createName(String name) {
     return THREAD_NAME_PREFIX + "-" + name;
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
@@ -4,7 +4,9 @@ public class ThreadNameUtils {
   public static final String THREAD_NAME_PREFIX = "Lucille";
 
 
-  public static String getThreadName(String name) {
+  public static String setThreadPrefix(String name) {
     return THREAD_NAME_PREFIX + "-" + name;
   }
+
+  public static boolean isLucilleThread(Thread thread) {return thread.getName().startsWith(THREAD_NAME_PREFIX);}
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
@@ -1,5 +1,8 @@
 package com.kmwllc.lucille.util;
 
+import java.util.Collection;
+import org.apache.commons.lang3.ThreadUtils;
+
 public class ThreadNameUtils {
   public static final String THREAD_NAME_PREFIX = "Lucille";
 
@@ -9,4 +12,16 @@ public class ThreadNameUtils {
   }
 
   public static boolean isLucilleThread(Thread thread) {return thread.getName().startsWith(THREAD_NAME_PREFIX);}
+
+  public static boolean hasRunningLucilleThread() {
+    Collection<Thread> nonSystemThreads =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+
+    for (Thread thread : nonSystemThreads) {
+      if (isLucilleThread(thread)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
@@ -13,7 +13,7 @@ public class ThreadNameUtils {
 
   public static boolean isLucilleThread(Thread thread) {return thread.getName().startsWith(THREAD_NAME_PREFIX);}
 
-  public static boolean hasRunningLucilleThread() {
+  public static boolean areLucilleThreadsRunning() {
     Collection<Thread> nonSystemThreads =
         ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
@@ -65,7 +65,7 @@ public class HeartbeatTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testWatcher AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         log.info("testWatcher failed here");
       }
     }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
@@ -57,18 +57,6 @@ public class HeartbeatTest {
 
     String lastLine = lines.skip(currentLineCount - 1).findFirst().get();
     assertTrue(lastLine.contains("INFO Heartbeat: Issuing heartbeat"));
-
-    //Thread.sleep(1000);
-
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      log.info("THREAD testWatcher AFTER: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        log.info("testWatcher failed here");
-      }
-    }
   }
 
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
@@ -2,25 +2,17 @@ package com.kmwllc.lucille.core;
 
 import com.kmwllc.lucille.message.LocalMessenger;
 import com.kmwllc.lucille.message.WorkerMessengerFactory;
-import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.util.Collection;
-import org.apache.commons.lang3.ThreadUtils;
 import org.junit.Test;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class HeartbeatTest {
-
-  private static final Logger log = LoggerFactory.getLogger(HeartbeatTest.class);
 
   @Test
   public void testWatcher() throws Exception {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
@@ -21,8 +21,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,7 +28,6 @@ import static org.mockito.Mockito.*;
 
 @RunWith(JUnit4.class)
 public class RunnerTest {
-  private static final Logger log = LoggerFactory.getLogger(RunnerTest.class);
   @Test
   public void testRunnerWithNoDocs() throws Exception {
     // we should be able to run a connector that generates no documents

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
@@ -10,10 +10,8 @@ import com.kmwllc.lucille.connector.RunSummaryMessageConnector;
 import com.kmwllc.lucille.message.TestMessenger;
 import com.kmwllc.lucille.stage.StartStopCaptureStage;
 import com.kmwllc.lucille.util.LogUtils;
-import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import org.apache.commons.lang3.ThreadUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -681,38 +679,15 @@ public class RunnerTest {
     RunResult result =
         Runner.run(ConfigFactory.load("RunnerTest/pipelineNotFound.conf"), Runner.RunType.TEST);
     assertFalse(result.getStatus());
-
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      log.info("THREAD testConnectorWithUnrecognizedPipeline AFTER: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
   }
 
   @Test
   public void testStartStopCalledOnPipelineStages() throws Exception {
-    Collection<Thread> nonSystemThreadsBefore =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-
     StartStopCaptureStage.reset();
     Runner.runInTestMode("RunnerTest/stageStartStop.conf");
     assertTrue(StartStopCaptureStage.startCalled);
     assertTrue(StartStopCaptureStage.stopCalled);
     StartStopCaptureStage.reset();
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      log.info("THREAD testStartStopCalledOnPipelineStages AFTER: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
   }
 
 
@@ -763,45 +738,13 @@ public class RunnerTest {
     // handle the failure
     assertFalse(Runner.run(ConfigFactory.load("RunnerTest/indexerConnectFailure.conf"),
         Runner.RunType.LOCAL).getStatus());
-
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      log.info("THREAD testIndexerConnectFailure AFTER: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
   }
 
   @Test
   public void testIndexerDeleteByFieldConfig() throws Exception {
-
-    Collection<Thread> nonSystemThreadsBefore =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsBefore) {
-      log.info("THREAD testIndexerDeleteByFieldConfig BEFORE: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
-
     assertFalse(Runner.run(ConfigFactory.load("RunnerTest/indexerDeleteByFieldInvalid1.conf"), Runner.RunType.LOCAL).getStatus());
     assertFalse(Runner.run(ConfigFactory.load("RunnerTest/indexerDeleteByFieldInvalid2.conf"), Runner.RunType.LOCAL).getStatus());
-
     assertTrue(Runner.run(ConfigFactory.load("RunnerTest/indexerDeleteByFieldValid.conf"), Runner.RunType.LOCAL).getStatus());
-
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      log.info("THREAD run3 AFTER: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
   }
 
   @Test
@@ -809,16 +752,6 @@ public class RunnerTest {
     assertFalse(Runner.run(ConfigFactory.load("RunnerTest/indexerDeleteInvalid1.conf"), Runner.RunType.LOCAL).getStatus());
     assertFalse(Runner.run(ConfigFactory.load("RunnerTest/indexerDeleteInvalid2.conf"), Runner.RunType.LOCAL).getStatus());
     assertTrue(Runner.run(ConfigFactory.load("RunnerTest/indexerDeleteValid.conf"), Runner.RunType.LOCAL).getStatus());
-
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      log.info("THREAD testIndexerDeleteMarkerConfig AFTER: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
@@ -687,7 +687,7 @@ public class RunnerTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testConnectorWithUnrecognizedPipeline AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }
     }
@@ -709,7 +709,7 @@ public class RunnerTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testStartStopCalledOnPipelineStages AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }
     }
@@ -769,7 +769,7 @@ public class RunnerTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testIndexerConnectFailure AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }
     }
@@ -783,7 +783,7 @@ public class RunnerTest {
 
     for (Thread thread : nonSystemThreadsBefore) {
       log.info("THREAD testIndexerDeleteByFieldConfig BEFORE: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }
     }
@@ -798,7 +798,7 @@ public class RunnerTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD run3 AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }
     }
@@ -815,7 +815,7 @@ public class RunnerTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testIndexerDeleteMarkerConfig AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }
     }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
@@ -3,7 +3,9 @@ package com.kmwllc.lucille.core;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
+import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Collection;
@@ -11,6 +13,8 @@ import org.apache.commons.lang3.ThreadUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests WorkerIndexerPool.
@@ -20,6 +24,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class WorkerIndexerPoolTest {
+  private static final Logger log = LoggerFactory.getLogger(WorkerIndexerPoolTest.class);
 
   @Test
   public void testParseConfig() throws Exception {
@@ -42,6 +47,13 @@ public class WorkerIndexerPoolTest {
     Collection<Thread> nonSystemThreadsBefore =
         ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
 
+    for (Thread thread : nonSystemThreadsBefore) {
+      log.info("THREAD testThreadCleanupUponEncounteringConfigProblem BEFORE: {}", thread.getName());
+      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+        fail("Lucille threads are running before run has started");
+      }
+    }
+
     // simulate a config error by passing an empty config to WorkerIndexerPool
     Config config = ConfigFactory.empty();
     WorkerIndexerPool pool = new WorkerIndexerPool(config, "pipeline12345", true, null);
@@ -50,7 +62,13 @@ public class WorkerIndexerPoolTest {
 
     Collection<Thread> nonSystemThreadsAfter =
         ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-    assertArrayEquals(nonSystemThreadsBefore.toArray(), nonSystemThreadsAfter.toArray());
+
+    for (Thread thread : nonSystemThreadsAfter) {
+      log.info("THREAD testThreadCleanupUponEncounteringConfigProblem AFTER: {}", thread.getName());
+      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+        fail("Lucille threads are still running");
+      }
+    }
   }
 
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.core;
 
-import static com.kmwllc.lucille.util.ThreadNameUtils.hasRunningLucilleThread;
+import static com.kmwllc.lucille.util.ThreadNameUtils.areLucilleThreadsRunning;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -45,7 +45,7 @@ public class WorkerIndexerPoolTest {
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
-    assertFalse(hasRunningLucilleThread());
+    assertFalse(areLucilleThreadsRunning());
   }
 
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
@@ -1,19 +1,16 @@
 package com.kmwllc.lucille.core;
 
+import static com.kmwllc.lucille.util.ThreadNameUtils.hasRunningLucilleThread;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
-import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.util.Collection;
-import org.apache.commons.lang3.ThreadUtils;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests WorkerIndexerPool.
@@ -48,14 +45,7 @@ public class WorkerIndexerPoolTest {
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
+    assertFalse(hasRunningLucilleThread());
   }
 
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
@@ -44,16 +44,6 @@ public class WorkerIndexerPoolTest {
 
   @Test
   public void testThreadCleanupUponEncounteringConfigProblem() throws Exception {
-    Collection<Thread> nonSystemThreadsBefore =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsBefore) {
-      log.info("THREAD testThreadCleanupUponEncounteringConfigProblem BEFORE: {}", thread.getName());
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are running before run has started");
-      }
-    }
-
     // simulate a config error by passing an empty config to WorkerIndexerPool
     Config config = ConfigFactory.empty();
     WorkerIndexerPool pool = new WorkerIndexerPool(config, "pipeline12345", true, null);
@@ -64,7 +54,6 @@ public class WorkerIndexerPoolTest {
         ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
 
     for (Thread thread : nonSystemThreadsAfter) {
-      log.info("THREAD testThreadCleanupUponEncounteringConfigProblem AFTER: {}", thread.getName());
       if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
@@ -49,7 +49,7 @@ public class WorkerIndexerPoolTest {
 
     for (Thread thread : nonSystemThreadsBefore) {
       log.info("THREAD testThreadCleanupUponEncounteringConfigProblem BEFORE: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are running before run has started");
       }
     }
@@ -65,7 +65,7 @@ public class WorkerIndexerPoolTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testThreadCleanupUponEncounteringConfigProblem AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are still running");
       }
     }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerIndexerPoolTest.java
@@ -1,6 +1,5 @@
 package com.kmwllc.lucille.core;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -24,7 +23,6 @@ import org.slf4j.LoggerFactory;
  */
 @RunWith(JUnit4.class)
 public class WorkerIndexerPoolTest {
-  private static final Logger log = LoggerFactory.getLogger(WorkerIndexerPoolTest.class);
 
   @Test
   public void testParseConfig() throws Exception {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-import static com.kmwllc.lucille.util.ThreadNameUtils.hasRunningLucilleThread;
+import static com.kmwllc.lucille.util.ThreadNameUtils.areLucilleThreadsRunning;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -73,7 +73,7 @@ public class WorkerPoolTest {
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
-    assertFalse(hasRunningLucilleThread());
+    assertFalse(areLucilleThreadsRunning());
   }
 
   @Test
@@ -83,6 +83,6 @@ public class WorkerPoolTest {
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
-    assertFalse(hasRunningLucilleThread());
+    assertFalse(areLucilleThreadsRunning());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -36,7 +36,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsBefore) {
       log.info("THREAD testParseConfig BEFORE: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         log.info("testParseConfig failed here");
       }
     }
@@ -68,7 +68,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testParseConfig AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         log.info("testParseConfig failed here");
       }
     }
@@ -88,7 +88,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsBefore) {
       log.info("THREAD testManagerClose BEFORE: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         log.info("testManagerClose failed here");
       }
     }
@@ -108,7 +108,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testManagerClose AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         log.info("testManagerClose failed here");
       }
     }
@@ -121,7 +121,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsBefore) {
       log.info("THREAD testThreadCleanupUponEncounteringConfigProblem BEFORE: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are running before run has started");
       }
     }
@@ -139,7 +139,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testThreadCleanupUponEncounteringConfigProblem AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         log.info("testThreadCleanupUponEncounteringConfigProblem failed here");
         fail("Lucille threads are still running");
       }
@@ -153,7 +153,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsBefore) {
       log.info("THREAD testThreadCleanupUponEncounteringNullMessenger BEFORE: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         fail("Lucille threads are running before run has started");
       }
     }
@@ -169,7 +169,7 @@ public class WorkerPoolTest {
 
     for (Thread thread : nonSystemThreadsAfter) {
       log.info("THREAD testThreadCleanupUponEncounteringNullMessenger AFTER: {}", thread.getName());
-      if (thread.getName().startsWith(ThreadNameUtils.THREAD_NAME_PREFIX)) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
         log.info("testThreadCleanupUponEncounteringNullMessenger failed here");
         fail("Lucille threads are still running");
       }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -83,6 +83,14 @@ public class WorkerPoolTest {
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
+    Collection<Thread> nonSystemThreadsAfter =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+
+    for (Thread thread : nonSystemThreadsAfter) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
+        fail("Lucille threads are still running");
+      }
+    }
   }
 
   @Test
@@ -92,5 +100,14 @@ public class WorkerPoolTest {
     WorkerPool pool = new WorkerPool(config, "pipeline1", null, "");
 
     assertThrows(Exception.class, () -> { pool.start(); });
+
+    Collection<Thread> nonSystemThreadsAfter =
+        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
+
+    for (Thread thread : nonSystemThreadsAfter) {
+      if (ThreadNameUtils.isLucilleThread(thread)) {
+        fail("Lucille threads are still running");
+      }
+    }
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -2,19 +2,17 @@ package com.kmwllc.lucille.core;
 
 import com.kmwllc.lucille.message.TestMessenger;
 import com.kmwllc.lucille.message.WorkerMessengerFactory;
-import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.util.Collection;
-import org.apache.commons.lang3.ThreadUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
+import static com.kmwllc.lucille.util.ThreadNameUtils.hasRunningLucilleThread;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -75,14 +73,7 @@ public class WorkerPoolTest {
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
+    assertFalse(hasRunningLucilleThread());
   }
 
   @Test
@@ -92,13 +83,6 @@ public class WorkerPoolTest {
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
-    Collection<Thread> nonSystemThreadsAfter =
-        ThreadUtils.findThreads(t -> !ThreadUtils.getSystemThreadGroup().equals(t.getThreadGroup()));
-
-    for (Thread thread : nonSystemThreadsAfter) {
-      if (ThreadNameUtils.isLucilleThread(thread)) {
-        fail("Lucille threads are still running");
-      }
-    }
+    assertFalse(hasRunningLucilleThread());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -6,17 +6,12 @@ import com.kmwllc.lucille.util.ThreadNameUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
 import org.apache.commons.lang3.ThreadUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -25,8 +20,6 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(JUnit4.class)
 public class WorkerPoolTest {
-
-  private static final Logger log = LoggerFactory.getLogger(WorkerPoolTest.class);
 
   @Test
   public void testParseConfig() throws Exception {
@@ -61,7 +54,6 @@ public class WorkerPoolTest {
    */
   @Test
   public void testManagerClose() throws Exception {
-
     TestMessenger messenger = Mockito.spy(new TestMessenger());
     WorkerMessengerFactory factory = WorkerMessengerFactory.getConstantFactory(messenger);
     WorkerPool pool = new WorkerPool(ConfigFactory.load("WorkerPoolTest/onePipeline.conf"),
@@ -95,7 +87,6 @@ public class WorkerPoolTest {
 
   @Test
   public void testThreadCleanupUponEncounteringNullMessenger() throws Exception {
-
     Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
     WorkerPool pool = new WorkerPool(config, "pipeline1", null, "");
 

--- a/lucille-core/src/test/resources/WorkerPoolTest/watcher.conf
+++ b/lucille-core/src/test/resources/WorkerPoolTest/watcher.conf
@@ -4,7 +4,11 @@ pipelines: [{name: "pipeline1", stages: []},
 
 worker {
   threads: 1,
-  heartbeat: true,
+  enableHeartbeat: true,
   exitOnTimeout: false,
   maxProcessingSecs: 1
+}
+
+log {
+  seconds:5
 }


### PR DESCRIPTION
- created ThreadNameUtils class for naming/catching Lucille threads
    - all Lucille threads are now created with prefix “Lucille”
- unified logTimer and heartbeat logs to a single Timer thread, which is scheduled using a executorService to watch every 5 seconds
    - each time workerPool logs, a heartbeat is also logged.