### PR TITLE
LC-544 - Upgrade junit 4.13 to 4.13.2

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -269,6 +269,13 @@
       <artifactId>kafka-junit</artifactId>
       <version>3.6.0</version>
       <scope>test</scope>
+      <!-- Bug junit 5.6.2 that doesn't support junit 4.13.2 (only 4.12 and 4.13) -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!--  test dependency for db connector tests -->

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -269,7 +269,7 @@
       <artifactId>kafka-junit</artifactId>
       <version>3.6.0</version>
       <scope>test</scope>
-      <!-- Bug junit 5.6.2 that doesn't support junit 4.13.2 (only 4.12 and 4.13) -->
+      <!-- Bug in junit 5.6.2 that doesn't support junit 4.13.2 (only 4.12 and 4.13) -->
       <exclusions>
         <exclusion>
           <groupId>org.junit.jupiter</groupId>

--- a/lucille-examples/lucille-distributed-example/pom.xml
+++ b/lucille-examples/lucille-distributed-example/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13</version>
+      <version>${junit4.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/lucille-examples/lucille-opensearch-ingest-example/pom.xml
+++ b/lucille-examples/lucille-opensearch-ingest-example/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13</version>
+      <version>${junit4.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -65,6 +65,7 @@
     <grpc.version>1.53.0</grpc.version>
     <dropwizard-core.version>4.0.7</dropwizard-core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit4.version>4.13.2</junit4.version>
 
   </properties>
 
@@ -169,19 +170,17 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13</version>
+      <version>${junit4.version}</version>
       <scope>test</scope>
     </dependency>
 
-
-
-    <!-- uncomment to enable Junit 5; can coexist with Junit 4 -->
-    <!--dependency>
+    <!-- enabling Junit 5 because of bug with inherited version 5.6.2 in lucille-core with 'net.mguenther.kafka', overriding here -->
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.8.1</version>
+      <version>5.11.0</version>
       <scope>test</scope>
-    </dependency-->
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
There is a vulnerability with junit 4.13: [CVE -CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)
We are upgrading to junit 4.13.2 to fix this and it includes need for upgrading junit 5 because bug in junit 5.6.2 that doesn't support junit 4.13.2 (only 4.12 and 4.13).