### PR TITLE
LC-467: downgrade opennlp tools

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -309,7 +309,7 @@
     <dependency>
       <groupId>org.apache.opennlp</groupId>
       <artifactId>opennlp-tools</artifactId>
-      <version>2.4.0</version>
+      <version>2.2.0</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
current opennlp tools dependency for ChunkText stage was compiled in Java 17 while Lucille is compiled in Java 11, which only threw errors in the process of merging to main. Downgrading version of opennlp tools to 2.2.0, where it was compiled with Java 11.

opennlp-tools v2.3.0 raises minimum java version to 17 -> https://opennlp.apache.org/news/release-230.html