### PR TITLE
LC-557: investigate bug causing publishing failures

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/QueryDatabase.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/QueryDatabase.java
@@ -154,6 +154,7 @@ public class QueryDatabase extends Stage {
     for (int attempt = 0; attempt <= connectionRetries; attempt++) {
       try {
         connection = DriverManager.getConnection(connectionString, jdbcUser, jdbcPassword);
+        break;
       } catch (SQLException e) {
         if (attempt == connectionRetries) {
           log.error("Unable to connect to database {} user:{} after retrying {} time(s).", connectionString, jdbcUser, attempt);


### PR DESCRIPTION
Noticed that publishing process would fail when trying to merge PRs to main, even though the PRs themselves pass the build process. Went through the logs and found that DatabaseConnectorTests in publishing process is failing due to detecting more than one session to the test database. Found out that Stage QueryDatabase tests were not explicitly closing connection. Found out that QueryDatabaseTests ran first before DatabaseConnectorTests ran in publishing process, while the DatabaseConnectorTests ran before QueryDatabaseTest in the building process, which explains why one was passing while the other was failing. Also found out that QueryDatabase was creating unnecessary connections.

Things changed:
- fix QueryDatabase to break out of connection retry loop once a single connection has been established
- close connections to database in tests where connection was made
- add assertions to tests to make sure only a single session is taken place