### PR TITLE
LC-568: revert github action in publishing workflow for debugging

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -7,10 +7,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           java-version: |
             21

--- a/.github/workflows/release-to-sonatype.yml
+++ b/.github/workflows/release-to-sonatype.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - run: echo "Release version ${{ env.release }}!"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           java-version: |
             21


### PR DESCRIPTION
This PR is created due to a previous error that occured during publishing after a few changes in the workflow files. While the failed workflow gave error about authentication, we want to make sure it did not stem from the changes that we made to the workflow file. This PR is to investigate if we would get the same errors by reverting some (not all) of the changes that happened since the last pass of the workflow run