### PR TITLE
LC-582/LC-583 improve AddRandomFields stage

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
@@ -142,7 +142,7 @@ public class AddRandomField extends Stage {
   private static List<String> getRandomIntegerStringList(int length, int rangeSize) {
     List<String> result = new ArrayList();
     for (int i = 0; i < length; i++) {
-      result.add(String.valueOf(ThreadLocalRandom.current().nextInt(0, rangeSize + 1)));
+      result.add(String.valueOf(ThreadLocalRandom.current().nextInt(0, rangeSize)));
     }
     return result;
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
@@ -85,6 +85,9 @@ public class AddRandomField extends Stage {
     if (inputDataPath == null && rangeSize == null) {
       throw new StageException("range_size must be specified if there is no input_data_path");
     }
+    if (concatenate && isNested) {
+      throw new StageException("concatenate=true is not currently supported when is_nested=true");
+    }
   }
 
   @Override
@@ -115,6 +118,7 @@ public class AddRandomField extends Stage {
 
     if (isNested) {
       ArrayNode array = MAPPER.createArrayNode();
+      // TODO: concatenate option not yet supported with nested mode; need tests for nested mode
       for (String value : data) {
         array.add(MAPPER.createObjectNode().put("data", value));
       }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
@@ -6,18 +6,14 @@ import com.kmwllc.lucille.core.ConfigUtils;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
-import com.kmwllc.lucille.util.FileUtils;
 import com.typesafe.config.Config;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -58,15 +54,17 @@ public class AddRandomField extends Stage {
   private final boolean isNested;
   private List<String> dataArr;
   private List<String> uniqueValues;
+  private final boolean concatenate;
 
   public AddRandomField(Config config) throws StageException {
     super(config, new StageSpec().withOptionalProperties("input_data_path", "field_name", "range_size", "min_num_of_terms",
-        "max_num_of_terms", "is_nested"));
+        "max_num_of_terms", "is_nested", "concatenate"));
     this.inputDataPath = ConfigUtils.getOrDefault(config, "input_data_path", null);
     this.fieldName = ConfigUtils.getOrDefault(config, "field_name", "data");
     this.minNumOfTerms = ConfigUtils.getOrDefault(config, "min_num_of_terms", null);
     this.maxNumOfTerms = ConfigUtils.getOrDefault(config, "max_num_of_terms", null);
     this.isNested = ConfigUtils.getOrDefault(config, "is_nested", false);
+    this.concatenate = ConfigUtils.getOrDefault(config, "concatenate", false);
     this.dataArr = null;
     this.rangeSize = null;
     this.uniqueValues = null;
@@ -116,8 +114,12 @@ public class AddRandomField extends Stage {
   }
 
   private void populateFieldsDefault(String fieldName, Document doc, ArrayList<String> fieldDataArr) {
-    for (String value : fieldDataArr) {
-      doc.setOrAdd(fieldName, value);
+    if (concatenate) {
+      doc.setOrAdd(fieldName, String.join(" ", fieldDataArr));
+    } else {
+      for (String value : fieldDataArr) {
+        doc.setOrAdd(fieldName, value);
+      }
     }
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomField.java
@@ -91,13 +91,17 @@ public class AddRandomField extends Stage {
   public void start() throws StageException {
     fileData = (inputDataPath != null) ? getFileData(inputDataPath) : null;
 
-    if (fileData != null && rangeSize > fileData.size()) {
-      throw new StageException("Range size must be less than the number of lines in given file");
-    }
+    if (fileData != null && rangeSize != null) {
+        if (rangeSize > fileData.size()) {
+          throw new StageException("Range size must be less than the number of lines in given file");
+        }
 
-    if (fileData != null && rangeSize < fileData.size()) {
-      Collections.shuffle(fileData);
-      fileData = fileData.subList(0, rangeSize);
+        if (rangeSize < fileData.size()) {
+          // shuffle contents so when we truncate we're not always using the initial elements
+          // TODO: might be slow for large files, consider whether this is actually needed
+          Collections.shuffle(fileData);
+          fileData = fileData.subList(0, rangeSize);
+        }
     }
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/AddRandomFieldTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/AddRandomFieldTest.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.stage;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -45,6 +46,15 @@ public class AddRandomFieldTest {
     assertTrue(0 <= docVal3 && docVal3 < 20);
   }
 
+  @Test
+  public void testConcatenate() throws StageException {
+    Stage stage = factory.get("AddRandomFieldTest/concatenate.conf");
+    Document doc = Document.create("doc1");
+    stage.processDocument(doc);
+    assertFalse(doc.isMultiValued("data"));
+    assertEquals(10, doc.getString("data").split(" ").length);
+  }
+  
   /**
    * Tests stage with a basic file path
    *

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/AddRandomFieldTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/AddRandomFieldTest.java
@@ -8,11 +8,9 @@ import static org.junit.Assert.assertTrue;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import com.kmwllc.lucille.stage.StageFactory;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -54,7 +52,7 @@ public class AddRandomFieldTest {
     assertFalse(doc.isMultiValued("data"));
     assertEquals(10, doc.getString("data").split(" ").length);
   }
-  
+
   /**
    * Tests stage with a basic file path
    *

--- a/lucille-core/src/test/resources/AddRandomFieldTest/concatenate.conf
+++ b/lucille-core/src/test/resources/AddRandomFieldTest/concatenate.conf
@@ -1,0 +1,7 @@
+{
+  name = "AddRandomFieldTest",
+  class = "com.kmwllc.lucille.stage.AddRandomField",
+  min_num_of_terms = 10,
+  max_num_of_terms = 10,
+  concatenate = true
+}

--- a/lucille-core/src/test/resources/AddRandomFieldTest/concatenate.conf
+++ b/lucille-core/src/test/resources/AddRandomFieldTest/concatenate.conf
@@ -4,4 +4,5 @@
   min_num_of_terms = 10,
   max_num_of_terms = 10,
   concatenate = true
+  range_size = 100
 }

--- a/lucille-core/src/test/resources/AddRandomFieldTest/nofilepath.conf
+++ b/lucille-core/src/test/resources/AddRandomFieldTest/nofilepath.conf
@@ -2,5 +2,6 @@
   name = "AddRandomFieldTest",
   class = "com.kmwllc.lucille.stage.AddRandomField",
   min_num_of_terms = 1,
-  max_num_of_terms = 20
+  max_num_of_terms = 20,
+  range_size = 20
 }


### PR DESCRIPTION
This PR includes several improvements to the AddRandomFields stage:

1) a "concatenate" mode now allows for multiple random values to be set as a single space-separated string instead of as multiple field values. i.e. "14 34 323 54" vs. ["14", "34", "323", "54"]
2) when selecting random values from an integer range, the stage no longer generates a list of all integers in the range
3) when reading data from a file, the stage no longer attempts to uniquify the contents (which can be very time consuming for a large file)