### PR TITLE
LC-596 - adding a stage that can hash a field value to a specified set of buckets and put the bucket label in an output field.

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/HashFieldValueToBucket.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/HashFieldValueToBucket.java
@@ -1,0 +1,54 @@
+package com.kmwllc.lucille.stage;
+
+import java.util.Iterator;
+import java.util.List;
+
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Stage;
+import com.kmwllc.lucille.core.StageException;
+import com.typesafe.config.Config;
+
+/**
+ * This stage will use the java object hash code modulus the number of buckets as specified in the buckets parameter, 
+ * the resulting label will be placed in the dest field.
+ * 
+ * <br/>
+ * Config Parameters -
+ * <br/>
+ * <p>
+ * <b>field_name</b> (String, Required) : Field that will be used as the input for the hashing function.
+ * </p>
+ * <p>
+ * <b>dest</b> (String, Required) : Field that will contain the hash bucket label.
+ * </p>
+ * <p>
+ * <b>buckets</b> (List of String, Required) : list of buckets for the hash function.
+ * </p>
+ * 
+ */
+public class HashFieldValueToBucket extends Stage {
+
+  private final String fieldName;
+	private final List<String> buckets;
+	private final String destField;
+	private final int numBuckets;
+
+	public HashFieldValueToBucket(Config config) {
+		super(config, new StageSpec().withRequiredProperties("field_name", "dest", "buckets"));
+		this.fieldName = config.getString("field_name");
+		this.buckets = config.getStringList("buckets");
+		this.destField = config.getString("dest");
+		numBuckets = buckets.size();
+	}
+
+	@Override
+	public Iterator<Document> processDocument(Document doc) throws StageException {
+		int hashIndex = doc.getId().hashCode() % numBuckets;
+		if (hashIndex < 0) {
+			hashIndex = hashIndex * -1;
+		}
+		doc.setField(destField, buckets.get(hashIndex));
+		return null;
+	}
+
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/HashFieldValueToBucketTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/HashFieldValueToBucketTest.java
@@ -1,0 +1,24 @@
+package com.kmwllc.lucille.stage;
+
+import static org.junit.Assert.assertEquals;
+
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Stage;
+import com.kmwllc.lucille.core.StageException;
+import org.junit.Test;
+
+public class HashFieldValueToBucketTest {
+
+  private final StageFactory factory = StageFactory.of(HashFieldValueToBucket.class);
+
+  @Test
+  public void testHashDocIdStage() throws StageException {
+    // Validate that the value from the id field properly hashes to the bucket called "shard4" 
+    Stage stage = factory.get("HashFieldValueToBucketTest/hashdocid.conf");
+    Document doc = Document.create("id");
+    stage.processDocument(doc);
+    assertEquals("shard4", doc.getString("bucket"));
+    
+  }
+
+}

--- a/lucille-core/src/test/resources/HashFieldValueToBucketTest/hashdocid.conf
+++ b/lucille-core/src/test/resources/HashFieldValueToBucketTest/hashdocid.conf
@@ -1,0 +1,6 @@
+{
+  "class" : "com.kmwllc.lucille.stage.HashIdToRouteDoc"
+  "field_name" : "id"
+  "dest": "bucket"
+  "buckets" : ["shard1", "shard2", "shard3", "shard4"]
+}


### PR DESCRIPTION
the java hash code is used from the field value on the document.  the hash code will be modulus the length of the buckets property on the stage.  the resulting bucket label will be placed in the dest field.