### PR TITLE
LC-144: enhance FileConnector

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClient.java
@@ -87,7 +87,7 @@ public class AzureStorageClient extends BaseStorageClient {
   @Override
   public void traverse(Publisher publisher) throws Exception{
     containerClient.listBlobs(new ListBlobsOptions().setPrefix(startingDirectory).setMaxResultsPerPage(maxNumOfPages), Duration.ofSeconds(10)).stream()
-        .forEach(blob -> {
+        .forEachOrdered(blob -> {
           if (isValid(blob)) {
             String fullPathStr = getFullPath(blob);
             String fileExtension = FilenameUtils.getExtension(fullPathStr);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClient.java
@@ -74,7 +74,7 @@ public class LocalStorageClient extends BaseStorageClient {
 
   @Override
   public void traverse(Publisher publisher) throws Exception {
-    try (Stream<Path> paths = Files.walk(startingDirectoryPath)) {
+    try (Stream<Path> paths = Files.walk(startingDirectoryPath).sorted()) {
       paths.filter(this::isValidPath)
           .forEachOrdered(path -> {
             Path fullPath = path.toAbsolutePath().normalize();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/S3StorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/S3StorageClient.java
@@ -75,7 +75,7 @@ public class S3StorageClient extends BaseStorageClient {
     ListObjectsV2Request request = ListObjectsV2Request.builder().bucket(bucketOrContainerName).prefix(startingDirectory).maxKeys(maxNumOfPages).build();
     ListObjectsV2Iterable response = s3.listObjectsV2Paginator(request);
     response.stream()
-        .forEach(resp -> {
+        .forEachOrdered(resp -> {
           resp.contents().forEach(obj -> {
             if (isValid(obj)) {
               String fullPathStr = getFullPath(obj);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -183,66 +183,58 @@ public class FileConnectorTest {
     assertEquals("Rustic Cows Mug", doc1.getString("name"));
 
     Document doc2 = documentList.get(1);
-    assertEquals("jsonHandled-b", doc2.getId());
-    assertEquals("Gorgeous Woman Mug", doc2.getString("name"));
+    assertTrue(doc2.getId().startsWith("normal-"));
+    assertTrue(doc2.getString(FILE_PATH).endsWith("helloWorld.txt.gz:helloWorld.txt"));
 
     Document doc3 = documentList.get(2);
-    assertTrue(doc3.getString(FILE_PATH).endsWith("e.yaml"));
-    assertEquals("586", doc3.getString("file_size_bytes"));
+    assertTrue(doc3.getId().startsWith("normal-"));
+    assertTrue(doc3.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip:subDirWith2TxtFiles/first.txt"));
+    assertEquals("First!", new String(doc3.getBytes("file_content")));
 
     Document doc4 = documentList.get(3);
-    assertEquals("jsonHandled-c1", doc4.getId());
-    assertEquals("Awesome Night Mug", doc4.getString("name"));
+    assertTrue(doc4.getId().startsWith("normal-"));
+    assertTrue(doc4.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip:subDirWith2TxtFiles/second.txt"));
+    assertEquals("Second!", new String(doc4.getBytes("file_content")));
 
     Document doc5 = documentList.get(4);
-    assertEquals("jsonHandled-c2", doc5.getId());
-    assertEquals("Ergonomic Mountains Mug", doc5.getString("name"));
+    assertEquals("jsonHandled-b", doc5.getId());
+    assertEquals("Gorgeous Woman Mug", doc5.getString("name"));
 
     Document doc6 = documentList.get(5);
-    assertEquals("jsonHandled-c3", doc6.getId());
-    assertEquals("Refined Fog Mug", doc6.getString("name"));
+    assertEquals("jsonHandled-c1", doc6.getId());
+    assertEquals("Awesome Night Mug", doc6.getString("name"));
 
     Document doc7 = documentList.get(6);
-    assertEquals("jsonHandled-c4", doc7.getId());
-    assertEquals("Sleek Castle Mug", doc7.getString("name"));
+    assertEquals("jsonHandled-c2", doc7.getId());
+    assertEquals("Ergonomic Mountains Mug", doc7.getString("name"));
 
     Document doc8 = documentList.get(7);
-    assertEquals("jsonHandled-c5", doc8.getId());
-    assertEquals("Small City Mug", doc8.getString("name"));
+    assertEquals("jsonHandled-c3", doc8.getId());
+    assertEquals("Refined Fog Mug", doc8.getString("name"));
 
     Document doc9 = documentList.get(8);
-    assertTrue(doc9.getString(FILE_PATH).endsWith("first.txt"));
-    assertEquals("First!", new String(doc9.getBytes("file_content")));
+    assertEquals("jsonHandled-c4", doc9.getId());
+    assertEquals("Sleek Castle Mug", doc9.getString("name"));
 
     Document doc10 = documentList.get(9);
-    assertTrue(doc10.getString(FILE_PATH).endsWith("second.txt"));
-    assertEquals("Second!", new String(doc10.getBytes("file_content")));
+    assertEquals("jsonHandled-c5", doc10.getId());
+    assertEquals("Small City Mug", doc10.getString("name"));
 
     Document doc11 = documentList.get(10);
     assertTrue(doc11.getId().startsWith("normal-"));
-    assertTrue(doc11.getString(FILE_PATH).endsWith("helloWorld.txt.gz:helloWorld.txt"));
-
+    assertTrue(doc11.getString(FILE_PATH).endsWith("subdir/e.yaml"));
 
     Document doc12 = documentList.get(11);
     assertEquals("csvHandled-default.csv-1", doc12.getId());
-    assertEquals("a", doc12.getString("field1"));
-    assertEquals("b", doc12.getString("field2"));
-    assertEquals("c", doc12.getString("field3"));
-    assertTrue(doc12.getString("source").endsWith("default.csv"));
+    assertTrue(doc12.getString("source").endsWith("subdirWith1csv1xml.tar.gz:subdirWith1csv1xml/default.csv"));
 
     Document doc13 = documentList.get(12);
     assertEquals("csvHandled-default.csv-2", doc13.getId());
-    assertEquals("d", doc13.getString("field1"));
-    assertEquals("e,f", doc13.getString("field2"));
-    assertEquals("g", doc13.getString("field3"));
-    assertTrue(doc13.getString("source").endsWith("default.csv"));
+    assertTrue(doc13.getString("source").endsWith("subdirWith1csv1xml.tar.gz:subdirWith1csv1xml/default.csv"));
 
     Document doc14 = documentList.get(13);
     assertEquals("csvHandled-default.csv-3", doc14.getId());
-    assertEquals("x", doc14.getString("field1"));
-    assertEquals("y", doc14.getString("field2"));
-    assertEquals("z", doc14.getString("field3"));
-    assertTrue(doc14.getString("source").endsWith("default.csv"));
+    assertTrue(doc14.getString("source").endsWith("subdirWith1csv1xml.tar.gz:subdirWith1csv1xml/default.csv"));
 
     Document doc15 = documentList.get(14);
     assertEquals("xmlHandled-1001", doc15.getId());
@@ -263,6 +255,5 @@ public class FileConnectorTest {
         "        <salary currency=\"EUR\">8000</salary>\n" +
         "        <bio>I enjoy reading</bio>\n" +
         "    </staff>", doc16.getString("xml"));
-
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
@@ -154,6 +154,7 @@ public class LocalStorageClientTest {
         )
     ));
 
+
     localStorageClient.init();
     TestMessenger messenger = new TestMessenger();
     Publisher publisher = new PublisherImpl(ConfigFactory.empty(), messenger, "run1", "pipeline1");
@@ -169,47 +170,48 @@ public class LocalStorageClientTest {
     Assert.assertEquals("Rustic Cows Mug", doc1.getString("name"));
 
     Document doc2 = documents.get(1);
-    Assert.assertEquals("d", doc2.getId());
-    Assert.assertEquals("Incredible People Mug", doc2.getString("name"));
+    Assert.assertEquals("b", doc2.getId());
+    Assert.assertEquals("Gorgeous Woman Mug", doc2.getString("name"));
 
     Document doc3 = documents.get(2);
-    Assert.assertEquals("e", doc3.getId());
-    Assert.assertEquals("Awesome Wood Mug", doc3.getString("name"));
+    Assert.assertEquals("c", doc3.getId());
+    Assert.assertEquals("Awesome City Mug", doc3.getString("name"));
 
     Document doc4 = documents.get(3);
-    Assert.assertEquals("f1", doc4.getId());
-    Assert.assertEquals("Awesome Night Mug", doc4.getString("name"));
+    Assert.assertEquals("d", doc4.getId());
+    Assert.assertEquals("Incredible People Mug", doc4.getString("name"));
 
     Document doc5 = documents.get(4);
-    Assert.assertEquals("f2", doc5.getId());
-    Assert.assertEquals("Ergonomic Mountains Mug", doc5.getString("name"));
+    Assert.assertEquals("e", doc5.getId());
+    Assert.assertEquals("Awesome Wood Mug", doc5.getString("name"));
 
     Document doc6 = documents.get(5);
-    Assert.assertEquals("f3", doc6.getId());
-    Assert.assertEquals("Refined Fog Mug", doc6.getString("name"));
+    Assert.assertTrue(doc6.getString(FILE_PATH).endsWith("subdir1/e.json.gz"));
 
     Document doc7 = documents.get(6);
-    Assert.assertEquals("f4", doc7.getId());
-    Assert.assertEquals("Sleek Castle Mug", doc7.getString("name"));
+    Assert.assertTrue(doc7.getString(FILE_PATH).endsWith("subdir1/e.yaml"));
 
     Document doc8 = documents.get(7);
-    Assert.assertEquals("f5", doc8.getId());
-    Assert.assertEquals("Small City Mug", doc8.getString("name"));
+    Assert.assertEquals("f1", doc8.getId());
+    Assert.assertEquals("Awesome Night Mug", doc8.getString("name"));
 
     Document doc9 = documents.get(8);
-    Assert.assertTrue(doc9.getString(FILE_PATH).endsWith("subdir1/e.yaml"));
+    Assert.assertEquals("f2", doc9.getId());
+    Assert.assertEquals("Ergonomic Mountains Mug", doc9.getString("name"));
 
     Document doc10 = documents.get(9);
-    Assert.assertTrue(doc10.getString(FILE_PATH).endsWith("subdir1/e.json.gz"));
+    Assert.assertEquals("f3", doc10.getId());
+    Assert.assertEquals("Refined Fog Mug", doc10.getString("name"));
 
     Document doc11 = documents.get(10);
-    Assert.assertEquals("c", doc11.getId());
-    Assert.assertEquals("Awesome City Mug", doc11.getString("name"));
+    Assert.assertEquals("f4", doc11.getId());
+    Assert.assertEquals("Sleek Castle Mug", doc11.getString("name"));
 
     Document doc12 = documents.get(11);
-    Assert.assertEquals("b", doc12.getId());
-    Assert.assertEquals("Gorgeous Woman Mug", doc12.getString("name"));
+    Assert.assertEquals("f5", doc12.getId());
+    Assert.assertEquals("Small City Mug", doc12.getString("name"));
 
+    localStorageClient.shutdown();
   }
 
 
@@ -226,6 +228,7 @@ public class LocalStorageClientTest {
             "handleCompressedFiles", true
         )));
 
+
     localStorageClient.init();
     TestMessenger messenger = new TestMessenger();
     Publisher publisher = new PublisherImpl(ConfigFactory.empty(), messenger, "run1", "pipeline1");
@@ -235,65 +238,84 @@ public class LocalStorageClientTest {
 
     Assert.assertEquals(19, docs.size());
 
-    // check documents published from jsonlCsvAndFolderWithFooTxt.tar
     Document doc1 = docs.get(0);
-    Assert.assertTrue(doc1.getId().endsWith("default.csv-1"));
-    Assert.assertEquals("default.csv", doc1.getString("filename"));
+    Assert.assertTrue(doc1.getString(FILE_PATH).endsWith("hello.zip:hello"));
+
     Document doc2 = docs.get(1);
-    Assert.assertTrue(doc2.getId().endsWith("default.csv-2"));
-    Assert.assertEquals("default.csv", doc2.getString("filename"));
+    Assert.assertEquals("default.csv-1", doc2.getId());
+    Assert.assertEquals("a", doc2.getString("field1"));
+    Assert.assertEquals("b", doc2.getString("field2"));
+    Assert.assertEquals("c", doc2.getString("field3"));
+
     Document doc3 = docs.get(2);
-    Assert.assertTrue(doc3.getId().endsWith("default.csv-3"));
-    Assert.assertEquals("default.csv", doc3.getString("filename"));
+    Assert.assertEquals("default.csv-2", doc3.getId());
+    Assert.assertEquals("d", doc3.getString("field1"));
+    Assert.assertEquals("e,f", doc3.getString("field2"));
+    Assert.assertEquals("g", doc3.getString("field3"));
+
     Document doc4 = docs.get(3);
-    Assert.assertEquals("2", doc4.getId());
-    Assert.assertEquals("Gorgeous Woman Mug", doc4.getString("name"));
+    Assert.assertEquals("default.csv-3", doc4.getId());
+    Assert.assertEquals("x", doc4.getString("field1"));
+    Assert.assertEquals("y", doc4.getString("field2"));
+    Assert.assertEquals("z", doc4.getString("field3"));
+
     Document doc5 = docs.get(4);
-    Assert.assertEquals("3", doc5.getId());
-    Assert.assertEquals("Awesome City Mug", doc5.getString("name"));
+    Assert.assertEquals("2", doc5.getId());
+    Assert.assertEquals("Gorgeous Woman Mug", doc5.getString("name"));
+
     Document doc6 = docs.get(5);
-    Assert.assertTrue(doc6.getString(FILE_PATH).endsWith("FolderWithFooTxt/foo.txt"));
+    Assert.assertEquals("3", doc6.getId());
+    Assert.assertEquals("Awesome City Mug", doc6.getString("name"));
 
-    // check documents published from textFiles.tar
     Document doc7 = docs.get(6);
-    Assert.assertTrue(doc7.getString(FILE_PATH).endsWith("helloWorld.txt"));
-    Document doc8 = docs.get(7);
-    Assert.assertTrue(doc8.getString(FILE_PATH).endsWith("goodbye.txt"));
+    Assert.assertTrue(doc7.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar:FolderWithFooTxt/foo.txt"));
 
-    // check documents published from jsonlCsvAndFolderWithFooTxt.tar.gz
+    Document doc8 = docs.get(7);
+    Assert.assertEquals("default.csv-1", doc8.getId());
+    Assert.assertEquals("a", doc8.getString("field1"));
+    Assert.assertEquals("b", doc8.getString("field2"));
+    Assert.assertEquals("c", doc8.getString("field3"));
+
     Document doc9 = docs.get(8);
-    Assert.assertTrue(doc9.getId().endsWith("default.csv-1"));
-    Assert.assertEquals("default.csv", doc9.getString("filename"));
+    Assert.assertEquals("default.csv-2", doc9.getId());
+    Assert.assertEquals("d", doc9.getString("field1"));
+    Assert.assertEquals("e,f", doc9.getString("field2"));
+    Assert.assertEquals("g", doc9.getString("field3"));
+
     Document doc10 = docs.get(9);
-    Assert.assertTrue(doc10.getId().endsWith("default.csv-2"));
-    Assert.assertEquals("default.csv", doc10.getString("filename"));
+    Assert.assertEquals("default.csv-3", doc10.getId());
+    Assert.assertEquals("x", doc10.getString("field1"));
+    Assert.assertEquals("y", doc10.getString("field2"));
+    Assert.assertEquals("z", doc10.getString("field3"));
+
     Document doc11 = docs.get(10);
-    Assert.assertTrue(doc11.getId().endsWith("default.csv-3"));
-    Assert.assertEquals("default.csv", doc11.getString("filename"));
+    Assert.assertEquals("2", doc11.getId());
+    Assert.assertEquals("Gorgeous Woman Mug", doc11.getString("name"));
+
     Document doc12 = docs.get(11);
-    Assert.assertEquals("2", doc12.getId());
-    Assert.assertEquals("Gorgeous Woman Mug", doc12.getString("name"));
+    Assert.assertEquals("3", doc12.getId());
+    Assert.assertEquals("Awesome City Mug", doc12.getString("name"));
+
     Document doc13 = docs.get(12);
-    Assert.assertEquals("3", doc13.getId());
-    Assert.assertEquals("Awesome City Mug", doc13.getString("name"));
+    Assert.assertTrue(doc13.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar.gz:FolderWithFooTxt/foo.txt"));
+
     Document doc14 = docs.get(13);
-    Assert.assertTrue(doc14.getString(FILE_PATH).endsWith("FolderWithFooTxt/foo.txt"));
-    // check documents published from zippedFolder.zip
+    Assert.assertTrue(doc14.getString(FILE_PATH).endsWith("textFiles.tar:helloWorld.txt"));
+
     Document doc15 = docs.get(14);
-    Assert.assertTrue(doc15.getString(FILE_PATH).endsWith("zippedFolder/foo.txt"));
-    // check document published from hello.zip
+    Assert.assertTrue(doc15.getString(FILE_PATH).endsWith("textFiles.tar:goodbye.txt"));
+
     Document doc16 = docs.get(15);
-    Assert.assertTrue(doc16.getString(FILE_PATH).endsWith("hello"));
-    // check documents published from zipped.csv
+    Assert.assertEquals("zipped.csv-1", doc16.getId());
+
     Document doc17 = docs.get(16);
-    Assert.assertTrue(doc17.getId().endsWith("zipped.csv-1"));
-    Assert.assertEquals("zipped.csv", doc17.getString("filename"));
+    Assert.assertEquals("zipped.csv-2", doc17.getId());
+
     Document doc18 = docs.get(17);
-    Assert.assertTrue(doc18.getId().endsWith("zipped.csv-2"));
-    Assert.assertEquals("zipped.csv", doc18.getString("filename"));
+    Assert.assertEquals("zipped.csv-3", doc18.getId());
+
     Document doc19 = docs.get(18);
-    Assert.assertTrue(doc19.getId().endsWith("zipped.csv-3"));
-    Assert.assertEquals("zipped.csv", doc19.getString("filename"));
+    Assert.assertTrue(doc19.getString(FILE_PATH).endsWith("zippedFolder.zip:zippedFolder/foo.txt"));
 
     localStorageClient.shutdown();
   }


### PR DESCRIPTION
Publishing has failed for LC-144 even though the Maven built process passed. Taking a look at the publishing, some of the test are failing even though the maven build is passing. Took a deeper look and it seems like Files.walk(startingDirectory) in LocalStorageClient does not guarantee ordering of the files, causing assertion to fail. Instead, we should use Files.walk(startingDirectory).sorted() to produce a stream in the natural order. This PR is to correct that and make sure that we get repeatable results