### PR TITLE
LC-599: Fix Nightly Smoketest

### DIFF
--- a/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
+++ b/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
@@ -26,7 +26,7 @@ public class VerifyIngestResult {
     for (int i = 0; i < numDocs; i++) {
       docs.add(json.get("response").get("docs").get(i));
     }
-    
+
     assertTrue(docs.stream()
         .anyMatch(doc -> doc.get("id").asText().equals("source.csv-1")
             && doc.get("source").get(0).asText().equals("/conf/source.csv")

--- a/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
+++ b/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
@@ -26,20 +26,20 @@ public class VerifyIngestResult {
     for (int i = 0; i < numDocs; i++) {
       docs.add(json.get("response").get("docs").get(i));
     }
-
+    
     assertTrue(docs.stream()
         .anyMatch(doc -> doc.get("id").asText().equals("source.csv-1")
-            && doc.get("source").get(0).asText().equals("conf/source.csv")
+            && doc.get("source").get(0).asText().equals("/conf/source.csv")
             && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Italy")
             && doc.get("my_price").get(0).asInt() == 30 && doc.get("my_name").get(0).asText().equals("Carbonara")));
     assertTrue(docs.stream()
         .anyMatch(doc -> doc.get("id").asText().equals("source.csv-2")
-            && doc.get("source").get(0).asText().equals("conf/source.csv")
+            && doc.get("source").get(0).asText().equals("/conf/source.csv")
             && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Italy")
             && doc.get("my_price").get(0).asInt() == 10 && doc.get("my_name").get(0).asText().equals("Pizza")));
     assertTrue(docs.stream()
         .anyMatch(doc -> doc.get("id").asText().equals("source.csv-3")
-            && doc.get("source").get(0).asText().equals("conf/source.csv")
+            && doc.get("source").get(0).asText().equals("/conf/source.csv")
             && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Korea")
             && doc.get("my_price").get(0).asInt() == 12 && doc.get("my_name").get(0).asText().equals("Tofu Soup")));
 


### PR DESCRIPTION
`VerifyIngestResult` now expects absolute paths in the ingested document's "source" field. 
Change was needed as part of the changes in LC-144... here's my understanding of what necessitated this:
- Previously, `CSVConnector` was extracting a path String from `config`.
- In `execute`, it set `filePathField` to this extracted path String.
- Now, this functionality takes place in `CSVFileHandler`.
- Its `getDocumentFromLine` method sets `filePathField` to one of its arguments - which instead appears to be a String generated from a `Path` object's `toAbsolutePath()` output.

This appears to be the behavior with other file types, so I'm guessing this is the intended behavior moving forward?