### PR TITLE
LC-426: Improved Unit Tests for CSV/Open/Elasticsearch Indexers

### DIFF
--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
@@ -30,15 +30,11 @@ public class CSVIndexerTest {
   @Before
   public void init() {
     outputFile.delete();
-    nestedOutputFile.delete();
-    parentDirFile.delete();
   }
 
   @After
   public void teardown() {
     outputFile.delete();
-    nestedOutputFile.delete();
-    parentDirFile.delete();
   }
 
   /**
@@ -144,13 +140,21 @@ public class CSVIndexerTest {
   // Ensures the CSVIndexer is willing to create directories for output files.
   @Test
   public void testMakeParentDir() {
-    assertFalse(parentDirFile.exists());
+    try {
+      nestedOutputFile.delete();
+      parentDirFile.delete();
 
-    TestMessenger messenger = new TestMessenger();
-    Config config = ConfigFactory.load("CSVIndexerTest/missingParentConfig.conf");
-    new CSVIndexer(config, messenger, false, "testing");
+      assertFalse(parentDirFile.exists());
 
-    assertTrue(parentDirFile.exists());
+      TestMessenger messenger = new TestMessenger();
+      Config config = ConfigFactory.load("CSVIndexerTest/missingParentConfig.conf");
+      new CSVIndexer(config, messenger, false, "testing");
+
+      assertTrue(parentDirFile.exists());
+    } finally {
+      nestedOutputFile.delete();
+      parentDirFile.delete();
+    }
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
@@ -24,8 +24,6 @@ import static org.junit.Assert.assertTrue;
 public class CSVIndexerTest {
 
   private final File outputFile = new File("output.csv");
-  private final File parentDirFile = new File("my_files");
-  private final File nestedOutputFile = new File("my_files/output.csv");
 
   @Before
   public void init() {
@@ -140,10 +138,13 @@ public class CSVIndexerTest {
   // Ensures the CSVIndexer is willing to create directories for output files.
   @Test
   public void testMakeParentDir() {
-    try {
-      nestedOutputFile.delete();
-      parentDirFile.delete();
+    File parentDirFile = new File("my_files");
+    File nestedOutputFile = new File("my_files/output.csv");
 
+    nestedOutputFile.delete();
+    parentDirFile.delete();
+
+    try {
       assertFalse(parentDirFile.exists());
 
       TestMessenger messenger = new TestMessenger();

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
@@ -112,6 +112,7 @@ public class CSVIndexerTest {
 
   @Test
   public void testInvalidConfig() {
+    // cannot use the indexOverrideField
     TestMessenger messenger = new TestMessenger();
     Config config = ConfigFactory.load("CSVIndexerTest/invalidConfig.conf");
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/CSVIndexerTest.java
@@ -3,8 +3,10 @@ package com.kmwllc.lucille.indexer;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Event;
 import com.kmwllc.lucille.message.TestMessenger;
+import com.opencsv.ICSVWriter;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,22 +14,31 @@ import org.junit.Test;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class CSVIndexerTest {
 
   private final File outputFile = new File("output.csv");
+  private final File parentDirFile = new File("my_files");
+  private final File nestedOutputFile = new File("my_files/output.csv");
 
   @Before
   public void init() {
     outputFile.delete();
+    nestedOutputFile.delete();
+    parentDirFile.delete();
   }
 
   @After
   public void teardown() {
     outputFile.delete();
+    nestedOutputFile.delete();
+    parentDirFile.delete();
   }
 
   /**
@@ -97,5 +108,70 @@ public class CSVIndexerTest {
     assertEquals(2, lines.size());
     assertEquals("\"doc1\",\"123\",\"abc\"", lines.get(0));
     assertEquals("\"doc2\",\"456\",\"def\"", lines.get(1));
+  }
+
+  @Test
+  public void testInvalidConfig() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("CSVIndexerTest/invalidConfig.conf");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new CSVIndexer(config, messenger, false, "testing"));
+  }
+
+  @Test
+  public void testValidateConnection() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("CSVIndexerTest/includeHeader.conf");
+
+    CSVIndexer noErrorIndexer = new CSVIndexer(config, messenger, null, false, "testing");
+    assertFalse(noErrorIndexer.validateConnection());
+
+    CSVIndexer faultyIndexer = new CSVIndexer(config, messenger, null, true, "testing");
+    assertThrows(NullPointerException.class,
+        () -> faultyIndexer.validateConnection());
+
+    CSVIndexer indexer = new CSVIndexer(config, messenger, false, "testing");
+    assertTrue(indexer.validateConnection());
+
+    // no include header
+    config = ConfigFactory.load("CSVIndexerTest/config.conf");
+    indexer = new CSVIndexer(config, messenger, false, "testing");
+    assertTrue(indexer.validateConnection());
+  }
+
+  // Ensures the CSVIndexer is willing to create directories for output files.
+  @Test
+  public void testMakeParentDir() {
+    assertFalse(parentDirFile.exists());
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("CSVIndexerTest/missingParentConfig.conf");
+    new CSVIndexer(config, messenger, false, "testing");
+
+    assertTrue(parentDirFile.exists());
+  }
+
+  @Test
+  public void testCloseNullWriter() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("CSVIndexerTest/config.conf");
+    CSVIndexer indexer = new CSVIndexer(config, messenger, null, false, "testing");
+
+    // should not throw an error.
+    indexer.closeConnection();
+  }
+
+  @Test
+  public void testCloseConnectionWithError() throws Exception {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("CSVIndexerTest/config.conf");
+
+    ICSVWriter mockWriter = Mockito.mock(ICSVWriter.class);
+    Mockito.doThrow(new IOException("Mocked Error")).when(mockWriter).close();
+    CSVIndexer indexer = new CSVIndexer(config, messenger, mockWriter, false, "testing");
+
+    // Again, doesn't throw an error.
+    indexer.closeConnection();
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -658,6 +658,7 @@ public class ElasticsearchIndexerTest {
 
   @Test
   public void testInvalidConfig() {
+    // cannot use the indexOverrideField
     TestMessenger messenger = new TestMessenger();
     Config config = ConfigFactory.load("ElasticsearchIndexerTest/invalidConfig.conf");
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -45,11 +45,6 @@ import static org.mockito.Mockito.when;
 public class ElasticsearchIndexerTest {
 
   private ElasticsearchClient mockClient;
-  // throws an exception when you ping
-  private ElasticsearchClient mockFailPingClient;
-
-  private ElasticsearchTransport mockTransport;
-  private ElasticsearchClient mockTransportClient;
 
   @Before
   public void setup() throws IOException {
@@ -64,13 +59,6 @@ public class ElasticsearchIndexerTest {
 
     BulkResponse mockResponse = Mockito.mock(BulkResponse.class);
     Mockito.when(mockClient.bulk(any(BulkRequest.class))).thenReturn(mockResponse);
-
-    mockFailPingClient = Mockito.mock(ElasticsearchClient.class);
-    Mockito.when(mockFailPingClient.ping()).thenThrow(RuntimeException.class);
-
-    mockTransport = Mockito.mock(ElasticsearchTransport.class);
-    mockTransportClient = Mockito.mock(ElasticsearchClient.class);
-    when(mockTransportClient._transport()).thenReturn(mockTransport);
   }
 
   /**
@@ -174,6 +162,9 @@ public class ElasticsearchIndexerTest {
 
   @Test
   public void testValidateConnection() throws Exception {
+    ElasticsearchClient mockFailPingClient = Mockito.mock(ElasticsearchClient.class);
+    Mockito.when(mockFailPingClient.ping()).thenThrow(RuntimeException.class);
+
     TestMessenger messenger = new TestMessenger();
     Config config = ConfigFactory.load("ElasticsearchIndexerTest/config.conf");
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient, "testing");
@@ -670,6 +661,10 @@ public class ElasticsearchIndexerTest {
 
   @Test
   public void testCloseConnection() throws IOException {
+    ElasticsearchTransport mockTransport = Mockito.mock(ElasticsearchTransport.class);
+    ElasticsearchClient mockTransportClient = Mockito.mock(ElasticsearchClient.class);
+    when(mockTransportClient._transport()).thenReturn(mockTransport);
+
     TestMessenger messenger = new TestMessenger();
     Config config = ConfigFactory.load("ElasticsearchIndexerTest/testOverride.conf");
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -801,6 +801,7 @@ public class OpenSearchIndexerTest {
 
   @Test
   public void testInvalidConfig() {
+    // cannot use the indexOverrideField
     TestMessenger messenger = new TestMessenger();
     Config config = ConfigFactory.load("OpenSearchIndexerTest/invalidConfig.conf");
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -52,10 +52,6 @@ import org.opensearch.client.transport.endpoints.BooleanResponse;
 public class OpenSearchIndexerTest {
 
   private OpenSearchClient mockClient;
-  private OpenSearchClient mockFailPingClient;
-
-  private OpenSearchTransport mockTransport;
-  private OpenSearchClient mockTransportClient;
 
   @Before
   public void setup() throws IOException {
@@ -80,13 +76,6 @@ public class OpenSearchIndexerTest {
     DeleteByQueryResponse mockDeleteByQueryResponse = Mockito.mock(DeleteByQueryResponse.class);
     when(mockClient.deleteByQuery(any(DeleteByQueryRequest.class))).thenReturn(mockDeleteByQueryResponse);
     when(mockDeleteByQueryResponse.failures()).thenReturn(new ArrayList<>());
-
-    mockFailPingClient = Mockito.mock(OpenSearchClient.class);
-    when(mockFailPingClient.ping()).thenThrow(RuntimeException.class);
-
-    mockTransport = Mockito.mock(OpenSearchTransport.class);
-    mockTransportClient = Mockito.mock(OpenSearchClient.class);
-    when(mockTransportClient._transport()).thenReturn(mockTransport);
   }
 
   /**
@@ -189,6 +178,9 @@ public class OpenSearchIndexerTest {
 
   @Test
   public void testValidateConnection() throws Exception {
+    OpenSearchClient mockFailPingClient = Mockito.mock(OpenSearchClient.class);
+    when(mockFailPingClient.ping()).thenThrow(RuntimeException.class);
+
     TestMessenger messenger = new TestMessenger();
     Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf");
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient, "testing");
@@ -811,6 +803,10 @@ public class OpenSearchIndexerTest {
 
   @Test
   public void testCloseConnection() throws IOException {
+    OpenSearchTransport mockTransport = Mockito.mock(OpenSearchTransport.class);
+    OpenSearchClient mockTransportClient = Mockito.mock(OpenSearchClient.class);
+    when(mockTransportClient._transport()).thenReturn(mockTransport);
+
     TestMessenger messenger = new TestMessenger();
     Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf");
 

--- a/lucille-core/src/test/resources/CSVIndexerTest/includeHeader.conf
+++ b/lucille-core/src/test/resources/CSVIndexerTest/includeHeader.conf
@@ -1,0 +1,13 @@
+indexer {
+  type : "CSV"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+}
+
+csv {
+  columns: ["id","f1","f2"]
+  path: "output.csv"
+  append: true
+  includeHeader: true
+}

--- a/lucille-core/src/test/resources/CSVIndexerTest/invalidConfig.conf
+++ b/lucille-core/src/test/resources/CSVIndexerTest/invalidConfig.conf
@@ -1,0 +1,14 @@
+indexer {
+  type : "CSV"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+  indexOverrideField: "something"
+}
+
+csv {
+  columns: ["id","f1","f2"]
+  path: "output.csv"
+  append: true
+  includeHeader: false
+}

--- a/lucille-core/src/test/resources/CSVIndexerTest/missingParentConfig.conf
+++ b/lucille-core/src/test/resources/CSVIndexerTest/missingParentConfig.conf
@@ -1,0 +1,13 @@
+indexer {
+  type : "CSV"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+}
+
+csv {
+  columns: ["id","f1","f2"]
+  path: "my_files/output.csv"
+  append: true
+  includeHeader: false
+}

--- a/lucille-core/src/test/resources/ElasticsearchIndexerTest/invalidConfig.conf
+++ b/lucille-core/src/test/resources/ElasticsearchIndexerTest/invalidConfig.conf
@@ -1,0 +1,15 @@
+indexer {
+  type : "Elasticsearch"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+  idOverrideField: "other_id"
+  indexOverrideField: "something"
+}
+
+elasticsearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+}

--- a/lucille-core/src/test/resources/ElasticsearchIndexerTest/routingAndUpdate.conf
+++ b/lucille-core/src/test/resources/ElasticsearchIndexerTest/routingAndUpdate.conf
@@ -1,0 +1,22 @@
+indexer {
+  type: "Elasticsearch"
+  routingField: "routing"
+
+  # not a necessary setting. meant to demonstrate that routing will be set even though it is in the ignoreFields list
+  ignoreFields: [
+    "id"
+    "routing"
+  ]
+
+  batchSize: 1
+  batchTimeout: 1000
+  logRate: 1000
+}
+
+elasticsearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+  update: true
+}

--- a/lucille-core/src/test/resources/ElasticsearchIndexerTest/updateConfig.conf
+++ b/lucille-core/src/test/resources/ElasticsearchIndexerTest/updateConfig.conf
@@ -1,0 +1,14 @@
+indexer {
+  type : "Elasticsearch"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+}
+
+elasticsearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+  update: true
+}

--- a/lucille-core/src/test/resources/ElasticsearchIndexerTest/versioningUpdate.conf
+++ b/lucille-core/src/test/resources/ElasticsearchIndexerTest/versioningUpdate.conf
@@ -1,0 +1,15 @@
+indexer {
+  type : "Elasticsearch"
+  versionType: "ExternalGte"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+}
+
+elasticsearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+  update: true
+}

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/invalidConfig.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/invalidConfig.conf
@@ -1,0 +1,14 @@
+indexer {
+  type : "OpenSearch"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+  indexOverrideField: "something"
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+}

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/routingAndUpdate.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/routingAndUpdate.conf
@@ -1,0 +1,19 @@
+indexer {
+  type : "OpenSearch"
+  routingField: "routing"
+  ignoreFields: [
+    "id"
+    "routing"
+  ]
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+  update: true
+}

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/updateConfig.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/updateConfig.conf
@@ -1,0 +1,14 @@
+indexer {
+  type : "OpenSearch"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+  update: true
+}

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/versioningUpdate.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/versioningUpdate.conf
@@ -1,0 +1,15 @@
+indexer {
+  type : "OpenSearch"
+  versionType: "ExternalGte"
+  batchSize : 1
+  batchTimeout : 1000
+  logRate : 1000
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+  type: "lucille-type"
+  sendEnabled: false
+  update: true
+}


### PR DESCRIPTION
ElasticsearchIndexer: 66% / 57% → 99% / 87%
OpensearchIndexer: 74% / 64% → 92% / 81%
CSVIndexer: 72% / 54% → 92% / 95%