### PR TITLE
LC-564 - upgrade packages for CVEs 

### DIFF
--- a/lucille-examples/lucille-joining-db-connector-example/pom.xml
+++ b/lucille-examples/lucille-joining-db-connector-example/pom.xml
@@ -34,11 +34,11 @@
       <artifactId>lucille-core</artifactId>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+    <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
 <dependency>
-    <groupId>mysql</groupId>
-    <artifactId>mysql-connector-java</artifactId>
-    <version>8.0.33</version>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <version>9.1.0</version>
 </dependency>
 
 

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -60,8 +60,8 @@
     <slf4j.version>2.0.7</slf4j.version>
     <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
     <apache-commons-text.version>1.10.0</apache-commons-text.version>
-    <protobuf.version>3.25.3</protobuf.version>
-    <netty.version>4.1.113.Final</netty.version>
+    <protobuf.version>3.25.5</protobuf.version>
+    <netty.version>4.1.114.Final</netty.version>
     <grpc.version>1.66.0</grpc.version>
     <dropwizard-core.version>4.0.7</dropwizard-core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -61,7 +61,7 @@
     <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
     <apache-commons-text.version>1.10.0</apache-commons-text.version>
     <protobuf.version>3.25.5</protobuf.version>
-    <netty.version>4.1.114.Final</netty.version>
+    <netty.version>4.1.117.Final</netty.version>
     <grpc.version>1.66.0</grpc.version>
     <dropwizard-core.version>4.0.7</dropwizard-core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lucille-plugins/lucille-parquet/pom.xml
+++ b/lucille-plugins/lucille-parquet/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>3.3.4</version>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
[CVE-2024-23454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-23454) : hadoop-common 

[CVE-2024-7254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7254) : protobuf-bom

[CVE-2024-47535](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47535): netty-bom 

[CVE-2023-22102](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-22102): mysql-connector-java > mysql-connector-j