### PR TITLE
LC-618: Special path separator for archive files

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -64,6 +64,7 @@ public class FileConnector extends AbstractConnector {
   public static final String SIZE = "file_size_bytes";
   public static final String CONTENT = "file_content";
   public static final String FILE_SEPARATOR = ":";
+  public static final String ARCHIVE_FILE_SEPARATOR = "!";
 
   // cloudOption Keys
   public static final String AZURE_CONNECTION_STRING = "connectionString";

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -63,7 +63,6 @@ public class FileConnector extends AbstractConnector {
   public static final String CREATED = "file_creation_date";
   public static final String SIZE = "file_size_bytes";
   public static final String CONTENT = "file_content";
-  public static final String FILE_SEPARATOR = ":";
   public static final String ARCHIVE_FILE_SEPARATOR = "!";
 
   // cloudOption Keys

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
@@ -11,6 +11,7 @@ import static com.kmwllc.lucille.connector.FileConnector.MODIFIED;
 import static com.kmwllc.lucille.connector.FileConnector.MOVE_TO_AFTER_PROCESSING;
 import static com.kmwllc.lucille.connector.FileConnector.MOVE_TO_ERROR_FOLDER;
 import static com.kmwllc.lucille.connector.FileConnector.SIZE;
+import static com.kmwllc.lucille.connector.FileConnector.ARCHIVE_FILE_SEPARATOR;
 import static com.kmwllc.lucille.core.fileHandler.FileHandler.SUPPORTED_FILE_TYPES;
 
 import com.kmwllc.lucille.core.ConnectorException;
@@ -270,7 +271,7 @@ public abstract class BaseStorageClient implements StorageClient {
    * helper method to get the full path of an entry in an archived file. Only used for archive files
    */
   protected String getEntryFullPath(String fullPathStr, String entryName) {
-    return fullPathStr + FILE_SEPARATOR + entryName;
+    return fullPathStr + ARCHIVE_FILE_SEPARATOR + entryName;
   }
 
   /**

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
@@ -1,6 +1,5 @@
 package com.kmwllc.lucille.connector.storageclient;
 
-import static com.kmwllc.lucille.connector.FileConnector.FILE_SEPARATOR;
 import static com.kmwllc.lucille.connector.FileConnector.CONTENT;
 import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static com.kmwllc.lucille.connector.FileConnector.GET_FILE_CONTENT;
@@ -110,7 +109,7 @@ public abstract class BaseStorageClient implements StorageClient {
           if (handleArchivedFiles && isSupportedArchiveFileType(decompressedPath)) {
             handleArchiveFiles(publisher, compressorStream, fullPathStr);
           } else {
-            String filePathFormat = fullPathStr + FILE_SEPARATOR + FilenameUtils.getName(decompressedPath);
+            String filePathFormat = fullPathStr + File.pathSeparatorChar + FilenameUtils.getName(decompressedPath);
             // if file is a supported file type that should be handled by a file handler
             if (!fileOptions.isEmpty() && FileHandler.supportAndContainFileType(resolvedExtension, fileOptions)) {
               handleStreamExtensionFiles(publisher, compressorStream, resolvedExtension, filePathFormat);
@@ -183,7 +182,7 @@ public abstract class BaseStorageClient implements StorageClient {
         ArchiveInputStream<? extends ArchiveEntry> in = new ArchiveStreamFactory().createArchiveInputStream(bis)) {
       ArchiveEntry entry = null;
       while ((entry = in.getNextEntry()) != null) {
-        String entryFullPathStr = getEntryFullPath(fullPathStr, entry.getName());
+        String entryFullPathStr = getArchiveEntryFullPath(fullPathStr, entry.getName());
         if (!in.canReadEntryData(entry)) {
           log.info("Cannot read entry data for entry: '{}' in '{}'. Skipping...", entry.getName(), fullPathStr);
           continue;
@@ -270,7 +269,7 @@ public abstract class BaseStorageClient implements StorageClient {
   /**
    * helper method to get the full path of an entry in an archived file. Only used for archive files
    */
-  protected String getEntryFullPath(String fullPathStr, String entryName) {
+  protected String getArchiveEntryFullPath(String fullPathStr, String entryName) {
     return fullPathStr + ARCHIVE_FILE_SEPARATOR + entryName;
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
@@ -109,7 +109,7 @@ public abstract class BaseStorageClient implements StorageClient {
           if (handleArchivedFiles && isSupportedArchiveFileType(decompressedPath)) {
             handleArchiveFiles(publisher, compressorStream, fullPathStr);
           } else {
-            String filePathFormat = fullPathStr + File.pathSeparatorChar + FilenameUtils.getName(decompressedPath);
+            String filePathFormat = fullPathStr + ARCHIVE_FILE_SEPARATOR + FilenameUtils.getName(decompressedPath);
             // if file is a supported file type that should be handled by a file handler
             if (!fileOptions.isEmpty() && FileHandler.supportAndContainFileType(resolvedExtension, fileOptions)) {
               handleStreamExtensionFiles(publisher, compressorStream, resolvedExtension, filePathFormat);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.core.fileHandler;
 
-import static com.kmwllc.lucille.connector.FileConnector.FILE_SEPARATOR;
+import static com.kmwllc.lucille.connector.FileConnector.ARCHIVE_FILE_SEPARATOR;
 
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.util.FileUtils;
@@ -83,8 +83,8 @@ public class CSVFileHandler extends BaseFileHandler {
     String fileName = FilenameUtils.getName(pathStr);
 
     // handle the case where pathStr is a path of an entry of an archived file
-    if (pathStr.contains(FILE_SEPARATOR)) {
-      String entryName = pathStr.substring(pathStr.lastIndexOf(FILE_SEPARATOR) + 1);
+    if (pathStr.contains(ARCHIVE_FILE_SEPARATOR)) {
+      String entryName = pathStr.substring(pathStr.lastIndexOf(ARCHIVE_FILE_SEPARATOR) + 1);
       fileName = entryName.substring(entryName.lastIndexOf("/") + 1);
     }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -5,7 +5,6 @@ import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -183,10 +182,9 @@ public class FileConnectorTest {
     assertEquals("jsonHandled-a", doc1.getId());
     assertEquals("Rustic Cows Mug", doc1.getString("name"));
 
-    // compressed, but non-archived, file
     Document doc2 = documentList.get(1);
     assertTrue(doc2.getId().startsWith("normal-"));
-    assertTrue(doc2.getString(FILE_PATH).endsWith("helloWorld.txt.gz" + File.pathSeparatorChar + "helloWorld.txt"));
+    assertTrue(doc2.getString(FILE_PATH).endsWith("helloWorld.txt.gz!helloWorld.txt"));
 
     Document doc3 = documentList.get(2);
     assertTrue(doc3.getId().startsWith("normal-"));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -182,9 +182,10 @@ public class FileConnectorTest {
     assertEquals("jsonHandled-a", doc1.getId());
     assertEquals("Rustic Cows Mug", doc1.getString("name"));
 
+    // compressed, but non-archived, file
     Document doc2 = documentList.get(1);
     assertTrue(doc2.getId().startsWith("normal-"));
-    assertTrue(doc2.getString(FILE_PATH).endsWith("helloWorld.txt.gz:helloWorld.txt"));
+    assertTrue(doc2.getString(FILE_PATH).endsWith("helloWorld.txt.gz" + File.pathSeparatorChar + "helloWorld.txt"));
 
     Document doc3 = documentList.get(2);
     assertTrue(doc3.getId().startsWith("normal-"));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -1,5 +1,6 @@
 package com.kmwllc.lucille.connector;
 
+import static com.kmwllc.lucille.connector.FileConnector.ARCHIVE_FILE_SEPARATOR;
 import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -189,12 +190,12 @@ public class FileConnectorTest {
 
     Document doc3 = documentList.get(2);
     assertTrue(doc3.getId().startsWith("normal-"));
-    assertTrue(doc3.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip!subDirWith2TxtFiles/first.txt"));
+    assertTrue(doc3.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip" + ARCHIVE_FILE_SEPARATOR + "subDirWith2TxtFiles/first.txt"));
     assertEquals("First!", new String(doc3.getBytes("file_content")));
 
     Document doc4 = documentList.get(3);
     assertTrue(doc4.getId().startsWith("normal-"));
-    assertTrue(doc4.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip!subDirWith2TxtFiles/second.txt"));
+    assertTrue(doc4.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip" + ARCHIVE_FILE_SEPARATOR + "subDirWith2TxtFiles/second.txt"));
     assertEquals("Second!", new String(doc4.getBytes("file_content")));
 
     Document doc5 = documentList.get(4);
@@ -227,15 +228,15 @@ public class FileConnectorTest {
 
     Document doc12 = documentList.get(11);
     assertEquals("csvHandled-default.csv-1", doc12.getId());
-    assertTrue(doc12.getString("source").endsWith("subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv"));
+    assertTrue(doc12.getString("source").endsWith("subdirWith1csv1xml.tar.gz" + ARCHIVE_FILE_SEPARATOR + "subdirWith1csv1xml/default.csv"));
 
     Document doc13 = documentList.get(12);
     assertEquals("csvHandled-default.csv-2", doc13.getId());
-    assertTrue(doc13.getString("source").endsWith("subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv"));
+    assertTrue(doc13.getString("source").endsWith("subdirWith1csv1xml.tar.gz" + ARCHIVE_FILE_SEPARATOR + "subdirWith1csv1xml/default.csv"));
 
     Document doc14 = documentList.get(13);
     assertEquals("csvHandled-default.csv-3", doc14.getId());
-    assertTrue(doc14.getString("source").endsWith("subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv"));
+    assertTrue(doc14.getString("source").endsWith("subdirWith1csv1xml.tar.gz" + ARCHIVE_FILE_SEPARATOR + "subdirWith1csv1xml/default.csv"));
 
     Document doc15 = documentList.get(14);
     assertEquals("xmlHandled-1001", doc15.getId());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -188,12 +188,12 @@ public class FileConnectorTest {
 
     Document doc3 = documentList.get(2);
     assertTrue(doc3.getId().startsWith("normal-"));
-    assertTrue(doc3.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip:subDirWith2TxtFiles/first.txt"));
+    assertTrue(doc3.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip!subDirWith2TxtFiles/first.txt"));
     assertEquals("First!", new String(doc3.getBytes("file_content")));
 
     Document doc4 = documentList.get(3);
     assertTrue(doc4.getId().startsWith("normal-"));
-    assertTrue(doc4.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip:subDirWith2TxtFiles/second.txt"));
+    assertTrue(doc4.getString(FILE_PATH).endsWith("subDirWith2TxtFiles.zip!subDirWith2TxtFiles/second.txt"));
     assertEquals("Second!", new String(doc4.getBytes("file_content")));
 
     Document doc5 = documentList.get(4);
@@ -226,15 +226,15 @@ public class FileConnectorTest {
 
     Document doc12 = documentList.get(11);
     assertEquals("csvHandled-default.csv-1", doc12.getId());
-    assertTrue(doc12.getString("source").endsWith("subdirWith1csv1xml.tar.gz:subdirWith1csv1xml/default.csv"));
+    assertTrue(doc12.getString("source").endsWith("subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv"));
 
     Document doc13 = documentList.get(12);
     assertEquals("csvHandled-default.csv-2", doc13.getId());
-    assertTrue(doc13.getString("source").endsWith("subdirWith1csv1xml.tar.gz:subdirWith1csv1xml/default.csv"));
+    assertTrue(doc13.getString("source").endsWith("subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv"));
 
     Document doc14 = documentList.get(13);
     assertEquals("csvHandled-default.csv-3", doc14.getId());
-    assertTrue(doc14.getString("source").endsWith("subdirWith1csv1xml.tar.gz:subdirWith1csv1xml/default.csv"));
+    assertTrue(doc14.getString("source").endsWith("subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv"));
 
     Document doc15 = documentList.get(14);
     assertEquals("xmlHandled-1001", doc15.getId());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClientTest.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.connector.storageclient;
 
-import static com.kmwllc.lucille.connector.FileConnector.FILE_SEPARATOR;
+import static com.kmwllc.lucille.connector.FileConnector.ARCHIVE_FILE_SEPARATOR;
 import static com.kmwllc.lucille.connector.FileConnector.CONTENT;
 import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static com.kmwllc.lucille.connector.FileConnector.GET_FILE_CONTENT;
@@ -320,15 +320,15 @@ public class AzureStorageClientTest {
     Document doc1 = docs.get(0);
     assertEquals("default.csv-1", doc1.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar"
-        + FILE_SEPARATOR + "default.csv", doc1.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "default.csv", doc1.getString("source"));
     Document doc2 = docs.get(1);
     assertEquals("default.csv-2", doc2.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar"
-        + FILE_SEPARATOR + "default.csv", doc2.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "default.csv", doc2.getString("source"));
     Document doc3 = docs.get(2);
     assertEquals("default.csv-3", doc3.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar"
-        + FILE_SEPARATOR + "default.csv", doc3.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "default.csv", doc3.getString("source"));
     Document doc4 = docs.get(3);
     assertEquals("2", doc4.getId());
     assertEquals("Gorgeous Woman Mug", doc4.getString("name"));
@@ -337,27 +337,27 @@ public class AzureStorageClientTest {
     assertEquals("Awesome City Mug", doc5.getString("name"));
     Document doc6 = docs.get(5);
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar"
-        + FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc6.getString(FILE_PATH));
+        + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc6.getString(FILE_PATH));
 
     // check documents published from textFiles.tar
     Document doc7 = docs.get(6);
-    assertEquals("https://storagename.blob.core.windows.net/folder/textFiles.tar" + FILE_SEPARATOR + "helloWorld.txt", doc7.getString(FILE_PATH));
+    assertEquals("https://storagename.blob.core.windows.net/folder/textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "helloWorld.txt", doc7.getString(FILE_PATH));
     Document doc8 = docs.get(7);
-    assertEquals("https://storagename.blob.core.windows.net/folder/textFiles.tar" + FILE_SEPARATOR + "goodbye.txt", doc8.getString(FILE_PATH));
+    assertEquals("https://storagename.blob.core.windows.net/folder/textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "goodbye.txt", doc8.getString(FILE_PATH));
 
     // check documents published from jsonlCsvAndFolderWithFooTxt.tar.gz
     Document doc9 = docs.get(8);
     assertEquals("default.csv-1", doc9.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar.gz"
-        + FILE_SEPARATOR + "default.csv", doc9.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "default.csv", doc9.getString("source"));
     Document doc10 = docs.get(9);
     assertEquals("default.csv-2", doc10.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar.gz"
-        + FILE_SEPARATOR + "default.csv", doc10.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "default.csv", doc10.getString("source"));
     Document doc11 = docs.get(10);
     assertEquals("default.csv-3", doc11.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar.gz"
-        + FILE_SEPARATOR + "default.csv", doc11.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "default.csv", doc11.getString("source"));
     Document doc12 = docs.get(11);
     assertEquals("2", doc12.getId());
     assertEquals("Gorgeous Woman Mug", doc12.getString("name"));
@@ -366,28 +366,28 @@ public class AzureStorageClientTest {
     assertEquals("Awesome City Mug", doc13.getString("name"));
     Document doc14 = docs.get(13);
     assertEquals("https://storagename.blob.core.windows.net/folder/jsonlCsvAndFolderWithFooTxt.tar.gz"
-        + FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc14.getString(FILE_PATH));
+        + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc14.getString(FILE_PATH));
     // check documents published from zipped.csv.zip
     Document doc15 = docs.get(14);
     assertEquals("zipped.csv-1", doc15.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/zipped.csv.zip"
-        + FILE_SEPARATOR + "zipped.csv", doc15.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc15.getString("source"));
     Document doc16 = docs.get(15);
     assertEquals("zipped.csv-2", doc16.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/zipped.csv.zip"
-        + FILE_SEPARATOR + "zipped.csv", doc16.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc16.getString("source"));
     Document doc17 = docs.get(16);
     assertEquals("zipped.csv-3", doc17.getId());
     assertEquals("https://storagename.blob.core.windows.net/folder/zipped.csv.zip"
-        + FILE_SEPARATOR + "zipped.csv", doc17.getString("source"));
+        + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc17.getString("source"));
     // check documents published from zippedFolder.zip
     Document doc18 = docs.get(17);
     assertEquals("https://storagename.blob.core.windows.net/folder/zippedFolder.zip"
-        + FILE_SEPARATOR + "zippedFolder/foo.txt", doc18.getString(FILE_PATH));
+        + ARCHIVE_FILE_SEPARATOR + "zippedFolder/foo.txt", doc18.getString(FILE_PATH));
     // check documents published from hello.zip
     Document doc19 = docs.get(18);
     assertEquals("https://storagename.blob.core.windows.net/folder/hello.zip"
-        + FILE_SEPARATOR + "hello", doc19.getString(FILE_PATH));
+        + ARCHIVE_FILE_SEPARATOR + "hello", doc19.getString(FILE_PATH));
 
     azureStorageClient.shutdown();
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClientTest.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.connector.storageclient;
 
-import static com.kmwllc.lucille.connector.FileConnector.FILE_SEPARATOR;
+import static com.kmwllc.lucille.connector.FileConnector.ARCHIVE_FILE_SEPARATOR;
 import static com.kmwllc.lucille.connector.FileConnector.CONTENT;
 import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static com.kmwllc.lucille.connector.FileConnector.GET_FILE_CONTENT;
@@ -320,15 +320,15 @@ public class GoogleStorageClientTest {
     Document doc1 = docs.get(0);
     assertEquals("default.csv-1", doc1.getId());
     assertEquals("default.csv", doc1.getString("filename"));
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "default.csv", doc1.getString("source"));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc1.getString("source"));
     Document doc2 = docs.get(1);
     assertEquals("default.csv-2", doc2.getId());
     assertEquals("default.csv", doc2.getString("filename"));
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "default.csv", doc2.getString("source"));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc2.getString("source"));
     Document doc3 = docs.get(2);
     assertEquals("default.csv-3", doc3.getId());
     assertEquals("default.csv", doc3.getString("filename"));
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "default.csv", doc3.getString("source"));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc3.getString("source"));
     Document doc4 = docs.get(3);
     assertEquals("2", doc4.getId());
     assertEquals("Gorgeous Woman Mug", doc4.getString("name"));
@@ -336,27 +336,27 @@ public class GoogleStorageClientTest {
     assertEquals("3", doc5.getId());
     assertEquals("Awesome City Mug", doc5.getString("name"));
     Document doc6 = docs.get(5);
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc6.getString(FILE_PATH));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc6.getString(FILE_PATH));
 
     // check documents published from textFiles.tar
     Document doc7 = docs.get(6);
-    assertEquals("gs://bucket/textFiles.tar:helloWorld.txt", doc7.getString(FILE_PATH));
+    assertEquals("gs://bucket/textFiles.tar!helloWorld.txt", doc7.getString(FILE_PATH));
     Document doc8 = docs.get(7);
-    assertEquals("gs://bucket/textFiles.tar:goodbye.txt", doc8.getString(FILE_PATH));
+    assertEquals("gs://bucket/textFiles.tar!goodbye.txt", doc8.getString(FILE_PATH));
 
     // check documents published from jsonlCsvAndFolderWithFooTxt.tar.gz
     Document doc9 = docs.get(8);
     assertEquals("default.csv-1", doc9.getId());
     assertEquals("default.csv", doc9.getString("filename"));
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "default.csv", doc9.getString("source"));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc9.getString("source"));
     Document doc10 = docs.get(9);
     assertEquals("default.csv-2", doc10.getId());
     assertEquals("default.csv", doc10.getString("filename"));
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "default.csv", doc10.getString("source"));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc10.getString("source"));
     Document doc11 = docs.get(10);
     assertEquals("default.csv-3", doc11.getId());
     assertEquals("default.csv", doc11.getString("filename"));
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "default.csv", doc11.getString("source"));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc11.getString("source"));
     Document doc12 = docs.get(11);
     assertEquals("2", doc12.getId());
     assertEquals("Gorgeous Woman Mug", doc12.getString("name"));
@@ -364,26 +364,26 @@ public class GoogleStorageClientTest {
     assertEquals("3", doc13.getId());
     assertEquals("Awesome City Mug", doc13.getString("name"));
     Document doc14 = docs.get(13);
-    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc14.getString(FILE_PATH));
+    assertEquals("gs://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc14.getString(FILE_PATH));
     // check documents published from zipped.csv.zip
     Document doc15 = docs.get(14);
     assertEquals("zipped.csv-1", doc15.getId());
     assertEquals("zipped.csv", doc15.getString("filename"));
-    assertEquals("gs://bucket/zipped.csv.zip" + FILE_SEPARATOR + "zipped.csv", doc15.getString("source"));
+    assertEquals("gs://bucket/zipped.csv.zip" + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc15.getString("source"));
     Document doc16 = docs.get(15);
     assertEquals("zipped.csv-2", doc16.getId());
     assertEquals("zipped.csv", doc16.getString("filename"));
-    assertEquals("gs://bucket/zipped.csv.zip" + FILE_SEPARATOR + "zipped.csv", doc16.getString("source"));
+    assertEquals("gs://bucket/zipped.csv.zip" + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc16.getString("source"));
     Document doc17 = docs.get(16);
     assertEquals("zipped.csv-3", doc17.getId());
     assertEquals("zipped.csv", doc17.getString("filename"));
-    assertEquals("gs://bucket/zipped.csv.zip" + FILE_SEPARATOR + "zipped.csv", doc17.getString("source"));
+    assertEquals("gs://bucket/zipped.csv.zip" + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc17.getString("source"));
     // check documents published from zippedFolder.zip
     Document doc18 = docs.get(17);
-    assertEquals("gs://bucket/zippedFolder.zip" + FILE_SEPARATOR + "zippedFolder/foo.txt", doc18.getString(FILE_PATH));
+    assertEquals("gs://bucket/zippedFolder.zip" + ARCHIVE_FILE_SEPARATOR + "zippedFolder/foo.txt", doc18.getString(FILE_PATH));
     // check documents published from hello.zip
     Document doc19 = docs.get(18);
-    assertEquals("gs://bucket/hello.zip" + FILE_SEPARATOR + "hello", doc19.getString(FILE_PATH));
+    assertEquals("gs://bucket/hello.zip" + ARCHIVE_FILE_SEPARATOR + "hello", doc19.getString(FILE_PATH));
 
 
     // closes storage too

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClientTest.java
@@ -340,9 +340,9 @@ public class GoogleStorageClientTest {
 
     // check documents published from textFiles.tar
     Document doc7 = docs.get(6);
-    assertEquals("gs://bucket/textFiles.tar!helloWorld.txt", doc7.getString(FILE_PATH));
+    assertEquals("gs://bucket/textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "helloWorld.txt", doc7.getString(FILE_PATH));
     Document doc8 = docs.get(7);
-    assertEquals("gs://bucket/textFiles.tar!goodbye.txt", doc8.getString(FILE_PATH));
+    assertEquals("gs://bucket/textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "goodbye.txt", doc8.getString(FILE_PATH));
 
     // check documents published from jsonlCsvAndFolderWithFooTxt.tar.gz
     Document doc9 = docs.get(8);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
@@ -239,7 +239,7 @@ public class LocalStorageClientTest {
     Assert.assertEquals(19, docs.size());
 
     Document doc1 = docs.get(0);
-    Assert.assertTrue(doc1.getString(FILE_PATH).endsWith("hello.zip:hello"));
+    Assert.assertTrue(doc1.getString(FILE_PATH).endsWith("hello.zip!hello"));
 
     Document doc2 = docs.get(1);
     Assert.assertEquals("default.csv-1", doc2.getId());
@@ -268,7 +268,7 @@ public class LocalStorageClientTest {
     Assert.assertEquals("Awesome City Mug", doc6.getString("name"));
 
     Document doc7 = docs.get(6);
-    Assert.assertTrue(doc7.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar:FolderWithFooTxt/foo.txt"));
+    Assert.assertTrue(doc7.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar!FolderWithFooTxt/foo.txt"));
 
     Document doc8 = docs.get(7);
     Assert.assertEquals("default.csv-1", doc8.getId());
@@ -297,13 +297,13 @@ public class LocalStorageClientTest {
     Assert.assertEquals("Awesome City Mug", doc12.getString("name"));
 
     Document doc13 = docs.get(12);
-    Assert.assertTrue(doc13.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar.gz:FolderWithFooTxt/foo.txt"));
+    Assert.assertTrue(doc13.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar.gz!FolderWithFooTxt/foo.txt"));
 
     Document doc14 = docs.get(13);
-    Assert.assertTrue(doc14.getString(FILE_PATH).endsWith("textFiles.tar:helloWorld.txt"));
+    Assert.assertTrue(doc14.getString(FILE_PATH).endsWith("textFiles.tar!helloWorld.txt"));
 
     Document doc15 = docs.get(14);
-    Assert.assertTrue(doc15.getString(FILE_PATH).endsWith("textFiles.tar:goodbye.txt"));
+    Assert.assertTrue(doc15.getString(FILE_PATH).endsWith("textFiles.tar!goodbye.txt"));
 
     Document doc16 = docs.get(15);
     Assert.assertEquals("zipped.csv-1", doc16.getId());
@@ -315,7 +315,7 @@ public class LocalStorageClientTest {
     Assert.assertEquals("zipped.csv-3", doc18.getId());
 
     Document doc19 = docs.get(18);
-    Assert.assertTrue(doc19.getString(FILE_PATH).endsWith("zippedFolder.zip:zippedFolder/foo.txt"));
+    Assert.assertTrue(doc19.getString(FILE_PATH).endsWith("zippedFolder.zip!zippedFolder/foo.txt"));
 
     localStorageClient.shutdown();
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
@@ -1,5 +1,6 @@
 package com.kmwllc.lucille.connector.storageclient;
 
+import static com.kmwllc.lucille.connector.FileConnector.ARCHIVE_FILE_SEPARATOR;
 import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static com.kmwllc.lucille.connector.FileConnector.GET_FILE_CONTENT;
 import static org.junit.Assert.assertTrue;
@@ -239,7 +240,7 @@ public class LocalStorageClientTest {
     Assert.assertEquals(19, docs.size());
 
     Document doc1 = docs.get(0);
-    Assert.assertTrue(doc1.getString(FILE_PATH).endsWith("hello.zip!hello"));
+    Assert.assertTrue(doc1.getString(FILE_PATH).endsWith("hello.zip" + ARCHIVE_FILE_SEPARATOR + "hello"));
 
     Document doc2 = docs.get(1);
     Assert.assertEquals("default.csv-1", doc2.getId());
@@ -268,7 +269,7 @@ public class LocalStorageClientTest {
     Assert.assertEquals("Awesome City Mug", doc6.getString("name"));
 
     Document doc7 = docs.get(6);
-    Assert.assertTrue(doc7.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar!FolderWithFooTxt/foo.txt"));
+    Assert.assertTrue(doc7.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt"));
 
     Document doc8 = docs.get(7);
     Assert.assertEquals("default.csv-1", doc8.getId());
@@ -297,13 +298,13 @@ public class LocalStorageClientTest {
     Assert.assertEquals("Awesome City Mug", doc12.getString("name"));
 
     Document doc13 = docs.get(12);
-    Assert.assertTrue(doc13.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar.gz!FolderWithFooTxt/foo.txt"));
+    Assert.assertTrue(doc13.getString(FILE_PATH).endsWith("jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt"));
 
     Document doc14 = docs.get(13);
-    Assert.assertTrue(doc14.getString(FILE_PATH).endsWith("textFiles.tar!helloWorld.txt"));
+    Assert.assertTrue(doc14.getString(FILE_PATH).endsWith("textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "helloWorld.txt"));
 
     Document doc15 = docs.get(14);
-    Assert.assertTrue(doc15.getString(FILE_PATH).endsWith("textFiles.tar!goodbye.txt"));
+    Assert.assertTrue(doc15.getString(FILE_PATH).endsWith("textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "goodbye.txt"));
 
     Document doc16 = docs.get(15);
     Assert.assertEquals("zipped.csv-1", doc16.getId());
@@ -315,7 +316,7 @@ public class LocalStorageClientTest {
     Assert.assertEquals("zipped.csv-3", doc18.getId());
 
     Document doc19 = docs.get(18);
-    Assert.assertTrue(doc19.getString(FILE_PATH).endsWith("zippedFolder.zip!zippedFolder/foo.txt"));
+    Assert.assertTrue(doc19.getString(FILE_PATH).endsWith("zippedFolder.zip" + ARCHIVE_FILE_SEPARATOR + "zippedFolder/foo.txt"));
 
     localStorageClient.shutdown();
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/S3StorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/S3StorageClientTest.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.connector.storageclient;
 
-import static com.kmwllc.lucille.connector.FileConnector.FILE_SEPARATOR;
+import static com.kmwllc.lucille.connector.FileConnector.ARCHIVE_FILE_SEPARATOR;
 import static com.kmwllc.lucille.connector.FileConnector.CONTENT;
 import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static com.kmwllc.lucille.connector.FileConnector.GET_FILE_CONTENT;
@@ -316,13 +316,13 @@ public class S3StorageClientTest {
     // check documents published from jsonlCsvAndFolderWithFooTxt.tar
     Document doc1 = docs.get(0);
     assertEquals("default.csv-1", doc1.getId());
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "default.csv", doc1.getString("source"));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc1.getString("source"));
     Document doc2 = docs.get(1);
     assertEquals("default.csv-2", doc2.getId());
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "default.csv", doc2.getString("source"));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc2.getString("source"));
     Document doc3 = docs.get(2);
     assertEquals("default.csv-3", doc3.getId());
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "default.csv", doc3.getString("source"));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc3.getString("source"));
     Document doc4 = docs.get(3);
     assertEquals("2", doc4.getId());
     assertEquals("Gorgeous Woman Mug", doc4.getString("name"));
@@ -330,26 +330,26 @@ public class S3StorageClientTest {
     assertEquals("3", doc5.getId());
     assertEquals("Awesome City Mug", doc5.getString("name"));
     Document doc6 = docs.get(5);
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc6.getString(FILE_PATH));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar" + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc6.getString(FILE_PATH));
 
     // check document published from hello.zip
     Document doc7 = docs.get(6);
-    assertEquals("s3://bucket/hello.zip" + FILE_SEPARATOR + "hello", doc7.getString(FILE_PATH));
+    assertEquals("s3://bucket/hello.zip" + ARCHIVE_FILE_SEPARATOR + "hello", doc7.getString(FILE_PATH));
     // check documents published from textFiles.tar
     Document doc8 = docs.get(7);
-    assertEquals("s3://bucket/textFiles.tar" + FILE_SEPARATOR + "helloWorld.txt", doc8.getString(FILE_PATH));
+    assertEquals("s3://bucket/textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "helloWorld.txt", doc8.getString(FILE_PATH));
     Document doc9 = docs.get(8);
-    assertEquals("s3://bucket/textFiles.tar" + FILE_SEPARATOR + "goodbye.txt", doc9.getString(FILE_PATH));
+    assertEquals("s3://bucket/textFiles.tar" + ARCHIVE_FILE_SEPARATOR + "goodbye.txt", doc9.getString(FILE_PATH));
     // check documents published from jsonlCsvAndFolderWithFooTxt.tar.gz
     Document doc10 = docs.get(9);
     assertEquals("default.csv-1", doc10.getId());
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "default.csv", doc10.getString("source"));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc10.getString("source"));
     Document doc11 = docs.get(10);
     assertEquals("default.csv-2", doc11.getId());
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "default.csv", doc11.getString("source"));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc11.getString("source"));
     Document doc12 = docs.get(11);
     assertEquals("default.csv-3", doc12.getId());
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "default.csv", doc12.getString("source"));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "default.csv", doc12.getString("source"));
     Document doc13 = docs.get(12);
     assertEquals("2", doc13.getId());
     assertEquals("Gorgeous Woman Mug", doc13.getString("name"));
@@ -357,20 +357,20 @@ public class S3StorageClientTest {
     assertEquals("3", doc14.getId());
     assertEquals("Awesome City Mug", doc14.getString("name"));
     Document doc15 = docs.get(14);
-    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc15.getString(FILE_PATH));
+    assertEquals("s3://bucket/jsonlCsvAndFolderWithFooTxt.tar.gz" + ARCHIVE_FILE_SEPARATOR + "FolderWithFooTxt/foo.txt", doc15.getString(FILE_PATH));
     // check document published from zippedFolder.zip
     Document doc16 = docs.get(15);
-    assertEquals("s3://bucket/zippedFolder.zip" + FILE_SEPARATOR + "zippedFolder/foo.txt", doc16.getString(FILE_PATH));
+    assertEquals("s3://bucket/zippedFolder.zip" + ARCHIVE_FILE_SEPARATOR + "zippedFolder/foo.txt", doc16.getString(FILE_PATH));
     // check documents published from zipped.csv.zip
     Document doc17 = docs.get(16);
     assertEquals("zipped.csv-1", doc17.getId());
-    assertEquals("s3://bucket/zipped.csv.zip" + FILE_SEPARATOR + "zipped.csv", doc17.getString("source"));
+    assertEquals("s3://bucket/zipped.csv.zip" + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc17.getString("source"));
     Document doc18 = docs.get(17);
     assertEquals("zipped.csv-2", doc18.getId());
-    assertEquals("s3://bucket/zipped.csv.zip" + FILE_SEPARATOR + "zipped.csv", doc18.getString("source"));
+    assertEquals("s3://bucket/zipped.csv.zip" + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc18.getString("source"));
     Document doc19 = docs.get(18);
     assertEquals("zipped.csv-3", doc19.getId());
-    assertEquals("s3://bucket/zipped.csv.zip" + FILE_SEPARATOR + "zipped.csv", doc19.getString("source"));
+    assertEquals("s3://bucket/zipped.csv.zip" + ARCHIVE_FILE_SEPARATOR + "zipped.csv", doc19.getString("source"));
 
     s3StorageClient.shutdown();
   }


### PR DESCRIPTION
Now we have a different character for when we are handling zip / tar files. This just was a small change in `BaseStorageClient` as well as a minor update for `CSVFileHandler` because of how it was assigning IDs to documents.