### PR TITLE
LC-627: Run IDs in Thread Names

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
@@ -184,7 +184,7 @@ class Worker implements Runnable {
     WorkerMessengerFactory workerMessengerFactory =
         WorkerMessengerFactory.getKafkaFactory(config, pipelineName);
 
-    WorkerPool workerPool = new WorkerPool(config, pipelineName, workerMessengerFactory, pipelineName);
+    WorkerPool workerPool = new WorkerPool(config, pipelineName, null, workerMessengerFactory, pipelineName);
     workerPool.start();
 
     Signal.handle(new Signal("INT"), signal -> {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/WorkerPool.java
@@ -41,15 +41,18 @@ public class WorkerPool {
 
   private final Config config;
   private final String pipelineName;
+  // The current runId, if in a local mode.
+  private final String localRunId;
   private Integer numWorkers = null;
   private WorkerMessengerFactory workerMessengerFactory;
   private boolean started = false;
   private final int logSeconds;
   private final String metricsPrefix;
 
-  public WorkerPool(Config config, String pipelineName, WorkerMessengerFactory factory, String metricsPrefix) {
+  public WorkerPool(Config config, String pipelineName, String localRunId, WorkerMessengerFactory factory, String metricsPrefix) {
     this.config = config;
     this.pipelineName = pipelineName;
+    this.localRunId = localRunId;
     this.workerMessengerFactory = factory;
     this.metricsPrefix = metricsPrefix;
     try {
@@ -80,7 +83,7 @@ public class WorkerPool {
       for (int i = 0; i < numWorkers; i++) {
         WorkerMessenger messenger = workerMessengerFactory.create();
 
-        String name = ThreadNameUtils.createName("Worker-" + (i + 1));
+        String name = ThreadNameUtils.createName("Worker-" + (i + 1), localRunId);
         // will throw exception if pipeline has errors
         Worker worker = new Worker(config, messenger, pipelineName, metricsPrefix);
         workers.add(worker);
@@ -175,7 +178,7 @@ public class WorkerPool {
 
     // creating a thread factory for executor to use
     BasicThreadFactory factory = new BasicThreadFactory.Builder()
-        .namingPattern(ThreadNameUtils.createName("WorkerWatcherExecutorService"))
+        .namingPattern(ThreadNameUtils.createName("WorkerWatcherExecutorService", localRunId))
         .daemon(true)
         .priority(Thread.NORM_PRIORITY)
         .build();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
@@ -6,20 +6,23 @@ import org.apache.commons.lang3.ThreadUtils;
 public class ThreadNameUtils {
   public static final String THREAD_NAME_PREFIX = "Lucille";
 
+  /**
+   * Create a Thread name with the given name.
+   */
   public static String createName(String name) {
-    return THREAD_NAME_PREFIX + "-" + name;
+    return createName(name, null);
   }
 
   /**
-   * Create a Thread name with the given name and runId associated. If the given runId is null,
-   * it will not be included in the thread name - the default will be returned.
+   * Create a Thread name with the given name and runId associated. If the given runId is null, the thread name
+   * will just be the base prefix and the given name.
    */
   public static String createName(String name, String runId) {
     if (runId == null) {
-      return createName(name);
+      return THREAD_NAME_PREFIX + "-" + name;
+    } else {
+      return THREAD_NAME_PREFIX + "-" + runId + "-" + name;
     }
-
-    return THREAD_NAME_PREFIX + "-" + runId + "-" + name;
   }
 
   public static boolean isLucilleThread(Thread thread) {return thread.getName().startsWith(THREAD_NAME_PREFIX);}

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ThreadNameUtils.java
@@ -6,9 +6,20 @@ import org.apache.commons.lang3.ThreadUtils;
 public class ThreadNameUtils {
   public static final String THREAD_NAME_PREFIX = "Lucille";
 
-
   public static String createName(String name) {
     return THREAD_NAME_PREFIX + "-" + name;
+  }
+
+  /**
+   * Create a Thread name with the given name and runId associated. If the given runId is null,
+   * it will not be included in the thread name - the default will be returned.
+   */
+  public static String createName(String name, String runId) {
+    if (runId == null) {
+      return createName(name);
+    }
+
+    return THREAD_NAME_PREFIX + "-" + runId + "-" + name;
   }
 
   public static boolean isLucilleThread(Thread thread) {return thread.getName().startsWith(THREAD_NAME_PREFIX);}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HeartbeatTest.java
@@ -29,7 +29,7 @@ public class HeartbeatTest {
     }
 
     Config config = ConfigFactory.load("WorkerPoolTest/watcher.conf");
-    WorkerPool pool1 = new WorkerPool(config, "pipeline1",
+    WorkerPool pool1 = new WorkerPool(config, "pipeline1", null,
         WorkerMessengerFactory.getConstantFactory(new LocalMessenger()), "");
 
     pool1.start();

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerPoolTest.java
@@ -23,10 +23,10 @@ public class WorkerPoolTest {
   public void testParseConfig() throws Exception {
     Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
 
-    WorkerPool pool1 = new WorkerPool(config, "pipeline1", null, "");
-    WorkerPool pool2 = new WorkerPool(config, "pipeline2", null, "");
-    WorkerPool pool3 = new WorkerPool(config, "pipeline3", null, "");
-    WorkerPool pool4 = new WorkerPool(ConfigFactory.empty(), "pipeline4", null, "");
+    WorkerPool pool1 = new WorkerPool(config, "pipeline1", null, null, "");
+    WorkerPool pool2 = new WorkerPool(config, "pipeline2", null, null, "");
+    WorkerPool pool3 = new WorkerPool(config, "pipeline3", null, null, "");
+    WorkerPool pool4 = new WorkerPool(ConfigFactory.empty(), "pipeline4", null, null, "");
 
     assertEquals(14, pool1.getNumWorkers());
     assertEquals(23, pool2.getNumWorkers());
@@ -55,7 +55,7 @@ public class WorkerPoolTest {
     TestMessenger messenger = Mockito.spy(new TestMessenger());
     WorkerMessengerFactory factory = WorkerMessengerFactory.getConstantFactory(messenger);
     WorkerPool pool = new WorkerPool(ConfigFactory.load("WorkerPoolTest/onePipeline.conf"),
-        "pipeline1", factory, "metricsPrefix");
+        "pipeline1", null, factory, "metricsPrefix");
     pool.start();
     pool.stop();
     pool.join();
@@ -69,7 +69,7 @@ public class WorkerPoolTest {
     WorkerMessengerFactory factory = WorkerMessengerFactory.getConstantFactory(messenger);
     Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
     // pipeline12345 is not present in config.conf
-    WorkerPool pool = new WorkerPool(config, "pipeline12345", factory, "");
+    WorkerPool pool = new WorkerPool(config, "pipeline12345", null, factory, "");
 
     assertThrows(Exception.class, () -> { pool.start(); });
 
@@ -79,7 +79,7 @@ public class WorkerPoolTest {
   @Test
   public void testThreadCleanupUponEncounteringNullMessenger() throws Exception {
     Config config = ConfigFactory.load("WorkerPoolTest/config.conf");
-    WorkerPool pool = new WorkerPool(config, "pipeline1", null, "");
+    WorkerPool pool = new WorkerPool(config, "pipeline1", null, null, "");
 
     assertThrows(Exception.class, () -> { pool.start(); });
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/WorkerTest.java
@@ -1,7 +1,7 @@
 package com.kmwllc.lucille.core;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,8 +46,9 @@ public class WorkerTest {
 
       assertEquals(args.get(pool).get(0), config);
       assertEquals(args.get(pool).get(1), "foo");
-      assertEquals(args.get(pool).get(2), mockFactory);
-      assertEquals(args.get(pool).get(3), "foo");
+      assertNull(args.get(pool).get(2));
+      assertEquals(args.get(pool).get(3), mockFactory);
+      assertEquals(args.get(pool).get(4), "foo");
     }
   }
   @Test
@@ -78,10 +79,11 @@ public class WorkerTest {
       assertEquals(1, constructed.size());
       WorkerPool pool = constructed.get(0);
 
-      assertEquals(args.get(pool).get(0), config);
-      assertEquals(args.get(pool).get(1), "foo2");
-      assertEquals(args.get(pool).get(2), mockFactory2);
-      assertEquals(args.get(pool).get(3), "foo2");
+      assertEquals(config, args.get(pool).get(0));
+      assertEquals("foo2", args.get(pool).get(1));
+      assertNull(args.get(pool).get(2));
+      assertEquals(mockFactory2, args.get(pool).get(3));
+      assertEquals("foo2", args.get(pool).get(4));
     }
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/ThreadNameUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/ThreadNameUtilsTest.java
@@ -1,0 +1,19 @@
+package com.kmwllc.lucille.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ThreadNameUtilsTest {
+
+  @Test
+  public void testCreateName() {
+    String nameUsingConvenience = ThreadNameUtils.createName("test");
+    String nameUsingNull = ThreadNameUtils.createName("test", null);
+    String nameWithRunId = ThreadNameUtils.createName("test", "runId");
+
+    assertEquals("Lucille-test", nameUsingConvenience);
+    assertEquals("Lucille-test", nameUsingNull);
+    assertEquals("Lucille-runId-test", nameWithRunId);
+  }
+}


### PR DESCRIPTION
Connector threads always get the runID. We only attach them to Worker/Indexer threads in local runs. Many of the "localRunID" changes/plumbing are mirrored in LC-608,