### PR TITLE
LC-643: More rigid VerifyIngestResult assertions

### DIFF
--- a/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
+++ b/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -27,7 +28,27 @@ public class VerifyIngestResult {
       docs.add(json.get("response").get("docs").get(i));
     }
 
-    JsonNode csvDoc1 = docs.get(0);
+    docs.sort(Comparator.comparing(o -> o.get("id").asText()));
+
+    JsonNode jsonDoc1 = docs.get(0);
+    assertEquals("3", jsonDoc1.get("id").asText());
+    assertEquals("USA", jsonDoc1.get("my_country").get(0).asText());
+    assertEquals("Burger", jsonDoc1.get("my_name").get(0).asText());
+    assertEquals(30, jsonDoc1.get("my_price").get(0).asInt());
+
+    JsonNode jsonDoc2 = docs.get(1);
+    assertEquals("4", jsonDoc2.get("id").asText());
+    assertEquals("USA", jsonDoc2.get("my_country").get(0).asText());
+    assertEquals("Salad", jsonDoc2.get("my_name").get(0).asText());
+    assertEquals(10, jsonDoc2.get("my_price").get(0).asInt());
+
+    JsonNode jsonDoc3 = docs.get(2);
+    assertEquals("5", jsonDoc3.get("id").asText());
+    assertEquals("France", jsonDoc3.get("my_country").get(0).asText());
+    assertEquals("Wine", jsonDoc3.get("my_name").get(0).asText());
+    assertEquals(12, jsonDoc3.get("my_price").get(0).asInt());
+
+    JsonNode csvDoc1 = docs.get(3);
     assertEquals("source.csv-1", csvDoc1.get("id").asText());
     assertEquals("/conf/source.csv", csvDoc1.get("source").get(0).asText());
     assertEquals("source.csv", csvDoc1.get("filename").get(0).asText());
@@ -35,7 +56,7 @@ public class VerifyIngestResult {
     assertEquals("Carbonara", csvDoc1.get("my_name").get(0).asText());
     assertEquals(30, csvDoc1.get("my_price").get(0).asInt());
 
-    JsonNode csvDoc2 = docs.get(1);
+    JsonNode csvDoc2 = docs.get(4);
     assertEquals("source.csv-2", csvDoc2.get("id").asText());
     assertEquals("/conf/source.csv", csvDoc2.get("source").get(0).asText());
     assertEquals("source.csv", csvDoc2.get("filename").get(0).asText());
@@ -43,30 +64,12 @@ public class VerifyIngestResult {
     assertEquals("Pizza", csvDoc2.get("my_name").get(0).asText());
     assertEquals(10, csvDoc2.get("my_price").get(0).asInt());
 
-    JsonNode csvDoc3 = docs.get(2);
+    JsonNode csvDoc3 = docs.get(5);
     assertEquals("source.csv-3", csvDoc3.get("id").asText());
     assertEquals("/conf/source.csv", csvDoc3.get("source").get(0).asText());
     assertEquals("source.csv", csvDoc3.get("filename").get(0).asText());
     assertEquals("Korea", csvDoc3.get("my_country").get(0).asText());
     assertEquals("Tofu Soup", csvDoc3.get("my_name").get(0).asText());
     assertEquals(12, csvDoc3.get("my_price").get(0).asInt());
-
-    JsonNode jsonDoc1 = docs.get(3);
-    assertEquals("3", jsonDoc1.get("id").asText());
-    assertEquals("USA", jsonDoc1.get("my_country").get(0).asText());
-    assertEquals("Burger", jsonDoc1.get("my_name").get(0).asText());
-    assertEquals(30, jsonDoc1.get("my_price").get(0).asInt());
-
-    JsonNode jsonDoc2 = docs.get(4);
-    assertEquals("4", jsonDoc2.get("id").asText());
-    assertEquals("USA", jsonDoc2.get("my_country").get(0).asText());
-    assertEquals("Salad", jsonDoc2.get("my_name").get(0).asText());
-    assertEquals(10, jsonDoc2.get("my_price").get(0).asInt());
-
-    JsonNode jsonDoc3 = docs.get(5);
-    assertEquals("5", jsonDoc3.get("id").asText());
-    assertEquals("France", jsonDoc3.get("my_country").get(0).asText());
-    assertEquals("Wine", jsonDoc3.get("my_name").get(0).asText());
-    assertEquals(12, jsonDoc3.get("my_price").get(0).asInt());
   }
 }

--- a/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
+++ b/lucille-examples/lucille-distributed-example/src/test/java/com/kmwllc/lucille/distributed/VerifyIngestResult.java
@@ -1,7 +1,7 @@
 package com.kmwllc.lucille.distributed;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -27,30 +27,46 @@ public class VerifyIngestResult {
       docs.add(json.get("response").get("docs").get(i));
     }
 
-    assertTrue(docs.stream()
-        .anyMatch(doc -> doc.get("id").asText().equals("source.csv-1")
-            && doc.get("source").get(0).asText().equals("/conf/source.csv")
-            && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Italy")
-            && doc.get("my_price").get(0).asInt() == 30 && doc.get("my_name").get(0).asText().equals("Carbonara")));
-    assertTrue(docs.stream()
-        .anyMatch(doc -> doc.get("id").asText().equals("source.csv-2")
-            && doc.get("source").get(0).asText().equals("/conf/source.csv")
-            && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Italy")
-            && doc.get("my_price").get(0).asInt() == 10 && doc.get("my_name").get(0).asText().equals("Pizza")));
-    assertTrue(docs.stream()
-        .anyMatch(doc -> doc.get("id").asText().equals("source.csv-3")
-            && doc.get("source").get(0).asText().equals("/conf/source.csv")
-            && doc.get("filename").get(0).asText().equals("source.csv") && doc.get("my_country").get(0).asText().equals("Korea")
-            && doc.get("my_price").get(0).asInt() == 12 && doc.get("my_name").get(0).asText().equals("Tofu Soup")));
+    JsonNode csvDoc1 = docs.get(0);
+    assertEquals("source.csv-1", csvDoc1.get("id").asText());
+    assertEquals("/conf/source.csv", csvDoc1.get("source").get(0).asText());
+    assertEquals("source.csv", csvDoc1.get("filename").get(0).asText());
+    assertEquals("Italy", csvDoc1.get("my_country").get(0).asText());
+    assertEquals("Carbonara", csvDoc1.get("my_name").get(0).asText());
+    assertEquals(30, csvDoc1.get("my_price").get(0).asInt());
 
-    assertTrue(
-        docs.stream().anyMatch(doc -> doc.get("id").asText().equals("3") && doc.get("my_country").get(0).asText().equals("USA")
-            && doc.get("my_price").get(0).asInt() == 30 && doc.get("my_name").get(0).asText().equals("Burger")));
-    assertTrue(
-        docs.stream().anyMatch(doc -> doc.get("id").asText().equals("4") && doc.get("my_country").get(0).asText().equals("USA")
-            && doc.get("my_price").get(0).asInt() == 10 && doc.get("my_name").get(0).asText().equals("Salad")));
-    assertTrue(
-        docs.stream().anyMatch(doc -> doc.get("id").asText().equals("5") && doc.get("my_country").get(0).asText().equals("France")
-            && doc.get("my_price").get(0).asInt() == 12 && doc.get("my_name").get(0).asText().equals("Wine")));
+    JsonNode csvDoc2 = docs.get(1);
+    assertEquals("source.csv-2", csvDoc2.get("id").asText());
+    assertEquals("/conf/source.csv", csvDoc2.get("source").get(0).asText());
+    assertEquals("source.csv", csvDoc2.get("filename").get(0).asText());
+    assertEquals("Italy", csvDoc2.get("my_country").get(0).asText());
+    assertEquals("Pizza", csvDoc2.get("my_name").get(0).asText());
+    assertEquals(10, csvDoc2.get("my_price").get(0).asInt());
+
+    JsonNode csvDoc3 = docs.get(2);
+    assertEquals("source.csv-3", csvDoc3.get("id").asText());
+    assertEquals("/conf/source.csv", csvDoc3.get("source").get(0).asText());
+    assertEquals("source.csv", csvDoc3.get("filename").get(0).asText());
+    assertEquals("Korea", csvDoc3.get("my_country").get(0).asText());
+    assertEquals("Tofu Soup", csvDoc3.get("my_name").get(0).asText());
+    assertEquals(12, csvDoc3.get("my_price").get(0).asInt());
+
+    JsonNode jsonDoc1 = docs.get(3);
+    assertEquals("3", jsonDoc1.get("id").asText());
+    assertEquals("USA", jsonDoc1.get("my_country").get(0).asText());
+    assertEquals("Burger", jsonDoc1.get("my_name").get(0).asText());
+    assertEquals(30, jsonDoc1.get("my_price").get(0).asInt());
+
+    JsonNode jsonDoc2 = docs.get(4);
+    assertEquals("4", jsonDoc2.get("id").asText());
+    assertEquals("USA", jsonDoc2.get("my_country").get(0).asText());
+    assertEquals("Salad", jsonDoc2.get("my_name").get(0).asText());
+    assertEquals(10, jsonDoc2.get("my_price").get(0).asInt());
+
+    JsonNode jsonDoc3 = docs.get(5);
+    assertEquals("5", jsonDoc3.get("id").asText());
+    assertEquals("France", jsonDoc3.get("my_country").get(0).asText());
+    assertEquals("Wine", jsonDoc3.get("my_name").get(0).asText());
+    assertEquals(12, jsonDoc3.get("my_price").get(0).asInt());
   }
 }


### PR DESCRIPTION
In the event of a test failure, it'll be a bit clearer which field caused the assertion to fail - so we can see it directly from the nightly smoketest and won't have to replicate locally by running the example and then running docker compose up, to gain access to Solr.