### PR TITLE
LC-644: Replace KafkaJUnit

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.7.2</version>
+      <version>3.8.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -347,17 +347,17 @@
     </dependency>
 
     <dependency>
-        <groupId>org.springframework.kafka</groupId>
-        <artifactId>spring-kafka</artifactId>
-        <version>3.2.7</version>
-        <scope>test</scope>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+      <version>3.3.3</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-        <groupId>org.springframework.kafka</groupId>
-        <artifactId>spring-kafka-test</artifactId>
-        <version>3.2.7</version>
-        <scope>test</scope>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <version>3.3.3</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -358,14 +358,6 @@
         <version>3.1.2</version>
         <scope>test</scope>
     </dependency>
-
-    <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>kafka</artifactId>
-        <version>1.19.3</version>
-        <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.6.1</version>
+      <version>3.7.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -349,13 +349,13 @@
     <dependency>
         <groupId>org.springframework.kafka</groupId>
         <artifactId>spring-kafka</artifactId>
-        <version>3.3.3</version>
+        <version>3.2.7</version>
     </dependency>
 
     <dependency>
         <groupId>org.springframework.kafka</groupId>
         <artifactId>spring-kafka-test</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.7</version>
         <scope>test</scope>
     </dependency>
   </dependencies>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -312,20 +312,6 @@
       <version>4.2.18</version>
     </dependency>
 
-    <dependency>
-      <groupId>net.mguenther.kafka</groupId>
-      <artifactId>kafka-junit</artifactId>
-      <version>3.6.0</version>
-      <scope>test</scope>
-      <!-- Bug in junit 5.6.2 that doesn't support junit 4.13.2 (only 4.12 and 4.13) -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
     <!--  test dependency for db connector tests -->
     <dependency>
       <groupId>com.h2database</groupId>
@@ -360,8 +346,27 @@
       <version>2.4.0</version>
     </dependency>
 
-  </dependencies>
+    <dependency>
+        <groupId>org.springframework.kafka</groupId>
+        <artifactId>spring-kafka</artifactId>
+        <version>3.3.3</version>
+    </dependency>
 
+    <dependency>
+        <groupId>org.springframework.kafka</groupId>
+        <artifactId>spring-kafka-test</artifactId>
+        <version>3.1.2</version>
+        <scope>test</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>kafka</artifactId>
+        <version>1.19.3</version>
+        <scope>test</scope>
+    </dependency>
+
+  </dependencies>
 
 
   <build>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -350,6 +350,7 @@
         <groupId>org.springframework.kafka</groupId>
         <artifactId>spring-kafka</artifactId>
         <version>3.2.7</version>
+        <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
@@ -143,6 +143,7 @@ public class HybridKafkaTest {
 
     String eventTopicName = KafkaUtils.getEventTopicName(config, "pipeline1", RUN_ID);
 
+    // TODO: Get all 15
     ConsumerRecord<String, String> record15 = template.receive(eventTopicName, 0, 14);
 
     // the last event should be the indexing event for doc3 (which should be indexed after its children);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
@@ -113,9 +113,9 @@ public class HybridKafkaTest {
     Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
         kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
             .partitionsToOffsetAndMetadata().get();
-    TopicPartition sourceTopicPartition = new TopicPartition(topicName, 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition));
-    assertEquals(3, retrievedOffsets.get(sourceTopicPartition).offset());
+    TopicPartition topicPartition = new TopicPartition(topicName, 0);
+    assertNotNull(retrievedOffsets.get(topicPartition));
+    assertEquals(3, retrievedOffsets.get(topicPartition).offset());
 
     // pipelineDest and offset queues should have been drained
     assertEquals(0, pipelineDest.size());
@@ -128,7 +128,7 @@ public class HybridKafkaTest {
     // one offset map should have been added to offset queue, containing offset 3 for partition 0
     assertEquals(1, offsets.getHistory().size());
     assertEquals(1, offsets.getHistory().get(0).entrySet().size());
-    assertEquals(3, offsets.getHistory().get(0).get(sourceTopicPartition).offset());
+    assertEquals(3, offsets.getHistory().get(0).get(topicPartition).offset());
   }
 
   @Test
@@ -360,9 +360,9 @@ public class HybridKafkaTest {
   @Test
   public void testWorkerIndexerPool() throws Exception {
     Config config = ConfigFactory.load("HybridKafkaTest/poolConfig.conf");
-    String sourceTopic = config.getString("kafka.sourceTopic");
+    String topicName = config.getString("kafka.sourceTopic");
 
-    embeddedKafka.getEmbeddedKafka().addTopics(new NewTopic(sourceTopic, 5, (short) 1));
+    embeddedKafka.getEmbeddedKafka().addTopics(new NewTopic(topicName, 5, (short) 1));
 
     Set<String> idSet = CounterUtils.getThreadSafeSet();
     WorkerIndexerPool pool =
@@ -371,13 +371,13 @@ public class HybridKafkaTest {
     assertEquals(5, pool.getNumWorkers());
 
     for (int i = 0; i < 500; i++) {
-      sendDoc("doc" + i, sourceTopic);
+      sendDoc("doc" + i, topicName);
     }
 
     pool.start();
 
     for (int i = 500; i < 1000; i++) {
-      sendDoc("doc" + i, sourceTopic);
+      sendDoc("doc" + i, topicName);
     }
 
     CounterUtils.waitUnique(idSet, 1000);
@@ -390,11 +390,11 @@ public class HybridKafkaTest {
     Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
         kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
             .partitionsToOffsetAndMetadata().get();
-    TopicPartition partition0 = new TopicPartition(sourceTopic, 0);
-    TopicPartition partition1 = new TopicPartition(sourceTopic, 1);
-    TopicPartition partition2 = new TopicPartition(sourceTopic, 2);
-    TopicPartition partition3 = new TopicPartition(sourceTopic, 3);
-    TopicPartition partition4 = new TopicPartition(sourceTopic, 4);
+    TopicPartition partition0 = new TopicPartition(topicName, 0);
+    TopicPartition partition1 = new TopicPartition(topicName, 1);
+    TopicPartition partition2 = new TopicPartition(topicName, 2);
+    TopicPartition partition3 = new TopicPartition(topicName, 3);
+    TopicPartition partition4 = new TopicPartition(topicName, 4);
 
     long sumOffsets = retrievedOffsets.get(partition0).offset() +
         retrievedOffsets.get(partition1).offset() +
@@ -409,7 +409,7 @@ public class HybridKafkaTest {
 
   @Test
   public void testSourceTopicWildcard() throws Exception {
-    // sourceTopic: "test_wildcard_topic.*"
+    // topicName: "test_wildcard_topic.*"
     Config config = ConfigFactory.load("HybridKafkaTest/sourceTopicWildcard.conf");
 
     embeddedKafka.getEmbeddedKafka().addTopics(new NewTopic("test_wildcard_topic1", 1, (short) 1));
@@ -450,18 +450,18 @@ public class HybridKafkaTest {
     Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
         kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
             .partitionsToOffsetAndMetadata().get();
-    TopicPartition sourceTopicPartition1 = new TopicPartition("test_wildcard_topic1", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition1));
-    assertEquals(1, retrievedOffsets.get(sourceTopicPartition1).offset());
-    TopicPartition sourceTopicPartition2 = new TopicPartition("test_wildcard_topic2", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition2));
-    assertEquals(1, retrievedOffsets.get(sourceTopicPartition2).offset());
-    TopicPartition sourceTopicPartition3 = new TopicPartition("test_wildcard_topic3", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition3));
-    assertEquals(2, retrievedOffsets.get(sourceTopicPartition3).offset());
-    TopicPartition sourceTopicPartition4 = new TopicPartition("test_wildcard_topic4", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition4));
-    assertEquals(1, retrievedOffsets.get(sourceTopicPartition4).offset());
+    TopicPartition topicPartition1 = new TopicPartition("test_wildcard_topic1", 0);
+    assertNotNull(retrievedOffsets.get(topicPartition1));
+    assertEquals(1, retrievedOffsets.get(topicPartition1).offset());
+    TopicPartition topicPartition2 = new TopicPartition("test_wildcard_topic2", 0);
+    assertNotNull(retrievedOffsets.get(topicPartition2));
+    assertEquals(1, retrievedOffsets.get(topicPartition2).offset());
+    TopicPartition topicPartition3 = new TopicPartition("test_wildcard_topic3", 0);
+    assertNotNull(retrievedOffsets.get(topicPartition3));
+    assertEquals(2, retrievedOffsets.get(topicPartition3).offset());
+    TopicPartition topicPartition4 = new TopicPartition("test_wildcard_topic4", 0);
+    assertNotNull(retrievedOffsets.get(topicPartition4));
+    assertEquals(1, retrievedOffsets.get(topicPartition4).offset());
 
     // pipelineDest and offset queues should have been drained
     assertEquals(0, pipelineDest.size());
@@ -476,10 +476,10 @@ public class HybridKafkaTest {
     assertEquals(2, offsets.getHistory().get(0).entrySet().size());
     assertEquals(2, offsets.getHistory().get(1).entrySet().size());
 
-    assertEquals(1, offsets.getHistory().get(0).get(sourceTopicPartition1).offset());
-    assertEquals(1, offsets.getHistory().get(0).get(sourceTopicPartition2).offset());
-    assertEquals(2, offsets.getHistory().get(1).get(sourceTopicPartition3).offset());
-    assertEquals(1, offsets.getHistory().get(1).get(sourceTopicPartition4).offset());
+    assertEquals(1, offsets.getHistory().get(0).get(topicPartition1).offset());
+    assertEquals(1, offsets.getHistory().get(0).get(topicPartition2).offset());
+    assertEquals(2, offsets.getHistory().get(1).get(topicPartition3).offset());
+    assertEquals(1, offsets.getHistory().get(1).get(topicPartition4).offset());
 
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
@@ -126,8 +126,11 @@ public class HybridKafkaTest {
 
   @Test
   public void testRunInKafkaHybridModeWithEvents() throws Exception {
+    // this config has "kafka.events: true"
     Config config = ConfigFactory.load("HybridKafkaTest/childrenConfigWithEvents.conf");
     String topicName = config.getString("kafka.sourceTopic");
+
+    embeddedKafka.getEmbeddedKafka().addTopics(new NewTopic(topicName, 1, (short) 1));
 
     sendDoc("doc1", RUN_ID, topicName);
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,6 +68,13 @@ public class HybridKafkaTest {
 
     DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
     template.setConsumerFactory(cf);
+  }
+
+  @After
+  public void tearDown() {
+    // Even though the @Rule should be recreating embeddedKafka each time, I was occasionally getting concurrent errors
+    // that topics already existed. Hoping this prevents it.
+    embeddedKafka.getEmbeddedKafka().destroy();
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
@@ -45,6 +45,8 @@ public class HybridKafkaTest {
   private static final String RUN_ID = "run1";
 
   // An embedded instance of Kafka created for each test that is run.
+  // NOTE: Creating an instance of Kafka once allows this test to be a bit faster. It means that you need
+  // to make sure each test has its OWN, UNIQUE topic name.
   @ClassRule
   public static final EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 1).kafkaPorts(9090).zkPort(9091);
 
@@ -396,7 +398,7 @@ public class HybridKafkaTest {
 
   @Test
   public void testSourceTopicWildcard() throws Exception {
-    // sourceTopic: "test_topic.*"
+    // sourceTopic: "test_wildcard_topic.*"
     Config config = ConfigFactory.load("HybridKafkaTest/sourceTopicWildcard.conf");
 
     embeddedKafka.getEmbeddedKafka().addTopics(new NewTopic("test_wildcard_topic1", 1, (short) 1));
@@ -423,7 +425,7 @@ public class HybridKafkaTest {
     sendDoc("doc3", "test_wildcard_topic3");
     sendDoc("doc4", "test_wildcard_topic4");
 
-    // send a second doc to test_topic_wildcard3
+    // send a second doc to test_wildcard_topic3
     sendDoc("doc5", "test_wildcard_topic3");
 
     CounterUtils.waitUnique(idSet, 5, 3 * 60 * 1000, CounterUtils.DEFAULT_END_LAG_MS);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
@@ -99,10 +99,14 @@ public class HybridKafkaTest {
     sendDoc("doc2", topicName);
     sendDoc("doc3", topicName);
 
+    // 9 docs should be indexed: three parents with two children each
     CounterUtils.waitUnique(idSet, 9);
 
     workerIndexer.stop();
 
+    // confirm that the consumer group is looking at offset 3 in the source topic,
+    // indicating it has consumed 3 documents (at offsets 0, 1, 2) and that offsets
+    // have been properly committed
     Properties props = new Properties();
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getString("kafka.bootstrapServers"));
     Admin kafkaAdminClient = Admin.create(props);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/HybridKafkaTest.java
@@ -1,60 +1,95 @@
 package com.kmwllc.lucille.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.kmwllc.lucille.message.KafkaUtils;
 import com.kmwllc.lucille.util.CounterUtils;
 import com.kmwllc.lucille.util.RecordingLinkedBlockingQueue;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
-import net.mguenther.kafka.junit.KeyValue;
-import net.mguenther.kafka.junit.ReadKeyValues;
-import net.mguenther.kafka.junit.SendKeyValues;
-import net.mguenther.kafka.junit.TopicConfig;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KeyValue;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-import java.util.*;
-import java.util.concurrent.LinkedBlockingQueue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.Message;
 
-import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
-import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
-import static org.junit.Assert.*;
-
-@RunWith(JUnit4.class)
 public class HybridKafkaTest {
 
   private static final String RUN_ID = "run1";
-  private EmbeddedKafkaCluster kafka;
+
+  @ClassRule
+  public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 1).kafkaPorts(9090).zkPort(9091);
+
+  KafkaTemplate<String, String> template;
 
   @Before
-  public void setupKafka() {
-    kafka = provisionWith(defaultClusterConfig());
-    kafka.start();
-  }
+  public void setUp() throws Exception {
+    Map<String, Object> producerProps =
+        KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
+    producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
-  @After
-  public void tearDownKafka() {
-    kafka.stop();
+    ProducerFactory<String, String> pf =
+        new DefaultKafkaProducerFactory<>(producerProps);
+    template = new KafkaTemplate<>(pf);
+
+    Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("lucille_workers", "false", embeddedKafka.getEmbeddedKafka());
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+    DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+    template.setConsumerFactory(cf);
   }
 
   @Test
-  public void testRunInKafkaHybridMode() throws Exception {
-    // use a pipeline that generates children documents to confirm they are handled properly in hybrid mode
-    // child docs do not originate in kafka so the logic for committing offsets should ignore them
+  public void testRunInHybridMode() throws Exception {
     Config config = ConfigFactory.load("HybridKafkaTest/childrenConfig.conf");
+    String topicName = config.getString("kafka.sourceTopic");
 
-    String sourceTopic = config.getString("kafka.sourceTopic");
-    kafka.createTopic(TopicConfig.withName(sourceTopic).withNumberOfPartitions(1));
+    embeddedKafka.getEmbeddedKafka().addTopics(new NewTopic(topicName, 1, (short) 1));
 
-    sendDoc("doc1", sourceTopic);
+    // send doc - doc1
+    sendDoc("doc1", topicName);
 
     WorkerIndexer workerIndexer = new WorkerIndexer();
 
@@ -67,24 +102,21 @@ public class HybridKafkaTest {
     Set<String> idSet = CounterUtils.getThreadSafeSet();
     workerIndexer.start(config, "pipeline1", pipelineDest, offsets, true, idSet);
 
-    sendDoc("doc2", sourceTopic);
-    sendDoc("doc3", sourceTopic);
+    // send docs 2 and 3
+    sendDoc("doc2", topicName);
+    sendDoc("doc3", topicName);
 
-    // 9 docs should be indexed: three parents with two children each
     CounterUtils.waitUnique(idSet, 9);
 
     workerIndexer.stop();
 
-    // confirm that the consumer group is looking at offset 3 in the source topic,
-    // indicating it has consumed 3 documents (at offsets 0, 1, 2) and that offsets
-    // have been properly committed
     Properties props = new Properties();
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getString("kafka.bootstrapServers"));
     Admin kafkaAdminClient = Admin.create(props);
     Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
         kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
             .partitionsToOffsetAndMetadata().get();
-    TopicPartition sourceTopicPartition = new TopicPartition(sourceTopic, 0);
+    TopicPartition sourceTopicPartition = new TopicPartition(topicName, 0);
     assertNotNull(retrievedOffsets.get(sourceTopicPartition));
     assertEquals(3, retrievedOffsets.get(sourceTopicPartition).offset());
 
@@ -104,15 +136,10 @@ public class HybridKafkaTest {
 
   @Test
   public void testRunInKafkaHybridModeWithEvents() throws Exception {
-    // this config has "kafka.events: true"
     Config config = ConfigFactory.load("HybridKafkaTest/childrenConfigWithEvents.conf");
+    String topicName = config.getString("kafka.sourceTopic");
 
-    String sourceTopic = config.getString("kafka.sourceTopic");
-    kafka.createTopic(TopicConfig.withName(sourceTopic).withNumberOfPartitions(1));
-
-    KafkaUtils.createEventTopic(config, "pipeline1", RUN_ID);
-
-    sendDoc("doc1", RUN_ID, sourceTopic);
+    sendDoc("doc1", RUN_ID, topicName);
 
     WorkerIndexer workerIndexer = new WorkerIndexer();
     LinkedBlockingQueue<Document> pipelineDest = new LinkedBlockingQueue<>();
@@ -121,8 +148,8 @@ public class HybridKafkaTest {
 
     workerIndexer.start(config, "pipeline1", pipelineDest, offsets, true, idSet);
 
-    sendDoc("doc2", RUN_ID, sourceTopic);
-    sendDoc("doc3", RUN_ID, sourceTopic);
+    sendDoc("doc2", RUN_ID, topicName);
+    sendDoc("doc3", RUN_ID, topicName);
 
     CounterUtils.waitUnique(idSet, 9);
 
@@ -130,19 +157,16 @@ public class HybridKafkaTest {
 
     String eventTopicName = KafkaUtils.getEventTopicName(config, "pipeline1", RUN_ID);
 
-    List<KeyValue<String, String>> records = kafka.read(ReadKeyValues
-        .from(eventTopicName));
-
-    // there should be 15 events in the event topic: 6 child creation events and 9 indexing events
-    assertEquals(15, records.size());
+    ConsumerRecord<String, String> record15 = template.receive(eventTopicName, 0, 14);
 
     // the last event should be the indexing event for doc3 (which should be indexed after its children);
     // in hybrid mode, indexing events should have kafka metadata from the source topic as there
     // is no destination topic;
     // within the source topic, doc3 would have offset 2 (as offsets are 0-based) and this
     // same offset should be recorded on the indexing event for doc3
-    Event event15 = Event.fromJsonString(records.get(14).getValue());
-    assertEquals(sourceTopic, event15.getTopic());
+
+    Event event15 = Event.fromJsonString(record15.value());
+    assertEquals(topicName, event15.getTopic());
     assertEquals(Integer.valueOf(0), event15.getPartition());
     assertEquals(Long.valueOf(2), event15.getOffset());
     assertEquals(Event.Type.FINISH, event15.getType());
@@ -152,12 +176,12 @@ public class HybridKafkaTest {
   @Test
   public void testTwoWorkerIndexerPairs() throws Exception {
     Config config = ConfigFactory.load("HybridKafkaTest/noopConfig.conf");
+    String topicName = config.getString("kafka.sourceTopic");
 
-    String sourceTopic = config.getString("kafka.sourceTopic");
-    kafka.createTopic(TopicConfig.withName(sourceTopic).withNumberOfPartitions(2));
+    embeddedKafka.getEmbeddedKafka().addTopics(new NewTopic(topicName, 2, (short) 1));
 
     for (int i = 0; i < 500; i++) {
-      sendDoc("doc" + i, sourceTopic);
+      sendDoc("doc" + i, topicName);
     }
 
     Set<String> idSet = CounterUtils.getThreadSafeSet();
@@ -184,7 +208,7 @@ public class HybridKafkaTest {
     workerIndexer2.start(config, "pipeline1", pipelineDest2, offsets2, true, idSet);
 
     for (int i = 500; i < 1000; i++) {
-      sendDoc("doc" + i, sourceTopic);
+      sendDoc("doc" + i, topicName);
     }
 
     CounterUtils.waitUnique(idSet, 1000);
@@ -193,8 +217,8 @@ public class HybridKafkaTest {
     workerIndexer2.stop();
 
     KafkaConsumer<String, KafkaDocument> consumer = KafkaUtils.createDocumentConsumer(config, "test-client");
-    TopicPartition p0 = new TopicPartition(sourceTopic, 0);
-    TopicPartition p1 = new TopicPartition(sourceTopic, 1);
+    TopicPartition p0 = new TopicPartition(topicName, 0);
+    TopicPartition p1 = new TopicPartition(topicName, 1);
     ArrayList partitions = new ArrayList<>();
     partitions.add(p0);
     partitions.add(p1);
@@ -296,187 +320,186 @@ public class HybridKafkaTest {
     }
 
   }
-
-  @Test
-  public void testCustomDeserializer() throws Exception {
-    // documentDeserializer: "com.kmwllc.com.kmwllc.lucille.core.NonstandardDocumentDeserializer"
-    Config config = ConfigFactory.load("HybridKafkaTest/customDeserializer.conf");
-
-    String sourceTopic = config.getString("kafka.sourceTopic");
-    kafka.createTopic(TopicConfig.withName(sourceTopic).withNumberOfPartitions(1));
-
-    // inputJson does not have the "id" field required for creating a KafkaDocument
-    String inputJson = "{\"myId\":\"doc1\", \"field1\":\"value1\"}";
-
-    // we expect the custom deserializer to copy myId to id
-    String outputJson = "{\"myId\":\"doc1\",\"field1\":\"value1\",\"id\":\"doc1\"}";
-
-    List<KeyValue<String, String>> records = new ArrayList<>();
-    records.add(new KeyValue<>("doc1", inputJson));
-    kafka.send(SendKeyValues.to(sourceTopic, records));
-
-    WorkerIndexer workerIndexer = new WorkerIndexer();
-
-    RecordingLinkedBlockingQueue<Document> pipelineDest =
-        new RecordingLinkedBlockingQueue<>();
-    RecordingLinkedBlockingQueue<Map<TopicPartition, OffsetAndMetadata>> offsets =
-        new RecordingLinkedBlockingQueue<>();
-
-    Set<String> idSet = CounterUtils.getThreadSafeSet();
-    workerIndexer.start(config, "pipeline1", pipelineDest, offsets, true, idSet);
-
-    CounterUtils.waitUnique(idSet, 1);
-
-    workerIndexer.stop();
-
-    assertEquals(1, pipelineDest.getHistory().size());
-    assertEquals(outputJson, pipelineDest.getHistory().get(0).toString());
-  }
-
-  @Test
-  public void testWorkerIndexerPool() throws Exception {
-    Config config = ConfigFactory.load("HybridKafkaTest/poolConfig.conf");
-
-    String sourceTopic = config.getString("kafka.sourceTopic");
-    kafka.createTopic(TopicConfig.withName(sourceTopic).withNumberOfPartitions(5));
-
-    Set<String> idSet = CounterUtils.getThreadSafeSet();
-    WorkerIndexerPool pool =
-        new WorkerIndexerPool(config, "pipeline1", true, idSet);
-
-    assertEquals(5, pool.getNumWorkers());
-
-    for (int i = 0; i < 500; i++) {
-      sendDoc("doc" + i, sourceTopic);
-    }
-
-    pool.start();
-
-    for (int i = 500; i < 1000; i++) {
-      sendDoc("doc" + i, sourceTopic);
-    }
-
-    CounterUtils.waitUnique(idSet, 1000);
-
-    pool.stop();
-
-    Properties props = new Properties();
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getString("kafka.bootstrapServers"));
-    Admin kafkaAdminClient = Admin.create(props);
-    Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
-        kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
-            .partitionsToOffsetAndMetadata().get();
-    TopicPartition partition0 = new TopicPartition(sourceTopic, 0);
-    TopicPartition partition1 = new TopicPartition(sourceTopic, 1);
-    TopicPartition partition2 = new TopicPartition(sourceTopic, 2);
-    TopicPartition partition3 = new TopicPartition(sourceTopic, 3);
-    TopicPartition partition4 = new TopicPartition(sourceTopic, 4);
-
-    long sumOffsets = retrievedOffsets.get(partition0).offset() +
-        retrievedOffsets.get(partition1).offset() +
-        retrievedOffsets.get(partition2).offset() +
-        retrievedOffsets.get(partition3).offset() +
-        retrievedOffsets.get(partition4).offset();
-
-    // the sum of offsets across the two partitions should be the same as the number of documents
-    // consumed. All 1000 documents we added to the source topic should have been consumed.
-    assertEquals(1000, sumOffsets);
-
-  }
-
-  @Test
-  public void testSourceTopicWildcard() throws Exception {
-    // sourceTopic: "test_topic.*"
-    Config config = ConfigFactory.load("HybridKafkaTest/sourceTopicWildcard.conf");
-
-    kafka.createTopic(TopicConfig.withName("test_topic1").withNumberOfPartitions(1));
-    kafka.createTopic(TopicConfig.withName("test_topic2").withNumberOfPartitions(1));
-
-    sendDoc("doc1", "test_topic1");
-    sendDoc("doc2", "test_topic2");
-
-    WorkerIndexer workerIndexer = new WorkerIndexer();
-
-    RecordingLinkedBlockingQueue<Document> pipelineDest =
-        new RecordingLinkedBlockingQueue<>();
-
-    RecordingLinkedBlockingQueue<Map<TopicPartition, OffsetAndMetadata>> offsets =
-        new RecordingLinkedBlockingQueue<>();
-
-    Set<String> idSet = CounterUtils.getThreadSafeSet();
-    workerIndexer.start(config, "pipeline1", pipelineDest, offsets, true, idSet);
-
-    CounterUtils.waitUnique(idSet, 2, 20000, CounterUtils.DEFAULT_END_LAG_MS);
-
-    kafka.createTopic(TopicConfig.withName("test_topic3").withNumberOfPartitions(1));
-    kafka.createTopic(TopicConfig.withName("test_topic4").withNumberOfPartitions(1));
-    sendDoc("doc3", "test_topic3");
-    sendDoc("doc4", "test_topic4");
-
-    // send a second doc to test_topic3
-    sendDoc("doc5", "test_topic3");
-
-    CounterUtils.waitUnique(idSet, 5, 3 * 60 * 1000, CounterUtils.DEFAULT_END_LAG_MS);
-
-    workerIndexer.stop();
-
-    // confirm that the consumer group is looking at the correct offset in each topic
-    Properties props = new Properties();
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getString("kafka.bootstrapServers"));
-    Admin kafkaAdminClient = Admin.create(props);
-    Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
-        kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
-            .partitionsToOffsetAndMetadata().get();
-    TopicPartition sourceTopicPartition1 = new TopicPartition("test_topic1", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition1));
-    assertEquals(1, retrievedOffsets.get(sourceTopicPartition1).offset());
-    TopicPartition sourceTopicPartition2 = new TopicPartition("test_topic2", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition2));
-    assertEquals(1, retrievedOffsets.get(sourceTopicPartition2).offset());
-    TopicPartition sourceTopicPartition3 = new TopicPartition("test_topic3", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition3));
-    assertEquals(2, retrievedOffsets.get(sourceTopicPartition3).offset());
-    TopicPartition sourceTopicPartition4 = new TopicPartition("test_topic4", 0);
-    assertNotNull(retrievedOffsets.get(sourceTopicPartition4));
-    assertEquals(1, retrievedOffsets.get(sourceTopicPartition4).offset());
-
-    // pipelineDest and offset queues should have been drained
-    assertEquals(0, pipelineDest.size());
-    assertEquals(0, offsets.size());
-
-    // five docs should have been added to pipelineDest queue
-    assertEquals(5, pipelineDest.getHistory().size());
-
-    // we should have committed one offset map for the first two topics
-    // and a second offset map for the reamining two topics which were created later
-    assertEquals(2, offsets.getHistory().size());
-    assertEquals(2, offsets.getHistory().get(0).entrySet().size());
-    assertEquals(2, offsets.getHistory().get(1).entrySet().size());
-
-    assertEquals(1, offsets.getHistory().get(0).get(sourceTopicPartition1).offset());
-    assertEquals(1, offsets.getHistory().get(0).get(sourceTopicPartition2).offset());
-    assertEquals(2, offsets.getHistory().get(1).get(sourceTopicPartition3).offset());
-    assertEquals(1, offsets.getHistory().get(1).get(sourceTopicPartition4).offset());
-
-  }
-
-  @Test
-  public void testSettingEventTopic() {
-    Config config = ConfigFactory.load("HybridKafkaTest/eventTopic.conf");
-    String eventTopic = KafkaUtils.getEventTopicName(config, "pipeline1", RUN_ID);
-
-    assertEquals("test_event_topic", eventTopic);
-  }
-
-  private Document sendDoc(String id, String topic) throws Exception {
+//
+//  @Test
+//  public void testCustomDeserializer() throws Exception {
+//    // documentDeserializer: "com.kmwllc.com.kmwllc.lucille.core.NonstandardDocumentDeserializer"
+//    Config config = ConfigFactory.load("HybridKafkaTest/customDeserializer.conf");
+//
+//    String sourceTopic = config.getString("kafka.sourceTopic");
+//    kafka.createTopic(TopicConfig.withName(sourceTopic).withNumberOfPartitions(1));
+//
+//    // inputJson does not have the "id" field required for creating a KafkaDocument
+//    String inputJson = "{\"myId\":\"doc1\", \"field1\":\"value1\"}";
+//
+//    // we expect the custom deserializer to copy myId to id
+//    String outputJson = "{\"myId\":\"doc1\",\"field1\":\"value1\",\"id\":\"doc1\"}";
+//
+//    List<KeyValue<String, String>> records = new ArrayList<>();
+//    records.add(new KeyValue<>("doc1", inputJson));
+//    kafka.send(SendKeyValues.to(sourceTopic, records));
+//
+//    WorkerIndexer workerIndexer = new WorkerIndexer();
+//
+//    RecordingLinkedBlockingQueue<Document> pipelineDest =
+//        new RecordingLinkedBlockingQueue<>();
+//    RecordingLinkedBlockingQueue<Map<TopicPartition, OffsetAndMetadata>> offsets =
+//        new RecordingLinkedBlockingQueue<>();
+//
+//    Set<String> idSet = CounterUtils.getThreadSafeSet();
+//    workerIndexer.start(config, "pipeline1", pipelineDest, offsets, true, idSet);
+//
+//    CounterUtils.waitUnique(idSet, 1);
+//
+//    workerIndexer.stop();
+//
+//    assertEquals(1, pipelineDest.getHistory().size());
+//    assertEquals(outputJson, pipelineDest.getHistory().get(0).toString());
+//  }
+//
+//  @Test
+//  public void testWorkerIndexerPool() throws Exception {
+//    Config config = ConfigFactory.load("HybridKafkaTest/poolConfig.conf");
+//
+//    String sourceTopic = config.getString("kafka.sourceTopic");
+//    kafka.createTopic(TopicConfig.withName(sourceTopic).withNumberOfPartitions(5));
+//
+//    Set<String> idSet = CounterUtils.getThreadSafeSet();
+//    WorkerIndexerPool pool =
+//        new WorkerIndexerPool(config, "pipeline1", true, idSet);
+//
+//    assertEquals(5, pool.getNumWorkers());
+//
+//    for (int i = 0; i < 500; i++) {
+//      sendDoc("doc" + i, sourceTopic);
+//    }
+//
+//    pool.start();
+//
+//    for (int i = 500; i < 1000; i++) {
+//      sendDoc("doc" + i, sourceTopic);
+//    }
+//
+//    CounterUtils.waitUnique(idSet, 1000);
+//
+//    pool.stop();
+//
+//    Properties props = new Properties();
+//    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getString("kafka.bootstrapServers"));
+//    Admin kafkaAdminClient = Admin.create(props);
+//    Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
+//        kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
+//            .partitionsToOffsetAndMetadata().get();
+//    TopicPartition partition0 = new TopicPartition(sourceTopic, 0);
+//    TopicPartition partition1 = new TopicPartition(sourceTopic, 1);
+//    TopicPartition partition2 = new TopicPartition(sourceTopic, 2);
+//    TopicPartition partition3 = new TopicPartition(sourceTopic, 3);
+//    TopicPartition partition4 = new TopicPartition(sourceTopic, 4);
+//
+//    long sumOffsets = retrievedOffsets.get(partition0).offset() +
+//        retrievedOffsets.get(partition1).offset() +
+//        retrievedOffsets.get(partition2).offset() +
+//        retrievedOffsets.get(partition3).offset() +
+//        retrievedOffsets.get(partition4).offset();
+//
+//    // the sum of offsets across the two partitions should be the same as the number of documents
+//    // consumed. All 1000 documents we added to the source topic should have been consumed.
+//    assertEquals(1000, sumOffsets);
+//
+//  }
+//
+//  @Test
+//  public void testSourceTopicWildcard() throws Exception {
+//    // sourceTopic: "test_topic.*"
+//    Config config = ConfigFactory.load("HybridKafkaTest/sourceTopicWildcard.conf");
+//
+//    kafka.createTopic(TopicConfig.withName("test_topic1").withNumberOfPartitions(1));
+//    kafka.createTopic(TopicConfig.withName("test_topic2").withNumberOfPartitions(1));
+//
+//    sendDoc("doc1", "test_topic1");
+//    sendDoc("doc2", "test_topic2");
+//
+//    WorkerIndexer workerIndexer = new WorkerIndexer();
+//
+//    RecordingLinkedBlockingQueue<Document> pipelineDest =
+//        new RecordingLinkedBlockingQueue<>();
+//
+//    RecordingLinkedBlockingQueue<Map<TopicPartition, OffsetAndMetadata>> offsets =
+//        new RecordingLinkedBlockingQueue<>();
+//
+//    Set<String> idSet = CounterUtils.getThreadSafeSet();
+//    workerIndexer.start(config, "pipeline1", pipelineDest, offsets, true, idSet);
+//
+//    CounterUtils.waitUnique(idSet, 2, 20000, CounterUtils.DEFAULT_END_LAG_MS);
+//
+//    kafka.createTopic(TopicConfig.withName("test_topic3").withNumberOfPartitions(1));
+//    kafka.createTopic(TopicConfig.withName("test_topic4").withNumberOfPartitions(1));
+//    sendDoc("doc3", "test_topic3");
+//    sendDoc("doc4", "test_topic4");
+//
+//    // send a second doc to test_topic3
+//    sendDoc("doc5", "test_topic3");
+//
+//    CounterUtils.waitUnique(idSet, 5, 3 * 60 * 1000, CounterUtils.DEFAULT_END_LAG_MS);
+//
+//    workerIndexer.stop();
+//
+//    // confirm that the consumer group is looking at the correct offset in each topic
+//    Properties props = new Properties();
+//    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getString("kafka.bootstrapServers"));
+//    Admin kafkaAdminClient = Admin.create(props);
+//    Map<TopicPartition, OffsetAndMetadata> retrievedOffsets =
+//        kafkaAdminClient.listConsumerGroupOffsets(config.getString("kafka.consumerGroupId"))
+//            .partitionsToOffsetAndMetadata().get();
+//    TopicPartition sourceTopicPartition1 = new TopicPartition("test_topic1", 0);
+//    assertNotNull(retrievedOffsets.get(sourceTopicPartition1));
+//    assertEquals(1, retrievedOffsets.get(sourceTopicPartition1).offset());
+//    TopicPartition sourceTopicPartition2 = new TopicPartition("test_topic2", 0);
+//    assertNotNull(retrievedOffsets.get(sourceTopicPartition2));
+//    assertEquals(1, retrievedOffsets.get(sourceTopicPartition2).offset());
+//    TopicPartition sourceTopicPartition3 = new TopicPartition("test_topic3", 0);
+//    assertNotNull(retrievedOffsets.get(sourceTopicPartition3));
+//    assertEquals(2, retrievedOffsets.get(sourceTopicPartition3).offset());
+//    TopicPartition sourceTopicPartition4 = new TopicPartition("test_topic4", 0);
+//    assertNotNull(retrievedOffsets.get(sourceTopicPartition4));
+//    assertEquals(1, retrievedOffsets.get(sourceTopicPartition4).offset());
+//
+//    // pipelineDest and offset queues should have been drained
+//    assertEquals(0, pipelineDest.size());
+//    assertEquals(0, offsets.size());
+//
+//    // five docs should have been added to pipelineDest queue
+//    assertEquals(5, pipelineDest.getHistory().size());
+//
+//    // we should have committed one offset map for the first two topics
+//    // and a second offset map for the reamining two topics which were created later
+//    assertEquals(2, offsets.getHistory().size());
+//    assertEquals(2, offsets.getHistory().get(0).entrySet().size());
+//    assertEquals(2, offsets.getHistory().get(1).entrySet().size());
+//
+//    assertEquals(1, offsets.getHistory().get(0).get(sourceTopicPartition1).offset());
+//    assertEquals(1, offsets.getHistory().get(0).get(sourceTopicPartition2).offset());
+//    assertEquals(2, offsets.getHistory().get(1).get(sourceTopicPartition3).offset());
+//    assertEquals(1, offsets.getHistory().get(1).get(sourceTopicPartition4).offset());
+//
+//  }
+//
+//  @Test
+//  public void testSettingEventTopic() {
+//    Config config = ConfigFactory.load("HybridKafkaTest/eventTopic.conf");
+//    String eventTopic = KafkaUtils.getEventTopicName(config, "pipeline1", RUN_ID);
+//
+//    assertEquals("test_event_topic", eventTopic);
+//  }
+//
+  private Document sendDoc(String id, String topic) {
     return sendDoc(id, null, topic);
   }
 
-  private Document sendDoc(String id, String runId, String topic) throws Exception {
-    List<KeyValue<String, String>> records = new ArrayList<>();
+  private Document sendDoc(String id, String runId, String topic) {
     Document doc = (runId == null) ? Document.create(id) : Document.create(id, runId);
-    records.add(new KeyValue<>(id, doc.toString()));
-    kafka.send(SendKeyValues.to(topic, records));
+    ProducerRecord<String, String> record = new ProducerRecord<>(topic, id, doc.toString());
+    template.send(record);
     return doc;
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
@@ -33,7 +33,7 @@ public class KafkaTest {
 
   @Before
   public void setUp() {
-    Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("lucille_workersss", "false", embeddedKafka.getEmbeddedKafka());
+    Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("alternate_group", "false", embeddedKafka.getEmbeddedKafka());
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
@@ -34,7 +34,7 @@ public class KafkaTest {
   @ClassRule
   public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 1).kafkaPorts(9090).zkPort(9091);
 
-  KafkaTemplate<String, String> template;
+  private KafkaTemplate<String, String> template;
 
   @Before
   public void setUp() {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
@@ -1,98 +1,154 @@
-//package com.kmwllc.lucille.core;
-//
-//import com.kmwllc.lucille.message.KafkaUtils;
-//import com.typesafe.config.Config;
-//import com.typesafe.config.ConfigFactory;
-//import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
-//import net.mguenther.kafka.junit.KeyValue;
-//import net.mguenther.kafka.junit.ReadKeyValues;
-//import org.junit.After;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.junit.runners.JUnit4;
-//
-//import java.util.List;
-//
-//import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
-//import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertTrue;
-//
-//@RunWith(JUnit4.class)
-//public class KafkaTest {
-//
-//  private EmbeddedKafkaCluster kafka;
-//
-//  @Before
-//  public void setupKafka() {
-//    kafka = provisionWith(defaultClusterConfig());
-//    kafka.start();
-//  }
-//
-//  @After
-//  public void tearDownKafka() {
-//    kafka.stop();
-//  }
-//
-//  @Test
-//  public void testRunInKafkaLocalMode() throws Exception {
-//
-//    // run two connectors in "Kafka local mode"
-//    // in "kafka local mode" Workers, Indexers, the Connector/Publisher will run in separate threads,
-//    // but they will communicate via Kafka (here we use an embedded kafka cluster)
-//    Config config = ConfigFactory.load("KafkaTest/twoConnectors.conf");
-//    RunResult result =
-//        Runner.run(config, Runner.RunType.KAFKA_LOCAL);
-//    assertTrue(result.getStatus());
-//
-//    // connector1 will feed 3 documents to pipeline1, so there should be 3 messages in each of
-//    // the source, dest, and event topics after the run is complete
-//    assertEquals(3, kafka.read(ReadKeyValues
-//        .from(KafkaUtils.getSourceTopicName("pipeline1", ConfigFactory.empty()))
-//        .seekTo(0, 0)).size());
-//
-//    assertEquals(3, kafka.read(ReadKeyValues
-//        .from(KafkaUtils.getDestTopicName("pipeline1"))
-//        .seekTo(0, 0)).size());
-//
-//    List<KeyValue<String, String>> eventRecords =
-//        kafka.read(ReadKeyValues.from(
-//            KafkaUtils.getEventTopicName(config, "pipeline1", result.getRunId())).seekTo(0, 0));
-//    assertEquals(3, eventRecords.size());
-//
-//    Event event0 = Event.fromJsonString(eventRecords.get(0).getValue());
-//    Event event1 = Event.fromJsonString(eventRecords.get(1).getValue());
-//    Event event2 = Event.fromJsonString(eventRecords.get(2).getValue());
-//    // in local kafka mode (or fully distributed kafka mode) as opposed to hybrid mode,
-//    // completion events will contain kafka metadata taken from messages found on the destination topic,
-//    // not the source topic, because that's where the indexer consumes from
-//    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event0.getTopic());
-//    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event1.getTopic());
-//    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event2.getTopic());
-//    assertEquals(Integer.valueOf(0), event1.getPartition());
-//    assertEquals(Long.valueOf(1), event1.getOffset());
-//    assertEquals(Event.Type.FINISH, event1.getType());
-//
-//    // connector2 will feed 1 documents to pipeline1, so there should be 1 messages in each of
-//    // the source, dest, and event topics after the run is complete
-//    assertEquals(1, kafka.read(ReadKeyValues
-//        .from(KafkaUtils.getSourceTopicName("pipeline2", ConfigFactory.empty()))
-//        .seekTo(0, 0)).size());
-//
-//    List<KeyValue<String, String>> records = kafka.read(ReadKeyValues
-//        .from(KafkaUtils.getDestTopicName("pipeline2"))
-//        .seekTo(0, 0));
-//    assertEquals(1, records.size());
-//
-//    // verify that the document was properly written to the destination topic
-//    Document doc = Document.createFromJson(records.get(0).getValue());
-//    assertEquals("2", doc.getId());
-//    assertEquals("apple", doc.getString("field1"));
-//
-//    assertEquals(1, kafka.read(ReadKeyValues
-//        .from(KafkaUtils.getEventTopicName(config, "pipeline2", result.getRunId()))
-//        .seekTo(0, 0)).size());
-//  }
-//
-//}
+package com.kmwllc.lucille.core;
+
+import com.kmwllc.lucille.message.KafkaUtils;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class KafkaTest {
+  @ClassRule
+  public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 1).kafkaPorts(9090).zkPort(9091);
+
+  KafkaTemplate<String, String> template;
+
+  @Before
+  public void setUp() {
+    Map<String, Object> producerProps =
+        KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
+    producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+    ProducerFactory<String, String> pf =
+        new DefaultKafkaProducerFactory<>(producerProps);
+    template = new KafkaTemplate<>(pf);
+
+    Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("lucille_workers", "false", embeddedKafka.getEmbeddedKafka());
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+    DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+    template.setConsumerFactory(cf);
+  }
+
+  @Test
+  public void testRunInKafkaLocalMode() throws Exception {
+    // run two connectors in "Kafka local mode"
+    // in "kafka local mode" Workers, Indexers, the Connector/Publisher will run in separate threads,
+    // but they will communicate via Kafka (here we use an embedded kafka cluster)
+    Config config = ConfigFactory.load("KafkaTest/twoConnectors.conf");
+    RunResult result =
+        Runner.run(config, Runner.RunType.KAFKA_LOCAL);
+    assertTrue(result.getStatus());
+
+    // connector1 will feed 3 documents to pipeline1, so there should be 3 messages in each of
+    // the source, dest, and event topics after the run is complete
+    String pipeline1SourceTopicName = KafkaUtils.getSourceTopicName("pipeline1", ConfigFactory.empty());
+    String pipeline1DestTopicName = KafkaUtils.getDestTopicName("pipeline1");
+    String pipeline1EventTopicName = KafkaUtils.getEventTopicName(ConfigFactory.empty(), "pipeline1", result.getRunId());
+
+    // check there are three entries in source + dest
+
+    // Trying to get a record that doesn't exist won't return any results. (we always request one extra record
+    // that we won't get / don't expect to be there to ensure the exact amount we want are actually in Kafka.)
+    ConsumerRecords<String, String> sourceRecords = template.receive(List.of(
+        new TopicPartitionOffset(pipeline1SourceTopicName, 0, 0L),
+        new TopicPartitionOffset(pipeline1SourceTopicName, 0, 1L),
+        new TopicPartitionOffset(pipeline1SourceTopicName, 0, 2L),
+        new TopicPartitionOffset(pipeline1EventTopicName, 0, 3L)
+    ));
+
+    assertEquals(3, sourceRecords.count());
+
+    ConsumerRecords<String, String> destRecords = template.receive(List.of(
+        new TopicPartitionOffset(pipeline1DestTopicName, 0, 0L),
+        new TopicPartitionOffset(pipeline1DestTopicName, 0, 1L),
+        new TopicPartitionOffset(pipeline1DestTopicName, 0, 2L),
+        new TopicPartitionOffset(pipeline1EventTopicName, 0, 3L)
+    ));
+
+    assertEquals(3, destRecords.count());
+
+    // check three entries in event and also run the JSON on it...
+    ConsumerRecords<String, String> eventRecords = template.receive(List.of(
+        new TopicPartitionOffset(pipeline1EventTopicName, 0, 0L),
+        new TopicPartitionOffset(pipeline1EventTopicName, 0, 1L),
+        new TopicPartitionOffset(pipeline1EventTopicName, 0, 2L),
+        new TopicPartitionOffset(pipeline1EventTopicName, 0, 3L)
+    ));
+
+    assertEquals(3, eventRecords.count());
+
+    List<ConsumerRecord<String, String>> eventRecordsList = eventRecords.records(new TopicPartition(pipeline1EventTopicName, 0));
+
+    Event event0 = Event.fromJsonString(eventRecordsList.get(0).value());
+    Event event1 = Event.fromJsonString(eventRecordsList.get(1).value());
+    Event event2 = Event.fromJsonString(eventRecordsList.get(2).value());
+    // in local kafka mode (or fully distributed kafka mode) as opposed to hybrid mode,
+    // completion events will contain kafka metadata taken from messages found on the destination topic,
+    // not the source topic, because that's where the indexer consumes from
+    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event0.getTopic());
+    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event1.getTopic());
+    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event2.getTopic());
+    assertEquals(Integer.valueOf(0), event1.getPartition());
+    assertEquals(Long.valueOf(1), event1.getOffset());
+    assertEquals(Event.Type.FINISH, event1.getType());
+
+    // connector2 will feed 1 documents to pipeline1, so there should be 1 messages in each of
+    // the source, dest, and event topics after the run is complete
+    String pipeline2SourceTopicName = KafkaUtils.getSourceTopicName("pipeline2", ConfigFactory.empty());
+    sourceRecords = template.receive(List.of(
+        new TopicPartitionOffset(pipeline2SourceTopicName, 0, 0L),
+        new TopicPartitionOffset(pipeline2SourceTopicName, 0, 1L)
+    ));
+    assertEquals(1, sourceRecords.count());
+
+    String pipeline2DestTopicName = KafkaUtils.getDestTopicName("pipeline2");
+    destRecords = template.receive(List.of(
+        new TopicPartitionOffset(pipeline2DestTopicName, 0, 0L),
+        new TopicPartitionOffset(pipeline2DestTopicName, 0, 1L)
+    ));
+    assertEquals(1, destRecords.count());
+
+    List<ConsumerRecord<String, String>> destRecordsList = destRecords.records(new TopicPartition(pipeline2DestTopicName, 0));
+
+    // verify that the document was properly written to the destination topic
+    System.out.println(destRecordsList.get(0));
+    System.out.println(destRecordsList.get(0).value());
+    Document doc = Document.createFromJson(destRecordsList.get(0).value());
+    assertEquals("2", doc.getId());
+    assertEquals("apple", doc.getString("field1"));
+
+    String pipeline2EventTopicName = KafkaUtils.getEventTopicName(ConfigFactory.empty(), "pipeline2", result.getRunId());
+    eventRecords = template.receive(List.of(
+        new TopicPartitionOffset(pipeline2EventTopicName, 0, 0L),
+        new TopicPartitionOffset(pipeline2EventTopicName, 0, 1L)
+    ));
+    assertEquals(1, eventRecords.count());
+  }
+
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
@@ -1,98 +1,98 @@
-package com.kmwllc.lucille.core;
-
-import com.kmwllc.lucille.message.KafkaUtils;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
-import net.mguenther.kafka.junit.KeyValue;
-import net.mguenther.kafka.junit.ReadKeyValues;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import java.util.List;
-
-import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
-import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-@RunWith(JUnit4.class)
-public class KafkaTest {
-
-  private EmbeddedKafkaCluster kafka;
-
-  @Before
-  public void setupKafka() {
-    kafka = provisionWith(defaultClusterConfig());
-    kafka.start();
-  }
-
-  @After
-  public void tearDownKafka() {
-    kafka.stop();
-  }
-
-  @Test
-  public void testRunInKafkaLocalMode() throws Exception {
-
-    // run two connectors in "Kafka local mode"
-    // in "kafka local mode" Workers, Indexers, the Connector/Publisher will run in separate threads,
-    // but they will communicate via Kafka (here we use an embedded kafka cluster)
-    Config config = ConfigFactory.load("KafkaTest/twoConnectors.conf");
-    RunResult result =
-        Runner.run(config, Runner.RunType.KAFKA_LOCAL);
-    assertTrue(result.getStatus());
-
-    // connector1 will feed 3 documents to pipeline1, so there should be 3 messages in each of
-    // the source, dest, and event topics after the run is complete
-    assertEquals(3, kafka.read(ReadKeyValues
-        .from(KafkaUtils.getSourceTopicName("pipeline1", ConfigFactory.empty()))
-        .seekTo(0, 0)).size());
-
-    assertEquals(3, kafka.read(ReadKeyValues
-        .from(KafkaUtils.getDestTopicName("pipeline1"))
-        .seekTo(0, 0)).size());
-
-    List<KeyValue<String, String>> eventRecords =
-        kafka.read(ReadKeyValues.from(
-            KafkaUtils.getEventTopicName(config, "pipeline1", result.getRunId())).seekTo(0, 0));
-    assertEquals(3, eventRecords.size());
-
-    Event event0 = Event.fromJsonString(eventRecords.get(0).getValue());
-    Event event1 = Event.fromJsonString(eventRecords.get(1).getValue());
-    Event event2 = Event.fromJsonString(eventRecords.get(2).getValue());
-    // in local kafka mode (or fully distributed kafka mode) as opposed to hybrid mode,
-    // completion events will contain kafka metadata taken from messages found on the destination topic,
-    // not the source topic, because that's where the indexer consumes from
-    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event0.getTopic());
-    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event1.getTopic());
-    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event2.getTopic());
-    assertEquals(Integer.valueOf(0), event1.getPartition());
-    assertEquals(Long.valueOf(1), event1.getOffset());
-    assertEquals(Event.Type.FINISH, event1.getType());
-
-    // connector2 will feed 1 documents to pipeline1, so there should be 1 messages in each of
-    // the source, dest, and event topics after the run is complete
-    assertEquals(1, kafka.read(ReadKeyValues
-        .from(KafkaUtils.getSourceTopicName("pipeline2", ConfigFactory.empty()))
-        .seekTo(0, 0)).size());
-
-    List<KeyValue<String, String>> records = kafka.read(ReadKeyValues
-        .from(KafkaUtils.getDestTopicName("pipeline2"))
-        .seekTo(0, 0));
-    assertEquals(1, records.size());
-
-    // verify that the document was properly written to the destination topic
-    Document doc = Document.createFromJson(records.get(0).getValue());
-    assertEquals("2", doc.getId());
-    assertEquals("apple", doc.getString("field1"));
-
-    assertEquals(1, kafka.read(ReadKeyValues
-        .from(KafkaUtils.getEventTopicName(config, "pipeline2", result.getRunId()))
-        .seekTo(0, 0)).size());
-  }
-
-}
+//package com.kmwllc.lucille.core;
+//
+//import com.kmwllc.lucille.message.KafkaUtils;
+//import com.typesafe.config.Config;
+//import com.typesafe.config.ConfigFactory;
+//import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
+//import net.mguenther.kafka.junit.KeyValue;
+//import net.mguenther.kafka.junit.ReadKeyValues;
+//import org.junit.After;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.JUnit4;
+//
+//import java.util.List;
+//
+//import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
+//import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertTrue;
+//
+//@RunWith(JUnit4.class)
+//public class KafkaTest {
+//
+//  private EmbeddedKafkaCluster kafka;
+//
+//  @Before
+//  public void setupKafka() {
+//    kafka = provisionWith(defaultClusterConfig());
+//    kafka.start();
+//  }
+//
+//  @After
+//  public void tearDownKafka() {
+//    kafka.stop();
+//  }
+//
+//  @Test
+//  public void testRunInKafkaLocalMode() throws Exception {
+//
+//    // run two connectors in "Kafka local mode"
+//    // in "kafka local mode" Workers, Indexers, the Connector/Publisher will run in separate threads,
+//    // but they will communicate via Kafka (here we use an embedded kafka cluster)
+//    Config config = ConfigFactory.load("KafkaTest/twoConnectors.conf");
+//    RunResult result =
+//        Runner.run(config, Runner.RunType.KAFKA_LOCAL);
+//    assertTrue(result.getStatus());
+//
+//    // connector1 will feed 3 documents to pipeline1, so there should be 3 messages in each of
+//    // the source, dest, and event topics after the run is complete
+//    assertEquals(3, kafka.read(ReadKeyValues
+//        .from(KafkaUtils.getSourceTopicName("pipeline1", ConfigFactory.empty()))
+//        .seekTo(0, 0)).size());
+//
+//    assertEquals(3, kafka.read(ReadKeyValues
+//        .from(KafkaUtils.getDestTopicName("pipeline1"))
+//        .seekTo(0, 0)).size());
+//
+//    List<KeyValue<String, String>> eventRecords =
+//        kafka.read(ReadKeyValues.from(
+//            KafkaUtils.getEventTopicName(config, "pipeline1", result.getRunId())).seekTo(0, 0));
+//    assertEquals(3, eventRecords.size());
+//
+//    Event event0 = Event.fromJsonString(eventRecords.get(0).getValue());
+//    Event event1 = Event.fromJsonString(eventRecords.get(1).getValue());
+//    Event event2 = Event.fromJsonString(eventRecords.get(2).getValue());
+//    // in local kafka mode (or fully distributed kafka mode) as opposed to hybrid mode,
+//    // completion events will contain kafka metadata taken from messages found on the destination topic,
+//    // not the source topic, because that's where the indexer consumes from
+//    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event0.getTopic());
+//    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event1.getTopic());
+//    assertEquals(KafkaUtils.getDestTopicName("pipeline1"), event2.getTopic());
+//    assertEquals(Integer.valueOf(0), event1.getPartition());
+//    assertEquals(Long.valueOf(1), event1.getOffset());
+//    assertEquals(Event.Type.FINISH, event1.getType());
+//
+//    // connector2 will feed 1 documents to pipeline1, so there should be 1 messages in each of
+//    // the source, dest, and event topics after the run is complete
+//    assertEquals(1, kafka.read(ReadKeyValues
+//        .from(KafkaUtils.getSourceTopicName("pipeline2", ConfigFactory.empty()))
+//        .seekTo(0, 0)).size());
+//
+//    List<KeyValue<String, String>> records = kafka.read(ReadKeyValues
+//        .from(KafkaUtils.getDestTopicName("pipeline2"))
+//        .seekTo(0, 0));
+//    assertEquals(1, records.size());
+//
+//    // verify that the document was properly written to the destination topic
+//    Document doc = Document.createFromJson(records.get(0).getValue());
+//    assertEquals("2", doc.getId());
+//    assertEquals("apple", doc.getString("field1"));
+//
+//    assertEquals(1, kafka.read(ReadKeyValues
+//        .from(KafkaUtils.getEventTopicName(config, "pipeline2", result.getRunId()))
+//        .seekTo(0, 0)).size());
+//  }
+//
+//}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
@@ -12,10 +12,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import java.util.List;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -29,10 +27,10 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(JUnit4.class)
 public class KafkaTest {
-  @ClassRule
-  public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 1).kafkaPorts(9090).zkPort(9091);
+
+  @Rule
+  public EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 1).kafkaPorts(9090).zkPort(9091);
 
   KafkaTemplate<String, String> template;
 

--- a/lucille-core/src/test/resources/HybridKafkaTest/childrenConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/childrenConfig.conf
@@ -23,7 +23,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "children_topic"
+  sourceTopic: "test_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/childrenConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/childrenConfig.conf
@@ -23,7 +23,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "children_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/childrenConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/childrenConfig.conf
@@ -21,9 +21,9 @@ indexer {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "children_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/childrenConfigWithEvents.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/childrenConfigWithEvents.conf
@@ -23,7 +23,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "children_events_topic"
+  sourceTopic: "test_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/childrenConfigWithEvents.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/childrenConfigWithEvents.conf
@@ -23,7 +23,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "children_with_events_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/childrenConfigWithEvents.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/childrenConfigWithEvents.conf
@@ -21,9 +21,9 @@ indexer {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "children_events_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/customDeserializer.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/customDeserializer.conf
@@ -20,7 +20,7 @@ indexer {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
   sourceTopic: "test_topic_for_custom_deserializer"
 

--- a/lucille-core/src/test/resources/HybridKafkaTest/customDeserializer.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/customDeserializer.conf
@@ -22,7 +22,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "deserializer_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/customDeserializer.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/customDeserializer.conf
@@ -22,7 +22,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic_for_custom_deserializer"
+  sourceTopic: "test_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/eventTopic.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/eventTopic.conf
@@ -20,7 +20,7 @@ indexer {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
   sourceTopic: "test_setting_topic"
   eventTopic: "test_setting_event_topic"

--- a/lucille-core/src/test/resources/HybridKafkaTest/eventTopic.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/eventTopic.conf
@@ -22,8 +22,8 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9092"
 
-  sourceTopic: "test_topic"
-  eventTopic: "test_event_topic"
+  sourceTopic: "test_setting_topic"
+  eventTopic: "test_setting_event_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/noopConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/noopConfig.conf
@@ -20,9 +20,9 @@ indexer {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "test_two_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/noopConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/noopConfig.conf
@@ -22,7 +22,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "noop_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/noopConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/noopConfig.conf
@@ -22,7 +22,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_two_topic"
+  sourceTopic: "test_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/poolConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/poolConfig.conf
@@ -24,7 +24,7 @@ worker {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
   sourceTopic: "test_topic"
 

--- a/lucille-core/src/test/resources/HybridKafkaTest/poolConfig.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/poolConfig.conf
@@ -26,7 +26,7 @@ worker {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic"
+  sourceTopic: "pool_topic"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
@@ -22,7 +22,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic_wildcard.*"
+  sourceTopic: "test_topic.*"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
@@ -20,9 +20,9 @@ indexer {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic.*"
+  sourceTopic: "test_topic_wildcard.*"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
@@ -22,7 +22,7 @@ indexer {
 kafka {
   bootstrapServers: "localhost:9090"
 
-  sourceTopic: "test_topic.*"
+  sourceTopic: "test_wildcard_topic.*"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-core/src/test/resources/KafkaTest/twoConnectors.conf
+++ b/lucille-core/src/test/resources/KafkaTest/twoConnectors.conf
@@ -43,7 +43,7 @@ indexer {
 }
 
 kafka {
-  bootstrapServers: "localhost:9092"
+  bootstrapServers: "localhost:9090"
 
   # how long a kafka poll should wait for data before returning an empty record set
   pollIntervalMs: 250

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -172,15 +172,6 @@
       <version>${junit4.version}</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- enabling Junit 5 because of bug with inherited version 5.6.2 in lucille-core with 'net.mguenther.kafka', overriding here -->
-    <!-- TODO: Able to remove now? -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.11.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -174,6 +174,7 @@
     </dependency>
 
     <!-- enabling Junit 5 because of bug with inherited version 5.6.2 in lucille-core with 'net.mguenther.kafka', overriding here -->
+    <!-- TODO: Able to remove now? -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>

--- a/lucille-plugins/lucille-pinecone/src/test/java/com/kmwllc/lucille/pinecone/stage/EmitDocsToDeleteByPrefixTest.java
+++ b/lucille-plugins/lucille-pinecone/src/test/java/com/kmwllc/lucille/pinecone/stage/EmitDocsToDeleteByPrefixTest.java
@@ -1,6 +1,11 @@
 package com.kmwllc.lucille.pinecone.stage;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Replaces the old dependency with some Kafka related libraries from Spring. This decreases the runtime of `HybridKafkaTest` from ~82 seconds to ~55.5 seconds, a ~26-27 second decrease. This decreases the runtime of `KafkaTest` from ~40 sec to ~20.5 sec, a ~19 second decrease.

Both use an `@ClassRule`, meaning there is one embedded instance of Kafka created for each test class. As such, for `HybridKafkaTest`, each test is using different topic names. We save ~10 seconds in runtime by only using one, class-level instance of EmbeddedKafka.

Kafka is brought up to `3.8.1`.  The Spring libraries are on version `3.3.3`. (Spring-Kafka versions don't match Kafka versions. These are compatible versions.). Kafka `3.9.0` is available, but it doesn't play nicely with the Spring libraries, which are internally still depending on `3.8.1` versions of Kafka. It's probably possible to upgrade to `3.9.0` but would require some dependency work and might not be worth it, since _there are not any Kafka-related CVEs anymore_ (according to IntelliJ).