### PR TITLE
LC-651: Improve HybridKafkaTest

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaUtils.java
@@ -1,10 +1,10 @@
 package com.kmwllc.lucille.message;
 
+import com.kmwllc.lucille.core.ConfigUtils;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.KafkaDocument;
 import com.kmwllc.lucille.util.FileContentFetcher;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.*;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -74,7 +74,7 @@ public class KafkaUtils {
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-    consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 30000);
+    consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, ConfigUtils.getOrDefault(config, "kafka.metadataMaxAgeMs", 30000));
     return consumerProps;
   }
 

--- a/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
+++ b/lucille-core/src/test/resources/HybridKafkaTest/sourceTopicWildcard.conf
@@ -33,6 +33,9 @@ kafka {
   # ID of consumer group that all com.kmwllc.lucille workers should belong to
   consumerGroupId: "lucille_workers"
 
+  # Check for newly created topics sooner than normal, to speed up the test
+  metadataMaxAgeMs: 3000
+
   maxRequestSize: 250000000
 
   events: false


### PR DESCRIPTION
With these changes, `testSourceTopicWildcard` runs ~25 seconds faster than before. In total, `HybridKafkaTest` only takes ~28 seconds now!

The culprit here was the call to `waitUnique` the second time in the test. It was taking _forever_ for the documents to actually show up to be indexed. My rudimentary understanding is that Kafka wasn't recognizing the new topics until a certain timeout interval, since I noticed the time it took for the documents to get polled was ~30 seconds - seemed like some sort of default / set timeout value to me. I went digging and found that `metadata.max.age.ms` could speed this up - so I made it possible to set this in a Config that is passed to `KafkaUtils.createConsumerProps`, and set it to `5000` in the test's Config. I found that if you set this too low the test will break - `2500` was working, so I set it to `3000` ms to be safe - this lets the Worker get an empty poll at least once (every ~2 sec). We can increase this a bit more of course. Hopefully this isn't changing the test - I did a lot of digging / logging and it seems we really were just waiting for the Kafka refresh here.