### PR TITLE
LC-343: Add Missing JavaDoc - Part 1

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/AbstractConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/AbstractConnector.java
@@ -7,7 +7,6 @@ import com.typesafe.config.Config;
 /**
  * Base class for use by Connector implementations, providing basic Config parsing behavior
  * for obtaining connector name, pipeline name, doc ID prefix, and collapsing mode.
- *
  */
 public abstract class AbstractConnector implements Connector {
 
@@ -16,8 +15,16 @@ public abstract class AbstractConnector implements Connector {
   private String docIdPrefix;
   private boolean collapse;
   private String message = null;
+
+  /**
+   * The configuration for this Connector.
+   */
   protected final Config config;
 
+  /**
+   * Create an abstract connector from the given Config.
+   * @param config The configuration of the connector. Must have a name.
+   */
   public AbstractConnector(Config config) {
     this.config = config;
     this.name = config.getString("name");
@@ -59,6 +66,7 @@ public abstract class AbstractConnector implements Connector {
   /**
    * Returns the configured prefix that this Connector will prepend to ids from the source
    * data when creating Documents from that data.
+   * @return The prefix that this Connector will append to document IDs when created.
    */
   public String getDocIdPrefix() {
     return docIdPrefix;
@@ -67,6 +75,8 @@ public abstract class AbstractConnector implements Connector {
   /**
    * Creates an extended doc ID by adding a prefix (and possibly in the future, a suffix) to the
    * given id.
+   * @param id An id to use and, potentially, add a prefix to.
+   * @return A completed doc ID, including the prefix and the given id.
    */
   public String createDocId(String id) {
     return docIdPrefix + id;
@@ -77,6 +87,10 @@ public abstract class AbstractConnector implements Connector {
     return message;
   }
 
+  /**
+   * Sets the message associated with this connector.
+   * @param message The new message to associate with this connector.
+   */
   protected void setMessage(String message) {
     this.message = message;
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
@@ -27,6 +27,10 @@ public class CSVConnector extends AbstractConnector {
   private final String moveToAfterProcessing;
   private final String moveToErrorFolder;
 
+  /**
+   * Creates a CSVConnector from the given config.
+   * @param config Configuration for the CSVConnector.
+   */
   public CSVConnector(Config config) {
     super(config);
     this.pathStr = config.getString("path");
@@ -69,6 +73,9 @@ public class CSVConnector extends AbstractConnector {
     return "CSVConnector: " + pathStr;
   }
 
+  /**
+   * If specified in the configuration, creates the moveToAfterProcessing and the moveToErrorFolder folders.
+   */
   public void createProcessedAndErrorFoldersIfSet() {
     if (moveToAfterProcessing != null) {
       // Create the destination directory if it doesn't exist.
@@ -88,6 +95,11 @@ public class CSVConnector extends AbstractConnector {
     }
   }
 
+  /**
+   * Moves the file at the given path to the path specified by the given String.
+   * @param absolutePath An absolute path to the file you want to move.
+   * @param option The path you want to move the file to.
+   */
   public void moveFile(Path absolutePath, String option) {
     if (absolutePath.startsWith("classpath:")) {
       log.warn("Skipping moving classpath file: {} to {}", absolutePath, moveToAfterProcessing);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/ConnectorState.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/ConnectorState.java
@@ -1,5 +1,13 @@
 package com.kmwllc.lucille.connector.jdbc;
 
+/**
+ * Represents the state of a Connector.
+ */
 public enum ConnectorState {
-  RUNNING, ERROR, STOPPED
+  /** A Connector that is running. */
+  RUNNING,
+  /** A Connector that encountered an error. */
+  ERROR,
+  /** A Connector that stopped. */
+  STOPPED
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
@@ -73,7 +73,10 @@ public class DatabaseConnector extends AbstractConnector {
   // TODO: consider moving this down to the base connector class.
   //  private ConnectorState state = null;
 
-  // The constructor that takes the config.
+  /**
+   * Creates a DatabaseConnector from the given config.
+   * @param config Configuration for the DatabaseConnector.
+   */
   public DatabaseConnector(Config config) {
     super(config);
 
@@ -385,7 +388,9 @@ public class DatabaseConnector extends AbstractConnector {
     }
   }
 
-  //@Override
+  /**
+   * Stops the DatabaseConnector. Currently a no-op.
+   */
   public void stop() {
     // TODO: move this to a base class..
   }
@@ -405,8 +410,10 @@ public class DatabaseConnector extends AbstractConnector {
     connections.clear();
   }
 
-  // for testing purposes
-  // return true if any connection is open to the database
+  /**
+   * Primarily for testing purposes. Returns whether the DatabaseConnector is closed.
+   * @return Whether the DatabaseConnector is closed.
+   */
   public boolean isClosed() {
     if (connections.isEmpty()) {
       return true;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClient.java
@@ -24,11 +24,19 @@ import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A storage client for Microsoft Azure.
+ */
 public class AzureStorageClient extends BaseStorageClient {
 
   private BlobServiceClient serviceClient;
   private static final Logger log = LoggerFactory.getLogger(AzureStorageClient.class);
 
+  /**
+   * Creates an AzureStorageClient from the given azureCloudOptions, which must contain either "connectionString" OR
+   * contains both "accountName" and "accountKey".
+   * @param azureCloudOptions Configuration for the AzureStorageClient.
+   */
   public AzureStorageClient(Config azureCloudOptions) {
     super(azureCloudOptions);
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/StorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/StorageClient.java
@@ -11,40 +11,46 @@ import java.util.Map;
 /**
  * Interface for storage clients. Implementations of this interface should be able to traverse a storage system
  * and publish files to the Lucille pipeline.
- *
- *  - create : create appropriate client based on the URI scheme with authentication/settings from Config. Authentication only checks that required information is present
- *  - init : Initialize the client
- *  - shutdown : Shutdown the client
- *  - validateOptions: Whether the storage client's Config is sufficient for it to connect to its file system. See below for necessary keys / arguments.
- *  - traverse : traverse through the storage client and publish files to Lucille pipeline
- *  - getFileContentStream : Given a URI to a file in the storage client's system, return an InputStream for the file's contents
- *  - createClients : Given a Config, build a map of StorageClients that can be created from the supplied options, using the URI schemes as keys for the map.
  */
-
 public interface StorageClient {
 
   /**
    * Initialize the client and creates necessary connections and/or resources
+   * @throws IOException If an error occurs during initialization.
    */
   void init() throws IOException;
 
   /**
    * Shutdown the client, closes any open connections and/or resources
+   * @throws IOException If an error occurs during shutdown.
    */
   void shutdown() throws IOException;
 
   /**
    * Traverses through the storage client and publish files to Lucille pipeline
+   * @param publisher The Publisher you want to publish documents to.
+   * @param params Parameters / options regarding the traversal of the client's file system.
+   * @throws Exception If an error occurs during traversal.
    */
   void traverse(Publisher publisher, TraversalParams params) throws Exception;
 
   /**
    * Opens and returns an InputStream for a file's contents, located at the given URI.
+   * @param uri A URI to the file whose contents you want to extract.
+   * @return An InputStream for the file's contents.
+   * @throws IOException If an error occurs while getting the file's contents.
    */
   InputStream getFileContentStream(URI uri) throws IOException;
 
   /**
    * Gets the appropriate client based on the URI scheme and validate with authentication/settings from the Config.
+   * @param pathToStorage A URI to storage - either local or cloud - where you want to start your traversal from.
+   * @param connectorConfig Configuration for your connector, which should contain configuration for cloud storage clients
+   *                        as needed.
+   * @return The appropriate, configured storage client to use for your traversal.
+   *
+   * @throws IllegalArgumentException If your path to storage requires support for a cloud storage client that you did not provide,
+   * or you provided a URI with an unsupported scheme.
    */
   static StorageClient create(URI pathToStorage, Config connectorConfig) {
     String activeClient = pathToStorage.getScheme() != null ? pathToStorage.getScheme() : "file";
@@ -104,6 +110,9 @@ public interface StorageClient {
    *   "accountName" : azure account name
    *   "accountKey" : azure account key
    *   "maxNumOfPages" : number of references of the files loaded into memory in a single fetch request. Optional, defaults to 100
+   *
+   * @param config The configuration which potentially contains cloud options that you want to use to build storage clients.
+   * @return A map of Strings to StorageClients. StorageClients are keyed by their URI scheme (gs, https, s3, file).
    */
   static Map<String, StorageClient> createClients(Config config) {
     Map<String, StorageClient> results = new HashMap<>();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/xml/XMLConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/xml/XMLConnector.java
@@ -15,8 +15,6 @@ import java.util.List;
 
 /**
  * Connector implementation that produces documents from a given XML file.
- * <p>
- * <p>
  * Config Parameters:
  * <ul>
  * <li>filePaths (List&lt;String&gt;): The list of file paths to parse through.</li>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Batch.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Batch.java
@@ -21,6 +21,9 @@ public interface Batch {
    * If the batch has reached its capacity or if it is expired, it will be flushed
    * and all of its contents will be returned. The newly added document will not
    * be returned but will be stored as the first element of the current batch.
+   *
+   * @param doc The doc to add to the batch.
+   * @return A list of documents that were flushed, if any. Will not contain the provided document.
    */
   public List<Document> add(Document doc);
 
@@ -28,17 +31,23 @@ public interface Batch {
    * Removes and returns all Documents in the current batch if the batch is expired
    * (i.e. if the configured timeout has been reached since the last add or flush).
    * Returns an empty list otherwise.
+   *
+   * @return If the batch is expired, all of its documents. If not, an empty list.
    */
   public List<Document> flushIfExpired();
 
   /**
    * Removes and returns all Documents in the current batch,
    * regardless of whether the batch is expired.
+   *
+   * @return All documents in the current batch.
    */
   public List<Document> flush();
 
   /**
    * Retrieves the capacity of a batch.
+   *
+   * @return The capacity of the batch.
    */
   public int getCapacity();
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/ConfigUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/ConfigUtils.java
@@ -9,11 +9,19 @@ import org.apache.http.message.BasicHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Utility functions for working with Config.
+ */
 public class ConfigUtils {
 
+  /**
+   * The pipeline environment property.
+   */
   public static final String ENV_PROP = "pipeline.env";
 
   private static final Logger log = LoggerFactory.getLogger(ConfigUtils.class);
+
+  private ConfigUtils() {}
 
   /**
    * Get the value of the given setting from the config file, or a default value if the setting does not exist in the

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Connector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Connector.java
@@ -26,27 +26,32 @@ import java.util.List;
 public interface Connector extends AutoCloseable {
 
   /**
-   * Returns the name of the Connector as specified in the configuration.
-   * Connectors within a Run must have unique names.
+   * Get the name of this connector. Connectors within a Run must have unique names.
+   * @return the name of the Connector as specified in the configuration.
    */
   String getName();
 
   /**
-   * Returns the name of the pipeline to which this Connector's Documents should be sent.
+   * Get the name of the pipeline that this Connector will send documents to.
+   * @return the name of the pipeline to which this Connector's Documents should be sent.
    */
   String getPipelineName();
 
   /**
-   * Indicates whether this Connector instance expects to be passed a collapsing Publisher
-   * when execute() is called. A collapsing Publisher combines Documents that are
+   * Return whether this Connector requires a collapsing Publisher. A collapsing Publisher combines Documents that are
    * published in sequence and share the same ID. Such sequences of Documents are combined
    * into a single document with multi-valued fields.
    *
+   * @return whether this Connector instance expects to be passed a collapsing Publisher
+   * when execute() is called.
    */
   boolean requiresCollapsingPublisher();
 
   /**
    * Performs any logic that should occur before execute().
+   *
+   * @param runId The id of the run you are pre-executing.
+   * @throws ConnectorException in the event an error occurs
    */
   void preExecute(String runId) throws ConnectorException;
 
@@ -58,6 +63,7 @@ public interface Connector extends AutoCloseable {
    * Will not be called if preExecute() throws an exception.
    *
    * @param publisher provides a publish() method accepting a document to be published
+   * @throws ConnectorException in the event an error occurs
    */
   void execute(Publisher publisher) throws ConnectorException;
 
@@ -66,14 +72,21 @@ public interface Connector extends AutoCloseable {
    * the closing of connections, which should be done in close().
    *
    * Will not be called if preExecute() or execute() throw an exception.
+   *
+   * @param runId The id of the run you are post-executing.
+   * @throws ConnectorException in the event an error occurs
    */
   void postExecute(String runId) throws ConnectorException;
 
   /**
    * Instantiates a list of Connectors from the designated Config.
+   *
+   * @param config The configuration you want to extract Connectors from.
+   * @throws ReflectiveOperationException If a reflective error occurs while constructing the specified Connector.
+   * @throws ConnectorException In the event you specify multiple connectors with the same name.
+   * @return A list of Connectors build from the given Config.
    */
-  static List<Connector> fromConfig(Config config) throws ClassNotFoundException, NoSuchMethodException,
-      IllegalAccessException, InvocationTargetException, InstantiationException, ConnectorException {
+  static List<Connector> fromConfig(Config config) throws ReflectiveOperationException, ConnectorException {
     List<? extends Config> connectorConfigs = config.getConfigList("connectors");
 
     List<Connector> connectors = new ArrayList();
@@ -97,7 +110,9 @@ public interface Connector extends AutoCloseable {
   }
 
   /**
-   * Returns a message that should be included in the Lucille Run Summary for this connector instance.
+   * Get the message that should be included in the Lucille Run Summary for this connector instance.
+   *
+   * @return A message that should be included in the Lucille Run Summary for this connector instance.
    */
   String getMessage();
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorException.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorException.java
@@ -1,23 +1,50 @@
 package com.kmwllc.lucille.core;
 
+/**
+ * An Exception thrown by a Connector.
+ */
 public class ConnectorException extends Exception {
 
+  /**
+   * Creates a ConnectorException with the given message.
+   * @param message The message associated with the ConnectorException.
+   */
   public ConnectorException(String message) {
     super(message);
   }
 
+  /**
+   * Creates a ConnectorException with the given message and Throwable.
+   * @param message The message associated with the ConnectorException.
+   * @param cause A Throwable that caused the ConnectorException.
+   */
   public ConnectorException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates a ConnectorException with the given Throwable as a cause.
+   * @param cause A Throwable that caused the ConnectorException.
+   */
   public ConnectorException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Creates a ConnectorException with the given message and Throwable cause. Uses the given settings to enable / disable
+   * suppression of the Exception and whether the stack trace is writable.
+   * @param message The message associated with the Exception.
+   * @param cause A Throwable that caused the ConnectorException.
+   * @param enableSuppression Whether the Exception can be suppressed.
+   * @param writableStackTrace Whether the stack trace is writable.
+   */
   protected ConnectorException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
   }
 
+  /**
+   * Creates a ConnectorException.
+   */
   public ConnectorException() {
     super();
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorResult.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorResult.java
@@ -14,11 +14,28 @@ public class ConnectorResult {
 
   private String message;
 
+  /**
+   * Creates a ConnectorResult for the given connector / publisher, using the given status (representing whether it was
+   * successful) and the given error Message.
+   * @param connector The associated connector you want to create a result for.
+   * @param publisher The associated publisher you want to create a result for.
+   * @param status Whether the connector was successful.
+   * @param errorMsg An error message associated with the connector / publisher's run.
+   */
   public ConnectorResult(Connector connector, Publisher publisher,
       boolean status, String errorMsg) {
     this(connector, publisher, status, errorMsg, null);
   }
 
+  /**
+   * Creates a ConnectorResult for the given connector / publisher, using the given status (representing whether it was
+   * successful) and the given error Message.
+   * @param connector The associated connector you want to create a result for.
+   * @param publisher The associated publisher you want to create a result for.
+   * @param status Whether the connector was successful.
+   * @param errMsg An error message associated with the connector / publisher's run.
+   * @param durationSecs How long the connector took.
+   */
   public ConnectorResult(Connector connector, Publisher publisher,
       boolean status, String errMsg, Double durationSecs) {
     this.status = status;
@@ -32,14 +49,26 @@ public class ConnectorResult {
     }
   }
 
+  /**
+   * Get the status of this ConnectorResult.
+   * @return the status of this ConnectorResult.
+   */
   public boolean getStatus() {
     return status;
   }
 
+  /**
+   * Get whether this ConnectorResult had docs that failed.
+   * @return whether this ConnectorResult had docs that failed.
+   */
   public boolean hasFailingDocs() {
     return numFailed > 0;
   }
 
+  /**
+   * Get whether this ConnectorResult had docs.
+   * @return whether this ConnectorResult had docs.
+   */
   public boolean hasDocs() {
     return numFailed + numSucceeded > 0;
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorThread.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/ConnectorThread.java
@@ -2,6 +2,9 @@ package com.kmwllc.lucille.core;
 
 import org.slf4j.MDC;
 
+/**
+ * A thread that runs a connector, publishing documents to a specified Publisher.
+ */
 public class ConnectorThread extends Thread {
 
   private final Connector connector;
@@ -10,6 +13,14 @@ public class ConnectorThread extends Thread {
 
   private volatile Exception exception;
 
+  /**
+   * Creates a ConnectorThread from the given arguments.
+   *
+   * @param connector The connector to execute.
+   * @param publisher The publisher to publish documents to.
+   * @param runId The runId associated with this thread.
+   * @param name The name of the thread.
+   */
   public ConnectorThread(Connector connector, Publisher publisher, String runId, String name) {
     this.setName(name);
     this.connector = connector;
@@ -28,10 +39,18 @@ public class ConnectorThread extends Thread {
     }
   }
 
+  /**
+   * Get the exception associated with this connector thread.
+   * @return the exception associated with this connector thread.
+   */
   public Exception getException() {
     return exception;
   }
 
+  /**
+   * Returns whether this thread has an exception.
+   * @return whether this thread has an exception.
+   */
   public boolean hasException() {
     return exception != null;
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
@@ -56,27 +56,90 @@ public interface Document {
    *
    * Returns null in two cases: if the field is absent, or if the field is present but contains a null.
    * To distinguish between these cases, use has() to see if the field exists.
+   *
+   * @param name the name of the field you want to get a String value for.
+   * @return The value of the designated field as a String.
    */
   String getString(String name);
 
+  /**
+   * Returns the value of the designated field as a boolean.
+   *
+   * @param name the name of the field you want to get a boolean value for.
+   * @return The value of the designated field as a boolean.
+   */
   Boolean getBoolean(String name);
 
+  /**
+   * Returns the value of the designated field as an int.
+   *
+   * @param name the name of the field you want to get an int value for.
+   * @return The value of the designated field as an int.
+   */
   Integer getInt(String name);
 
+  /**
+   * Returns the value of the designated field as a double.
+   *
+   * @param name the name of the field you want to get a double value for.
+   * @return The value of the designated field as a double.
+   */
   Double getDouble(String name);
 
+  /**
+   * Returns the value of the designated field as a float.
+   *
+   * @param name the name of the field you want to get a flaot value for.
+   * @return The value of the designated field as a float.
+   */
   Float getFloat(String name);
 
+  /**
+   * Returns the value of the designated float as a long.
+   *
+   * @param name the name of the field you want to get a long value for.
+   * @return The value of the designated field as a long.
+   */
   Long getLong(String name);
 
+  /**
+   * Returns the value of the designated float as an instant.
+   *
+   * @param name the name of the field you want to get an instant value for.
+   * @return The value of the designated field as an instant.
+   */
   Instant getInstant(String name);
 
+  /**
+   * Returns the value of the designated float as a byte array.
+   *
+   * @param name the name of the field you want to get a byte array for.
+   * @return The value of the designated field as a byte array.
+   */
   byte[] getBytes(String name);
 
+  /**
+   * Returns the value of the designated float as a JsonNode.
+   *
+   * @param name the name of the field you want to get a JsonNode from.
+   * @return The value of the designated field as a JsonNode.
+   */
   JsonNode getJson(String name);
 
+  /**
+   * Returns the value of the designated float as a Date.
+   *
+   * @param name the name of the field you want to get a Date value for.
+   * @return The value of the designated field as a Date.
+   */
   Date getDate(String name);
 
+  /**
+   * Returns the value of the designated float as a Timestamp.
+   *
+   * @param name the name of the field you want to get a Timestamp value for.
+   * @return The value of the designated field as a Timestamp.
+   */
   Timestamp getTimestamp(String name);
 
   /* --- LIST GETTERS --- */
@@ -85,28 +148,99 @@ public interface Document {
    * Returns the value of the designated field as a List of Strings. If the field is single-valued, the single value
    * will be placed inside a List and returned, but the field will not be converted to multi-valued.
    *
-   * Returns null if the field is absent.
+   * @param name the name of the field you want to get a String list from.
+   * @return The value of the designated field as a String list.
    */
   List<String> getStringList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of Booleans. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a boolean list from.
+   * @return The value of the designated field as a boolean list.
+   */
   List<Boolean> getBooleanList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of integers. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a int list from.
+   * @return The value of the designated field as a int list.
+   */
   List<Integer> getIntList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of doubles. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a double list from.
+   * @return The value of the designated field as a double list.
+   */
   List<Double> getDoubleList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of floats. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a float list from.
+   * @return The value of the designated field as a float list.
+   */
   List<Float> getFloatList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of longs. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a long list from.
+   * @return The value of the designated field as a long list.
+   */
   List<Long> getLongList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of Instants. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get an instant list from.
+   * @return The value of the designated field as an instant list.
+   */
   List<Instant> getInstantList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of byte arrays. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a list of byte arrays from.
+   * @return The value of the designated field as a list of byte arrays from.
+   */
   List<byte[]> getBytesList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of JsonNodes. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a JsonNode list from.
+   * @return The value of the designated field as a JsonNode list from.
+   */
   List<JsonNode> getJsonList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of Dates. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a Date list from.
+   * @return The value of the designated field as a Date list from.
+   */
   List<Date> getDateList(String name);
 
+  /**
+   * Returns the value of the designated field as a List of Timestamps. If the field is single-valued, the single value
+   * will be placed inside a List and returned, but the field will not be converted to multi-valued.
+   *
+   * @param name the name of the field you want to get a Timestamp list from.
+   * @return The value of the designated field as a Timestamp list from.
+   */
   List<Timestamp> getTimestampList(String name);
 
   /* --- SINGLE-VALUE SETTERS --- */

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -305,6 +305,9 @@ public abstract class Indexer implements Runnable {
    * Returns the ID that should be sent to the destination index/collection for the given doc, in
    * place of the value of the Document.ID_FIELD field. Returns null if no override should be
    * applied for the given document.
+   *
+   * @param doc The document you want to get an ID Override for.
+   * @return The idOverride from the document, if it exists. If not, returns null.
    */
   protected String getDocIdOverride(Document doc) {
     if (idOverrideField != null && doc.has(idOverrideField)) {
@@ -316,6 +319,9 @@ public abstract class Indexer implements Runnable {
   /**
    * Returns the index that should be the destination for the given doc, in place of the default
    * index. Returns null if no index override should be applied for the given document.
+   *
+   * @param doc The document you want to get an index override for.
+   * @return The indexOverride from the document, if it exists. If not, returns null.
    */
   protected String getIndexOverride(Document doc) {
     if (indexOverrideField != null && doc.has(indexOverrideField)) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
@@ -115,12 +115,23 @@ public abstract class Stage {
     }
   }
 
+  /**
+   * Starts this stage, performing any setup if needed.
+   * @throws StageException If an error occurs.
+   */
   public void start() throws StageException {
   }
 
+  /**
+   * Stops this stage, freeing any resources / closing any connections as needed.
+   * @throws StageException If an error occurs.
+   */
   public void stop() throws StageException {
   }
 
+  /**
+   * Log metrics relating to the stage's performance, if metrics have been initialized.
+   */
   public void logMetrics() {
     if (timer == null || childCounter == null || errorCounter == null) {
       LoggerFactory.getLogger(Stage.class).error("Metrics not initialized");
@@ -152,7 +163,7 @@ public abstract class Stage {
    *
    * @param doc the Document
    * @return a list of child documents resulting from this Stages processing
-   * @throws StageException
+   * @throws StageException If an error occurs while processing a document.
    */
   public Iterator<Document> processConditional(Document doc) throws StageException {
     if (shouldProcess(doc)) {
@@ -177,6 +188,10 @@ public abstract class Stage {
   /**
    * Applies an operation to a Document in place and returns an Iterator over any child Documents generated
    * by the operation, not including the parent. If no child Documents are generated, the return value should be null.
+   *
+   * @param doc The document to process.
+   * @return An iterator of children documents created by the stage. May be null.
+   * @throws StageException If an error occurs while processing the document.
    */
   public abstract Iterator<Document> processDocument(Document doc) throws StageException;
 
@@ -185,6 +200,10 @@ public abstract class Stage {
    * by the operation, with the input or parent document at the end. Unlike processDocument, the return
    * value will always be non-null and will at least contain the input document.
    * If the input document has a run ID, this ID will be copied to any children that do not have it.
+   *
+   * @param doc The document to process.
+   * @return An iterator of children documents created by the stage. May be null.
+   * @throws StageException If an error occurs while processing the document.
    */
   public Iterator<Document> apply(Document doc) throws StageException {
 
@@ -233,6 +252,10 @@ public abstract class Stage {
 
   /**
    * Wraps an Iterator over Documents so as to call apply(doc) on each doc in the sequence.
+   *
+   * @param docs The iterator of documents you want to wrap around.
+   * @return An iterator of documents, wrapping around the given iterator, calling apply on each as they are returned.
+   * @throws StageException in the event an error occurs.
    */
   public Iterator<Document> apply(Iterator<Document> docs) throws StageException {
 
@@ -281,13 +304,17 @@ public abstract class Stage {
     };
   }
 
-
+  /**
+   * Gets the name of this stage, as-is.
+   * @return The name of this stage, as-is.
+   */
   public String getName() {
     return name;
   }
 
   /**
    * Returns the class name plus the stage name in parentheses, if it is not null.
+   * @return A formatted version of this stage's name.
    */
   private String getDisplayName() {
     return this.getClass().getName() +
@@ -296,6 +323,9 @@ public abstract class Stage {
 
   /**
    * Initialize metrics and set the Stage's name based on the position if the name has not already been set.
+   * @param position The position of the stage.
+   * @param metricsPrefix The metricsPrefix associated with this stage.
+   * @throws StageException In the event of an error.
    */
   public void initialize(int position, String metricsPrefix) throws StageException {
     if (name == null) {
@@ -308,10 +338,18 @@ public abstract class Stage {
     this.childCounter = metrics.counter(metricsPrefix + ".stage." + name + ".children");
   }
 
+  /**
+   * Gets this stage's config.
+   * @return This stage's config.
+   */
   public Config getConfig() {
     return config;
   }
 
+  /**
+   * Throws an exception if the config for this stage is not valid or if the specified conditions are not all validated.
+   * @throws StageException If the stage is not valid.
+   */
   public void validateConfigWithConditions() throws StageException {
 
     try {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/BaseFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/BaseFileHandler.java
@@ -7,14 +7,36 @@ import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The base implementation of a FileHandler.
+ */
 public abstract class BaseFileHandler implements FileHandler {
-  protected String docIdPrefix;
+
   private static final Logger log = LoggerFactory.getLogger(BaseFileHandler.class);
 
+  /**
+   * The prefix to add to any Document's ID when it is created by this FileHandler.
+   */
+  protected String docIdPrefix;
+
+  /**
+   * Creates the base implementation of a FileHandler from the given config.
+   * @param config Configuration for a FileHandler.
+   */
   public BaseFileHandler(Config config) {
     this.docIdPrefix = config.hasPath("docIdPrefix") ? config.getString("docIdPrefix") : "";
   }
 
+  /**
+   * Process and publish the file, described by an InputStream to its contents and a String representation of its path, publishing
+   * any extracted documents to the Publisher.
+   *
+   * @param publisher The publisher you want to publish documents to.
+   * @param inputStream An InputStream of the file's contents.
+   * @param pathStr A string to the file you're processing, used for logging / debugging.
+   * @throws FileHandlerException If an error occurs while processing the file / setting up an Iterator of Documents
+   * to extract from the file.
+   */
   public void processFileAndPublish(Publisher publisher, InputStream inputStream, String pathStr) throws FileHandlerException {
     Iterator<Document> docIterator;
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
@@ -24,6 +24,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A file handler for CSV files. Extracts documents from the rows of a CSV file.
+ */
 public class CSVFileHandler extends BaseFileHandler {
 
   private static final Logger log = LoggerFactory.getLogger(CSVFileHandler.class);
@@ -41,6 +44,10 @@ public class CSVFileHandler extends BaseFileHandler {
   private final List<String> ignoredTerms;
   private static final String UTF8_BOM = "\uFEFF";
 
+  /**
+   * Creates a CSVFileHandler from the given config.
+   * @param config Configuration for the CSVFileHandler.
+   */
   public CSVFileHandler(Config config) {
     super(config);
     this.lineNumField = config.hasPath("lineNumberField") ? config.getString("lineNumberField") : "csvLineNumber";

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/FileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/FileHandler.java
@@ -14,7 +14,6 @@ import java.util.Set;
  * Each implementation of the FileHandler handles a specific file type and is able to process the file and return an Iterator
  * of documents. It can also publish straight to the Lucille pipeline if given a Publisher.
  */
-
 public interface FileHandler {
 
   /**
@@ -27,18 +26,35 @@ public interface FileHandler {
    * Processes a file given an InputStream of its contents and a representation path String to it, and returns an iterator
    * of Documents. The Iterator should close all resources when completed (hasNext() is false) or when an exception is thrown.
    * Path string is used for populating file path field of document and for logging/error/debugging purposes.
+   *
+   * @param inputStream An InputStream of the file's contents.
+   * @param pathStr A string to the file you're processing, used for logging / debugging.
+   * @return An Iterator of Documents extracted from the file's contents. Closes any resources when hasNext() is false.
+   * @throws FileHandlerException If an error occurs setting up an iterator for the file.
    */
   Iterator<Document> processFile(InputStream inputStream, String pathStr) throws FileHandlerException;
 
   /**
    * A helper function that processes a file and publishes the documents to a Publisher using the content in the given
    * InputStream. The given stream should be closed as part of this function's operations (namely the Iterators created)
+   *
+   * @param publisher The publisher you want to publish documents to.
+   * @param inputStream An InputStream of the file's contents.
+   * @param pathStr A string to the file you're processing, used for logging / debugging.
+   * @throws FileHandlerException If an error occurs setting up an iterator for the fiel.
    */
   void processFileAndPublish(Publisher publisher, InputStream inputStream, String pathStr) throws FileHandlerException;
 
   /**
    * Returns a new FileHandler based on the file extension and file options. Note that if you add support
    * for a new file type, you must also add the corresponding handler here AND in SUPPORTED_FILE_TYPES collection
+   *
+   * @param fileExtension The extension associated with the file.
+   * @param fileOptions Configuration for how you want to handle / process files. Should contain individaul maps with
+   *                    configuration for the different FileHandlers you want to support.
+   *
+   * @throws UnsupportedOperationException If you try to create a FileHandler for an unsupported file type.
+   * @return A FileHandler to process files with the given extension.
    */
   static FileHandler create(String fileExtension, Config fileOptions) {
     switch (fileExtension) {
@@ -63,6 +79,11 @@ public interface FileHandler {
    * Returns a Map from the given Config, creating FileHandlers that can be constructed from the given config, mapped
    * to their corresponding file extensions. If json is included, jsonl will be as well (and vice versa).
    * The returned map is not modifiable.
+   *
+   * @param optionsWithHandlers A config that contains individual maps / configuration for the file handlers that you want
+   *                            to support.
+   * @return A map of file extensions to their respective file handlers, creating as many as could be built from the
+   * provided config.
    */
   static Map<String, FileHandler> createFromConfig(Config optionsWithHandlers) {
     Map<String, FileHandler> handlerMap = new HashMap<>();
@@ -80,6 +101,11 @@ public interface FileHandler {
   /**
    * supportAndContainFileType returns true if the file extension is in SUPPORTED_FILE_TYPES and
    * the file options contain the file extension. Handles the special case of json and jsonl files.
+   *
+   * @param fileExtension The extension of the file you want to check.
+   * @param fileOptions A config that contains individual maps / configuration for the file handlers that you want
+   *                    to support.
+   * @return Whether the file type is supported by Lucille and your fileOptions contains configuration for the file type.
    */
   static boolean supportAndContainFileType(String fileExtension, Config fileOptions) {
     return SUPPORTED_FILE_TYPES.contains(fileExtension) &&

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -14,6 +14,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * An indexer that stores documents in a CSV file.
+ */
 public class CSVIndexer extends Indexer {
 
   private static final Logger log = LoggerFactory.getLogger(CSVIndexer.class);
@@ -23,7 +26,15 @@ public class CSVIndexer extends Indexer {
   private final List<String> columns;
   private final boolean includeHeader;
 
-
+  /**
+   * Creates a CSVIndexer from the given arguments.
+   * @param config Configuration for the CSVIndexer.
+   * @param messenger The messenger to use for the CSVIndexer.
+   * @param writer The CSVWriter to use for storing documents.
+   * @param bypass Whether to always invalidate the connection.
+   * @param metricsPrefix The prefix associated with metrics for this indexer.
+   * @param localRunId The runID for a local run, null otherwise.
+   */
   public CSVIndexer(Config config, IndexerMessenger messenger, ICSVWriter writer, boolean bypass, String metricsPrefix, String localRunId) {
     super(config, messenger, metricsPrefix, localRunId);
     if (this.indexOverrideField != null) {
@@ -36,16 +47,37 @@ public class CSVIndexer extends Indexer {
     this.includeHeader = config.hasPath("csv.includeHeader") ? config.getBoolean("csv.includeHeader") : true;
   }
 
+  /**
+   * Creates a CSVIndexer from the given arguments.
+   * @param config Configuration for the CSVIndexer.
+   * @param messenger The messenger to use for the CSVIndexer.
+   * @param bypass Whether to always invalidate the connection.
+   * @param metricsPrefix The prefix associated with metrics for this indexer.
+   * @param localRunId The runID for a local run, null otherwise.
+   */
   public CSVIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix, String localRunId) {
     this(config, messenger, getCsvWriter(config, bypass), bypass, metricsPrefix, localRunId);
   }
 
-  // Convenience constructor, mostly for testing. (No localRunId)
+  /**
+   * Creates a CSVIndexer from the given arguments with no local runID. Mostly for testing.
+   * @param config Configuration for the CSVIndexer.
+   * @param messenger The messenger to use for the CSVIndexer.
+   * @param writer The CSVWriter to use for storing documents.
+   * @param bypass Whether to always invalidate the connection.
+   * @param metricsPrefix The prefix associated with metrics for this indexer.
+   */
   public CSVIndexer(Config config, IndexerMessenger messenger, ICSVWriter writer, boolean bypass, String metricsPrefix) {
     this(config, messenger, writer, bypass, metricsPrefix, null);
   }
 
-  // Convenience constructor, mostly for testing. (No localRunId)
+  /**
+   * Creates a CSVIndexer from the given arguments with no local runID. Mostly for testing.
+   * @param config Configuration for the CSVIndexer.
+   * @param messenger The messenger to use for the CSVIndexer.
+   * @param bypass Whether to always invalidate the connection.
+   * @param metricsPrefix The prefix associated with metrics for this indexer.
+   */
   public CSVIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix) {
     this(config, messenger, getCsvWriter(config, bypass), bypass, metricsPrefix, null);
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomBoolean.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomBoolean.java
@@ -26,6 +26,11 @@ public class AddRandomBoolean extends Stage {
   private final String fieldName;
   private final int percentTrue;
 
+  /**
+   * Creates the AddRandomBoolean stage from the given Config.
+   * @param config Configuration for the AddRandomBoolean stage.
+   * @throws StageException If the percentTrue parameter has value less than 0 or greater than 100.
+   */
   public AddRandomBoolean(Config config) throws StageException {
     super(config, new StageSpec()
         .withOptionalProperties("field_name", "percent_true"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomDate.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomDate.java
@@ -39,6 +39,10 @@ public class AddRandomDate extends Stage {
   private Date rangeStartDate;
   private Date rangeEndDate;
 
+  /**
+   * Creates the AddRandomDate stage from the given Config.
+   * @param config Configuration for the AddRandomDate stage.
+   */
   public AddRandomDate(Config config) {
     super(config, new StageSpec()
         .withOptionalProperties("field_name", "range_start_date", "range_end_date"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomDouble.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomDouble.java
@@ -34,6 +34,11 @@ public class AddRandomDouble extends Stage {
   private final double rangeStart;
   private final double rangeEnd;
 
+  /**
+   * Creates the AddRandomDouble stage from the given config.
+   * @param config Configuration for the AddRandomDouble stage.
+   * @throws StageException If the range_start is greater than range_end.
+   */
   public AddRandomDouble(Config config) throws StageException {
     super(config, new StageSpec()
         .withOptionalProperties("field_name", "range_start", "range_end"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomInt.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomInt.java
@@ -34,6 +34,11 @@ public class AddRandomInt extends Stage {
   private final int rangeStart;
   private final int rangeEnd;
 
+  /**
+   * Creates the AddRandomInt stage from the given config.
+   * @param config Configuration for the AddRandomInt stage.
+   * @throws StageException If the range_start is greater than range_end.
+   */
   public AddRandomInt(Config config) throws StageException {
     super(config, new StageSpec()
         .withOptionalProperties("field_name", "range_start", "range_end"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomString.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/AddRandomString.java
@@ -60,6 +60,11 @@ public class AddRandomString extends Stage {
   private List<String> fileData;
   private final boolean concatenate;
 
+  /**
+   * Creates the AddRandomDate stage from the given Config.
+   * @param config Configuration for the AddRandomDate stage.
+   * @throws StageException In the event your config contains invalid values.
+   */
   public AddRandomString(Config config) throws StageException {
     super(config, new StageSpec().withOptionalProperties("input_data_path", "field_name", "range_size", "min_num_of_terms",
         "max_num_of_terms", "is_nested", "concatenate"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyFileHandlers.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyFileHandlers.java
@@ -51,6 +51,10 @@ public class ApplyFileHandlers extends Stage {
 
   private Map<String, FileHandler> fileHandlers;
 
+  /**
+   * Creates the ApplyFileHandlers stage from the given config.
+   * @param config Configuration for the ApplyFileHandlers stage.
+   */
   public ApplyFileHandlers(Config config) {
     super(config, new StageSpec()
         .withOptionalParents("handlerOptions", "gcp", "azure", "s3")

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyJSONNata.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyJSONNata.java
@@ -43,6 +43,11 @@ public class ApplyJSONNata extends Stage {
   private final String expression;
   private Expressions parsed;
 
+  /**
+   * Create the ApplyJSONNata stage from the given config.
+   * @param config Configuration for the ApplyJSONNata stage.
+   * @throws StageException If the configuration is invalid.
+   */
   public ApplyJSONNata(Config config) throws StageException {
     super(config, new StageSpec().withOptionalProperties("source", "destination").withRequiredProperties("expression"));
     this.source = ConfigUtils.getOrDefault(config, "source", null);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyJSoup.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyJSoup.java
@@ -72,6 +72,11 @@ public class ApplyJSoup extends Stage {
     STRING, BYTE, FILE
   }
 
+  /**
+   * Creates the ApplyJSoup stage from the given config.
+   * @param config Configuration for the ApplyJSoup stage.
+   * @throws StageException If your configuration is invalid.
+   */
   public ApplyJSoup(Config config) throws StageException {
     super(config, new StageSpec().withOptionalProperties("filePathField", "byteArrayField", "stringField", "charset")
         .withRequiredParents("destinationFields"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyRegex.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ApplyRegex.java
@@ -50,6 +50,10 @@ public class ApplyRegex extends Stage {
 
   private Pattern pattern;
 
+  /**
+   * Create the ApplyRegex stage from the given config.
+   * @param config Configuration for the ApplyRegex stage.
+   */
   public ApplyRegex(Config config) {
     super(config, new StageSpec().withRequiredProperties("source", "dest", "regex")
         .withOptionalProperties("update_mode", "ignore_case", "multiline", "dotall", "literal"));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/Base64Decode.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/Base64Decode.java
@@ -9,11 +9,19 @@ import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
 import com.typesafe.config.Config;
 
+/**
+ * A Stage for decoding base64 data strings and outputting them as arrays of bytes on a document.
+ */
 public class Base64Decode extends Stage {
 
   private String inputField;
   private String outputField;
-  
+
+  /**
+   * Creates the Base64Decode stage from the given configuration.
+   *
+   * @param config Configuration for the Base64Decode stage.
+   */
   public Base64Decode(Config config) {
     super(config, new StageSpec().withRequiredProperties("input_field", "output_field"));
     inputField = config.getString("input_field");

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ChunkText.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ChunkText.java
@@ -101,6 +101,11 @@ public class ChunkText extends Stage {
   private SentenceDetector sentenceDetector;
   private static final Logger log = LoggerFactory.getLogger(ChunkText.class);
 
+  /**
+   * Creates the ChunkText stage from the given config.
+   * @param config Configuration for the ChunkText stage.
+   * @throws StageException If your configuration is invalid.
+   */
   public ChunkText(Config config) throws StageException {
     super(config, new StageSpec()
         .withOptionalProperties("chunking_method", "chunks_to_merge", "dest", "regex", "character_limit",
@@ -255,6 +260,12 @@ public class ChunkText extends Stage {
     }
   }
 
+  /**
+   * Splits the given String input into chunks, using the given chunkSize.
+   * @param input The String you want to chunk up.
+   * @param chunkSize The desired size of your chunks.
+   * @return The chunked String as an array of individual Strings.
+   */
   public String[] splitBySize(String input, int chunkSize) {
     int inputLength = input.length();
     int numOfChunks = (inputLength + chunkSize - 1) / chunkSize;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/CollapseChildrenDocuments.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/CollapseChildrenDocuments.java
@@ -21,7 +21,11 @@ public class CollapseChildrenDocuments extends Stage {
 
   private List<String> fieldsToCopy;
   private boolean dropChildren;
-  
+
+  /**
+   * Creates the CollapseChildrenDocuments stage from the given config.
+   * @param config Configuration for the CollapseChildrenDocuments stage.
+   */
   public CollapseChildrenDocuments(Config config) { 
     super(config, new StageSpec().withRequiredProperties("fieldsToCopy", "dropChildren"));
     fieldsToCopy = config.getStringList("fieldsToCopy"); 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ComputeFieldSize.java
@@ -25,6 +25,10 @@ public class ComputeFieldSize extends Stage {
   private final String source;
   private final String destination;
 
+  /**
+   * Creates the ComputeFieldSize stage from the given config.
+   * @param config Configuration for the ComputeFieldSize stage.
+   */
   public ComputeFieldSize(Config config) {
     super(config, new StageSpec().withRequiredProperties("source", "dest"));
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/Concatenate.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/Concatenate.java
@@ -35,6 +35,10 @@ public class Concatenate extends Stage {
 
   private final List<String> fields;
 
+  /**
+   * Creates the Concatenate stage from the given configuration.
+   * @param config Configuration for the Concatenate stage.
+   */
   public Concatenate(Config config) {
     super(config, new StageSpec()
         .withRequiredProperties("dest", "format_string")

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/Contains.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/Contains.java
@@ -32,6 +32,11 @@ public class Contains extends Stage {
 
   private PayloadTrie<String> trie;
 
+  /**
+   * Creates the Contains stage from the given Config.
+   *
+   * @param config Configuration for the Contains stage.
+   */
   public Contains(Config config) {
     super(config, new StageSpec()
         .withRequiredProperties("contains", "output", "value", "fields")

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/CopyFields.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/CopyFields.java
@@ -30,6 +30,10 @@ public class CopyFields extends Stage {
   private final List<String> destFields;
   private final UpdateMode updateMode;
 
+  /**
+   * Creates the CopyFields from the given config.
+   * @param config Configuration for the CopyFields stage.
+   */
   public CopyFields(Config config) {
     super(config, new StageSpec()
         .withRequiredProperties("source", "dest")

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/CreateChildrenStage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/CreateChildrenStage.java
@@ -22,6 +22,10 @@ public class CreateChildrenStage extends Stage {
   private final Integer failAfter;
   private final Integer dropChild;
 
+  /**
+   * Creates the CreateChildrenStage from the given config.
+   * @param config Configuration for the CreateChildrenStage.
+   */
   public CreateChildrenStage(Config config) {
     super(config, new StageSpec().withOptionalProperties("numChildren", "dropParent", "failAfter", "dropChild"));
     this.numChildren = config.hasPath("numChildren") ? config.getInt("numChildren") : 3;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/CreateStaticTeaser.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/CreateStaticTeaser.java
@@ -31,6 +31,10 @@ public class CreateStaticTeaser extends Stage {
   private final int maxLength;
   private final UpdateMode updateMode;
 
+  /**
+   * Creates the CreateStaticTeaser stage from the given config.
+   * @param config Configuration for the CreateStaticTeaser stage.
+   */
   public CreateStaticTeaser(Config config) {
     super(config, new StageSpec()
         .withRequiredProperties("source", "dest", "maxLength")

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DeleteFields.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DeleteFields.java
@@ -19,6 +19,10 @@ public class DeleteFields extends Stage {
 
   private final List<String> fields;
 
+  /**
+   * Creates the DeleteFields stage from the given config.
+   * @param config Configuration for the DeleteFields stage.
+   */
   public DeleteFields(Config config) {
     super(config, new StageSpec().withRequiredProperties("fields"));
     this.fields = config.getStringList("fields");

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DetectLanguage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DetectLanguage.java
@@ -51,6 +51,10 @@ public class DetectLanguage extends Stage {
 
   private Detector detector;
 
+  /**
+   * Creates the DetectLanguage stage from the given config.
+   * @param config Configuration for the DetectLanguage stage.
+   */
   public DetectLanguage(Config config) {
     super(config, new StageSpec().withRequiredProperties("source", "language_field")
         .withOptionalProperties("language_confidence_field", "min_length", "max_length",

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
@@ -62,6 +62,11 @@ public class DictionaryLookup extends Stage {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   // Dummy value to indicate that a key is present in the HashMap
 
+  /**
+   * Creates the DictionaryLookup stage from the given configuration.
+   * @param config Configuration for the DictionaryLookup stage.
+   * @throws StageException If the provided configuration is invalid / insufficient.
+   */
   public DictionaryLookup(Config config) throws StageException {
     super(config, new StageSpec().withRequiredProperties("source", "dest", "dict_path")
         .withOptionalProperties("use_payloads", "update_mode", "ignore_case", "set_only", "ignore_missing_source")

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/EmitNestedChildren.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/EmitNestedChildren.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  *
  * Config Parameters:
  * - drop_parent (Boolean, Optional): if set to true, will mark parent document as dropped. Defaults to false
- * - fields_to_copy (Map<String>, Optional): map of fields to copy from parent to children. It's a map of the source field name to the destination field name.
+ * - fields_to_copy (Map (String, String), Optional): map of fields to copy from parent to children. It's a map of the source field name to the destination field name.
  */
 public class EmitNestedChildren extends Stage {
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateMonthStrFormatter.java
@@ -9,13 +9,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- *  Attempts to find dates of the form "January 1, 2000" and extract
- *  the values into a Java date. Will return null of the there are no dates formatted in it's style within the String.
+ * Attempts to find dates of the form "January 1, 2000" and extract the values into a Java date.
+ * Will return null of the there are no dates formatted in its style within the String.
  */
 public class DateMonthStrFormatter implements BiFunction<String, ZoneId, ZonedDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\w+ \\d{1,2}, \\d{1,4}");
   private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("LLLL d, u");
+
+  /** Creates a DateMonthStrFormatter. */
+  public DateMonthStrFormatter() {}
 
   @Override
   public ZonedDateTime apply(String value, ZoneId zone) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DatePipeFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DatePipeFormatter.java
@@ -7,12 +7,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Attempts to find dates of the form "YYYY|MM|DD" and extract the values
- * into a Java date. Will return null of the there are no dates formatted in it's style within the String.
+ * Attempts to find dates of the form "YYYY|MM|DD" and extract the values into a Java date.
+ * Will return null of the there are no dates formatted in its style within the String.
  */
 public class DatePipeFormatter implements BiFunction<String, ZoneId, ZonedDateTime> {
 
   private static final Pattern datePattern = Pattern.compile("\\d{1,4}\\|\\d{1,2}\\|\\d{1,2}");
+
+  /** Creates a DatePipeFormatter. */
+  public DatePipeFormatter() {}
 
   @Override
   public ZonedDateTime apply(String value, ZoneId zone) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateTwoYearsFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateTwoYearsFormatter.java
@@ -16,6 +16,9 @@ public class DateTwoYearsFormatter implements BiFunction<String, ZoneId, ZonedDa
 
   private static final Pattern datePattern = Pattern.compile("\\d{1,4}\\W\\d{1,4}");
 
+  /** Creates a DateTwoYearsFormatter. */
+  public DateTwoYearsFormatter() {}
+
   @Override
   public ZonedDateTime apply(String value, ZoneId zone) {
     Matcher matcher = datePattern.matcher(value);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/dateformatters/DateYearOnlyFormatter.java
@@ -15,6 +15,9 @@ public class DateYearOnlyFormatter implements BiFunction<String, ZoneId, ZonedDa
 
   private static final Pattern datePattern = Pattern.compile("^\\d{2,4}$");
 
+  /** Creates a DateYearOnlyFormatter. */
+  public DateYearOnlyFormatter() {}
+
   @Override
   public ZonedDateTime apply(String value, ZoneId zone) {
     Matcher matcher = datePattern.matcher(value);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/util/ChunkingMethod.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/util/ChunkingMethod.java
@@ -2,10 +2,27 @@ package com.kmwllc.lucille.stage.util;
 
 import com.typesafe.config.Config;
 
+/**
+ * A method of chunking contents.
+ */
 public enum ChunkingMethod {
-  FIXED("fixed"), CUSTOM("custom"), PARAGRAPH("paragraph"), SENTENCE("sentence");
+  /** Chunking by a fixed amount. */
+  FIXED("fixed"),
+  /** A custom method. */
+  CUSTOM("custom"),
+  /** Chunking by paragraph. */
+  PARAGRAPH("paragraph"),
+  /** Chunking by sentence. */
+  SENTENCE("sentence");
 
+  /**
+   * A path in configuration that should contain a specified chunking method, if desired.
+   */
   public static final String CONFIG_PATH = "chunking_method";
+
+  /**
+   * The default chunking method, currently "SENTENCE".
+   */
   public static final ChunkingMethod DEFAULT = SENTENCE;
 
   private String text;
@@ -14,6 +31,13 @@ public enum ChunkingMethod {
     this.text = text;
   }
 
+  /**
+   * Returns a chunking method from the given String. If it does not match one of the existing values, it returns the
+   * default method. This method is case insensitive.
+   *
+   * @param modeStr A String representing a chunking method.
+   * @return A ChunkingMethod associated with the given String, or the default method if one cannot be extracted.
+   */
   public static ChunkingMethod fromString(String modeStr) {
     for (ChunkingMethod mode : ChunkingMethod.values()) {
       if (modeStr.toLowerCase().equals(mode.text)) {
@@ -24,6 +48,13 @@ public enum ChunkingMethod {
     return DEFAULT;
   }
 
+  /**
+   * Gets a chunking method from the given config. Specifically, it reads a String from the "chunking_method" field, and then
+   * uses the fromString method on it. If this field is not present, returns the default chunking method.
+   *
+   * @param config A Configuration that you want to get a ChunkingMethod from.
+   * @return A ChunkingMethod extracted from the given Config.
+   */
   public static ChunkingMethod fromConfig(Config config) {
     if (config.hasPath(CONFIG_PATH)) {
       return ChunkingMethod.fromString(config.getString(CONFIG_PATH));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
@@ -16,14 +16,24 @@ import java.util.function.BiConsumer;
 import java.util.function.UnaryOperator;
 
 import static com.kmwllc.lucille.core.Document.RESERVED_FIELDS;
-import static com.kmwllc.lucille.core.Document.create;
 import static org.junit.Assert.*;
 
 @RunWith(JUnit4.class)
 public abstract class DocumentTest {
 
+  /**
+   * Creates a Document from the given ObjectNode.
+   * @param node The node to create a Document from.
+   * @return A Document created from the ObjectNode.
+   * @throws DocumentException If an error occurs.
+   */
   public abstract Document createDocument(ObjectNode node) throws DocumentException;
 
+  /**
+   * Creates an empty Document with the given ID.
+   * @param id The id to use for the document.
+   * @return An empty document with the given ID.
+   */
   public abstract Document createDocument(String id);
 
   public abstract Document createDocument(String id, String runId);

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -260,7 +260,7 @@
                Otherwise, the build will fail. https://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete
               The goal is to eventually remove this setting once we add correct JavaDoc comments where they are needed.
               !-->
-              <failOnError>false</failOnError>
+              <failOnError>true</failOnError>
             </configuration>
           </execution>
 

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -260,7 +260,7 @@
                Otherwise, the build will fail. https://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete
               The goal is to eventually remove this setting once we add correct JavaDoc comments where they are needed.
               !-->
-              <failOnError>true</failOnError>
+              <failOnError>false</failOnError>
             </configuration>
           </execution>
 


### PR DESCRIPTION
Adds JavaDoc in places that were missing it, causing a build failure when `failOnError` is set to true.