### PR TITLE
LC-658: Replace JSONata library

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -18,9 +18,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.ibm.jsonata4java</groupId>
-      <artifactId>JSONata4Java</artifactId>
-      <version>2.5.0</version>
+        <groupId>com.dashjoin</groupId>
+        <artifactId>jsonata</artifactId>
+        <version>0.9.8</version>
     </dependency>
     <dependency>
       <groupId>org.opensearch.client</groupId>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.core;
 
-import com.api.jsonata4java.expressions.Expressions;
+import com.dashjoin.jsonata.Jsonata;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -490,7 +490,7 @@ public interface Document {
    * @throws DocumentException if any reserved fields are mutated or if the result is not an object (primitive or array)
    * @see <a href="https://github.com/IBM/JSONata4Java">JSONNata implementation</a>
    */
-  void transform(Expressions expr) throws DocumentException;
+  void transform(Jsonata expr) throws DocumentException;
 
   /**
    * Returns an Iterator that contains only this document.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
@@ -1,6 +1,6 @@
 package com.kmwllc.lucille.core;
 
-import com.api.jsonata4java.expressions.Expressions;
+import com.dashjoin.jsonata.Jsonata;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
-import javax.naming.OperationNotSupportedException;
 
 
 @JsonIgnoreProperties(value = {"fieldNames", "runId", "dropped", "id", "children"})
@@ -676,7 +675,7 @@ public class HashMapDocument implements Document, Serializable {
   }
 
   @Override
-  public void transform(Expressions expr) throws DocumentException {
+  public void transform(Jsonata expr) throws DocumentException {
     throw new UnsupportedOperationException("Transform is not supported for HashMap implementation of Document");
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
@@ -935,7 +935,8 @@ public class JsonDocument implements Document {
     HashMap<String, JsonNode> reserved = new HashMap<>();
     RESERVED_FIELDS.stream().filter(field -> has(field)).forEach(field -> reserved.put(field, data.get(field)));
 
-    Object transformed = expr.evaluate(data.toString());
+    Map<String, Object> dataAsMap = new ObjectMapper().convertValue(data, Map.class);
+    Object transformed = expr.evaluate(dataAsMap);
 
     if (transformed == null) {
       throw new DocumentException("Transformation must return a Map (JSON object), returned null");
@@ -943,17 +944,17 @@ public class JsonDocument implements Document {
       throw new DocumentException("Transformation must return a Map (JSON object), returned " + transformed.getClass());
     }
 
-    ObjectNode transformedMap = new ObjectMapper().valueToTree(transformed);
+    ObjectNode transformedNode = new ObjectMapper().valueToTree(transformed);
 
-    System.out.println(transformedMap.toPrettyString());
+    System.out.println(transformedNode.toPrettyString());
 
     for (Map.Entry<String, JsonNode> entry : reserved.entrySet()) {
-      if (!entry.getValue().equals(transformedMap.get(entry.getKey()))) {
+      if (!entry.getValue().equals(transformedNode.get(entry.getKey()))) {
         throw new DocumentException("The given transformation mutates a reserved field");
       }
     }
 
-    data = transformedMap;
+    data = transformedNode;
   }
 
   private static ObjectNode getData(Document other) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
@@ -940,7 +940,7 @@ public class JsonDocument implements Document {
       Map<String, Object> dataAsMap = MAPPER.readValue(data.toString(), Map.class);
       transformed = expr.evaluate(dataAsMap);
     } catch (JsonProcessingException e) {
-      throw new DocumentException("Error getting the JSON");
+      throw new DocumentException("Error converting JSON to Map: " + e.getMessage());
     }
 
     if (transformed == null) {
@@ -949,7 +949,7 @@ public class JsonDocument implements Document {
       throw new DocumentException("Transformation must return a Map (JSON object), returned " + transformed.getClass());
     }
 
-    // Jsonata-java outputs a Map, need to convert to ObjectNode so we can update data.
+    // Jsonata-java outputs a Map, converting to ObjectNode so we can update data.
     ObjectNode transformedNode = new ObjectMapper().valueToTree(transformed);
 
     for (Map.Entry<String, JsonNode> entry : reserved.entrySet()) {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
@@ -1,5 +1,6 @@
 package com.kmwllc.lucille.core;
 
+import com.dashjoin.jsonata.Jsonata;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +17,7 @@ import java.util.function.UnaryOperator;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -215,35 +217,35 @@ public class JsonDocumentTest extends DocumentTest.NodeDocumentTest {
     assertEquals(mapper.readTree("[{\"a\":1}, {\"a\":2}, {\"a\":3}, {\"a\":4}]"), d.getJson("myJson"));
   }
 
-//  @Test
-//  public void testTransform() throws Exception {
-//    Document doc = createDocumentFromJson("{\"id\":\"id\",\"foo\": \"bar\"}");
-//    doc.setField("bytes", new byte[]{1, 2, 3});
-//
-//    // test mutating a reserved field
-//    Expressions mutateReservedExpr = Expressions.parse("{\"id\":\"diff\",\"foo\": \"bar\"}");
-//    assertThrows(DocumentException.class, () -> doc.transform(mutateReservedExpr));
-//    assertEquals(3, doc.getFieldNames().size());
-//    assertEquals("id", doc.getId());
-//    assertEquals("bar", doc.getString("foo"));
-//    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
-//
-//    // test mutatation does not create object
-//    Expressions mutateIntoArray = Expressions.parse("[1, 2, 3]");
-//    Expressions mutateIntoNum = Expressions.parse("3");
-//    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoArray));
-//    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoNum));
-//    assertEquals(3, doc.getFieldNames().size());
-//    assertEquals("id", doc.getId());
-//    assertEquals("bar", doc.getString("foo"));
-//    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
-//
-//    // test valid mutation
-//    Expressions mutateFoo = Expressions.parse("$merge([$, {\"foo\": $substring(foo, 2)}])");
-//    doc.transform(mutateFoo);
-//    assertEquals(3, doc.getFieldNames().size());
-//    assertEquals("id", doc.getId());
-//    assertEquals("r", doc.getString("foo"));
-//    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
-//  }
+  @Test
+  public void testTransform() throws Exception {
+    Document doc = createDocumentFromJson("{\"id\":\"id\",\"foo\": \"bar\"}");
+    doc.setField("bytes", new byte[]{1, 2, 3});
+
+    // test mutating a reserved field
+    Jsonata mutateReservedExpr = Jsonata.jsonata("{\"id\":\"diff\",\"foo\": \"bar\"}");
+    assertThrows(DocumentException.class, () -> doc.transform(mutateReservedExpr));
+    assertEquals(3, doc.getFieldNames().size());
+    assertEquals("id", doc.getId());
+    assertEquals("bar", doc.getString("foo"));
+    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
+
+    // test mutatation does not create object
+    Jsonata mutateIntoArray = Jsonata.jsonata("[1, 2, 3]");
+    Jsonata mutateIntoNum = Jsonata.jsonata("3");
+    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoArray));
+    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoNum));
+    assertEquals(3, doc.getFieldNames().size());
+    assertEquals("id", doc.getId());
+    assertEquals("bar", doc.getString("foo"));
+    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
+
+    // test valid mutation
+    Jsonata mutateFoo = Jsonata.jsonata("$merge([$, {\"foo\": $substring(foo, 2)}])");
+    doc.transform(mutateFoo);
+    assertEquals(3, doc.getFieldNames().size());
+    assertEquals("id", doc.getId());
+    assertEquals("r", doc.getString("foo"));
+    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
+  }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
@@ -1,6 +1,5 @@
 package com.kmwllc.lucille.core;
 
-import com.api.jsonata4java.expressions.Expressions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,7 +16,6 @@ import java.util.function.UnaryOperator;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -217,35 +215,35 @@ public class JsonDocumentTest extends DocumentTest.NodeDocumentTest {
     assertEquals(mapper.readTree("[{\"a\":1}, {\"a\":2}, {\"a\":3}, {\"a\":4}]"), d.getJson("myJson"));
   }
 
-  @Test
-  public void testTransform() throws Exception {
-    Document doc = createDocumentFromJson("{\"id\":\"id\",\"foo\": \"bar\"}");
-    doc.setField("bytes", new byte[]{1, 2, 3});
-    
-    // test mutating a reserved field
-    Expressions mutateReservedExpr = Expressions.parse("{\"id\":\"diff\",\"foo\": \"bar\"}");
-    assertThrows(DocumentException.class, () -> doc.transform(mutateReservedExpr));
-    assertEquals(3, doc.getFieldNames().size());
-    assertEquals("id", doc.getId());
-    assertEquals("bar", doc.getString("foo"));
-    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
-
-    // test mutatation does not create object 
-    Expressions mutateIntoArray = Expressions.parse("[1, 2, 3]");
-    Expressions mutateIntoNum = Expressions.parse("3");
-    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoArray));
-    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoNum));
-    assertEquals(3, doc.getFieldNames().size());
-    assertEquals("id", doc.getId());
-    assertEquals("bar", doc.getString("foo"));
-    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
-
-    // test valid mutation 
-    Expressions mutateFoo = Expressions.parse("$merge([$, {\"foo\": $substring(foo, 2)}])");
-    doc.transform(mutateFoo);
-    assertEquals(3, doc.getFieldNames().size());
-    assertEquals("id", doc.getId());
-    assertEquals("r", doc.getString("foo"));
-    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
-  }
+//  @Test
+//  public void testTransform() throws Exception {
+//    Document doc = createDocumentFromJson("{\"id\":\"id\",\"foo\": \"bar\"}");
+//    doc.setField("bytes", new byte[]{1, 2, 3});
+//
+//    // test mutating a reserved field
+//    Expressions mutateReservedExpr = Expressions.parse("{\"id\":\"diff\",\"foo\": \"bar\"}");
+//    assertThrows(DocumentException.class, () -> doc.transform(mutateReservedExpr));
+//    assertEquals(3, doc.getFieldNames().size());
+//    assertEquals("id", doc.getId());
+//    assertEquals("bar", doc.getString("foo"));
+//    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
+//
+//    // test mutatation does not create object
+//    Expressions mutateIntoArray = Expressions.parse("[1, 2, 3]");
+//    Expressions mutateIntoNum = Expressions.parse("3");
+//    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoArray));
+//    assertThrows(DocumentException.class, () -> doc.transform(mutateIntoNum));
+//    assertEquals(3, doc.getFieldNames().size());
+//    assertEquals("id", doc.getId());
+//    assertEquals("bar", doc.getString("foo"));
+//    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
+//
+//    // test valid mutation
+//    Expressions mutateFoo = Expressions.parse("$merge([$, {\"foo\": $substring(foo, 2)}])");
+//    doc.transform(mutateFoo);
+//    assertEquals(3, doc.getFieldNames().size());
+//    assertEquals("id", doc.getId());
+//    assertEquals("r", doc.getString("foo"));
+//    assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
+//  }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONNataTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONNataTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
@@ -34,10 +33,10 @@ public class ApplyJSONNataTest {
     Document doc = Document.create("id");
     doc.setField("foo", "bar");
 
-    invalidStage.processDocument(doc);
-    assertEquals(2, doc.getFieldNames().size());
-    assertEquals("id", doc.getId());
-    assertEquals("bar", doc.getString("foo"));
+//    invalidStage.processDocument(doc);
+//    assertEquals(2, doc.getFieldNames().size());
+//    assertEquals("id", doc.getId());
+//    assertEquals("bar", doc.getString("foo"));
 
     validStage.processDocument(doc);
     assertEquals(2, doc.getFieldNames().size());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONNataTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONNataTest.java
@@ -67,5 +67,11 @@ public class ApplyJSONNataTest {
     assertEquals(2, doc2.getFieldNames().size());
     assertEquals("id", doc2.getId());
     assertEquals(foo, doc2.getJson("source"));
+
+    Document docWithoutSource = Document.create("no_source");
+    docWithoutSource.setField("something_else", 12345);
+    stageWithDest.processDocument(docWithoutSource);
+    assertEquals("no_source", docWithoutSource.getId());
+    assertEquals((Integer) 12345, docWithoutSource.getInt("something_else"));
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONNataTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONNataTest.java
@@ -33,10 +33,10 @@ public class ApplyJSONNataTest {
     Document doc = Document.create("id");
     doc.setField("foo", "bar");
 
-//    invalidStage.processDocument(doc);
-//    assertEquals(2, doc.getFieldNames().size());
-//    assertEquals("id", doc.getId());
-//    assertEquals("bar", doc.getString("foo"));
+    invalidStage.processDocument(doc);
+    assertEquals(2, doc.getFieldNames().size());
+    assertEquals("id", doc.getId());
+    assertEquals("bar", doc.getString("foo"));
 
     validStage.processDocument(doc);
     assertEquals(2, doc.getFieldNames().size());

--- a/lucille-core/src/test/resources/ApplyJSONNataTest/fullValid.conf
+++ b/lucille-core/src/test/resources/ApplyJSONNataTest/fullValid.conf
@@ -1,5 +1,5 @@
 {
   name: test,
   class: com.kmwllc.lucille.stage.ApplyJSONNata,
-  expression: "{\"id\": \"id\", \"keys\": $keys($)}"
+  expression: "{\"id\": \"id\", \"keys\": $keys()}"
 }

--- a/lucille-core/src/test/resources/ApplyJSONNataTest/fullValid.conf
+++ b/lucille-core/src/test/resources/ApplyJSONNataTest/fullValid.conf
@@ -1,5 +1,5 @@
 {
   name: test,
   class: com.kmwllc.lucille.stage.ApplyJSONNata,
-  expression: "{\"id\": \"id\", \"keys\": $keys()}"
+  expression: "{\"id\": \"id\", \"keys\": $keys($)}"
 }


### PR DESCRIPTION
Replaces `JSONata4Java` w/ `jsonata-java`. It is seen to run 2 - 4x faster and doesn't have the same (minor) shortcomings of `JSONata4Java` that are pointed out in its documentation.