### PR TITLE
LC-666: Specific Indexer Failures for Solr, Open, and Elastic

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -275,6 +275,10 @@ public abstract class Indexer implements Runnable {
       failedDocs = Set.of();
     }
 
+    if (!failedDocs.isEmpty()) {
+      log.warn("{} Documents were not indexed successfully.", failedDocs.size());
+    }
+
     // Mark all the documents in failedDoc as failed
     for (Document d : failedDocs) {
       try {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -236,8 +236,8 @@ public abstract class Indexer implements Runnable {
       histogram.update(stopWatch.getNanoTime() / batchedDocs.size());
       meter.mark(batchedDocs.size());
     } catch (Exception e) {
-      // If an Exception is thrown, there was some larger error causing nothing (or essentially nothing?) to be indexed.
-      // So everything is considered to have failed, we won't look at failedDocs.
+      // If an Exception is thrown, there was some larger error causing nothing (or essentially nothing) to be indexed.
+      // So everything is considered to have failed - we won't even look at failedDocs.
       log.error("Error sending documents to index: " + e.getMessage(), e);
 
       for (Document d : batchedDocs) {
@@ -259,7 +259,7 @@ public abstract class Indexer implements Runnable {
         }
       }
 
-      // We've sent a message for each Document. Don't want to repeat in the code below.
+      // We've sent a message for each Document. Don't want to run the code below.
       return;
     } finally {
       // We always mark batches as completed, regardless of if failedDocs isn't null / empty.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -139,10 +139,10 @@ public abstract class Indexer implements Runnable {
    * call to the batch API provided by the search engine client, if available, as opposed to sending
    * each document individually.
    *
-   * @return A set of the Documents that were not successfully indexed. The set must never be null - returns an empty set
-   * if no Documents failed.
-   * @throws Exception In the event of a considerable error causing indexing to fail entirely, essentially. Does not throw
-   * Exceptions just because a Document may have not been indexed successfully.
+   * @return A set of the Documents that were not successfully indexed. Return an empty set if no documents fail / if not
+   * supported by the Indexer implementation.
+   * @throws Exception In the event of a considerable error causing indexing to fail. Does not throw
+   * Exceptions just because some Documents may have not been indexed successfully.
    */
   protected abstract Set<Document> sendToIndex(List<Document> documents) throws Exception;
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -259,7 +259,7 @@ public abstract class Indexer implements Runnable {
         }
       }
 
-      // We've sent a message for each Document. Don't want to run the code below.
+      // We've sent a message for each Document. Don't want to run the code coming after finally.
       return;
     } finally {
       // We always mark batches as completed, regardless of if failedDocs isn't null / empty.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -7,6 +7,7 @@ import com.opencsv.CSVWriterBuilder;
 import com.opencsv.ICSVWriter;
 import com.typesafe.config.Config;
 import java.io.File;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,13 +78,13 @@ public class CSVIndexer extends Indexer {
   }
 
   @Override
-  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
     for (Document doc : documents) {
       writer.writeNext(getLine(doc), true);
     }
     writer.flushQuietly();
 
-    return null;
+    return Set.of();
   }
 
   private String[] getLine(Document doc) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -77,11 +77,13 @@ public class CSVIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
     for (Document doc : documents) {
       writer.writeNext(getLine(doc), true);
     }
     writer.flushQuietly();
+
+    return null;
   }
 
   private String[] getLine(Document doc) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -94,10 +94,10 @@ public class ElasticsearchIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
-      return;
+      return null;
     }
 
     BulkRequest.Builder br = new BulkRequest.Builder();
@@ -179,6 +179,8 @@ public class ElasticsearchIndexer extends Indexer {
         }
       }
     }
+
+    return null;
   }
 
   @Override

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -18,6 +18,7 @@ import com.kmwllc.lucille.message.KafkaIndexerMessenger;
 import com.kmwllc.lucille.util.ElasticsearchUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.misc.Signal;
@@ -94,7 +95,7 @@ public class ElasticsearchIndexer extends Indexer {
   }
 
   @Override
-  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
       return null;
@@ -180,7 +181,7 @@ public class ElasticsearchIndexer extends Indexer {
       }
     }
 
-    return null;
+    return Set.of();
   }
 
   @Override

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -105,7 +105,6 @@ public class ElasticsearchIndexer extends Indexer {
     BulkRequest.Builder br = new BulkRequest.Builder();
 
     for (Document doc : documents) {
-      documentsUploaded.put(doc.getId(), doc);
       // populate join data to document
       joinData.populateJoinData(doc);
 
@@ -117,6 +116,7 @@ public class ElasticsearchIndexer extends Indexer {
 
       // if a doc id override value exists, make sure it is used instead of pre-existing doc id
       String docId = Optional.ofNullable(getDocIdOverride(doc)).orElse(doc.getId());
+      documentsUploaded.put(docId, doc);
 
       // This condition below avoids adding id if ignoreFields contains it and edge cases:
       // - Case 1: id and idOverride in ignoreFields -> idOverride used by Indexer, both removed from Document (tested in testIgnoreFieldsWithOverride)

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -97,7 +97,7 @@ public class ElasticsearchIndexer extends Indexer {
   protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
-      return null;
+      return Set.of();
     }
 
     // building a map so we can quickly retrieve documents later on, if they fail during indexing.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -5,6 +5,7 @@ import com.kmwllc.lucille.core.Indexer;
 import com.kmwllc.lucille.message.IndexerMessenger;
 import com.typesafe.config.Config;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The NopIndexer performs no operations and does not send documents to any index. It is intended to be used for testing or
@@ -26,9 +27,9 @@ public class NopIndexer extends Indexer {
   }
 
   @Override
-  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
-    return null;
+  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
     // no-op
+    return Set.of();
   }
 
   @Override

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -26,7 +26,8 @@ public class NopIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
+    return null;
     // no-op
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -111,7 +111,7 @@ public class OpenSearchIndexer extends Indexer {
   protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
-      return null;
+      return Set.of();
     }
 
     Map<String, Document> documentsToUpload = new LinkedHashMap<>();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.print.Doc;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.BulkIndexByScrollFailure;
 import org.opensearch.client.opensearch._types.FieldValue;
@@ -31,7 +30,6 @@ import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 public class OpenSearchIndexer extends Indexer {
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -303,11 +303,10 @@ public class OpenSearchIndexer extends Indexer {
     Set<Document> failedDocs = new HashSet<>();
 
     BulkResponse response = client.bulk(br.build());
-    // We're choosing not to check response.errors(), instead iterating to be sure whether errors exist
     if (response != null) {
       for (BulkResponseItem item : response.items()) {
         if (item.error() != null) {
-          // For the error. If the id is a document's id, then it failed, and we add it to the set.
+          // For the error - if the id is a document's id, then it failed, and we add it to the set.
           // If not, we don't know what the error is, and opt to throw an actual IndexerException instead.
           if (documentsToUpload.containsKey(item.id())) {
             Document failedDoc = documentsToUpload.get(item.id());

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -107,7 +107,7 @@ public class OpenSearchIndexer extends Indexer {
   }
 
   @Override
-  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
       return null;
@@ -144,7 +144,7 @@ public class OpenSearchIndexer extends Indexer {
     deleteById(new ArrayList<>(idsToDelete));
     deleteByQuery(termsToDeleteByQuery);
 
-    return null;
+    return Set.of();
   }
 
   private void deleteById(List<String> idsToDelete) throws Exception {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -107,10 +107,10 @@ public class OpenSearchIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
-      return;
+      return null;
     }
 
     Map<String, Document> documentsToUpload = new LinkedHashMap<>();
@@ -143,6 +143,8 @@ public class OpenSearchIndexer extends Indexer {
     uploadDocuments(new ArrayList<>(documentsToUpload.values()));
     deleteById(new ArrayList<>(idsToDelete));
     deleteByQuery(termsToDeleteByQuery);
+
+    return null;
   }
 
   private void deleteById(List<String> idsToDelete) throws Exception {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -162,7 +162,7 @@ public class OpenSearchIndexer extends Indexer {
       );
     }
 
-    BulkResponse response =  client.bulk(br.build());
+    BulkResponse response = client.bulk(br.build());
     if (response.errors()) {
       for (BulkResponseItem item : response.items()) {
         if (item.error() != null) {
@@ -301,6 +301,7 @@ public class OpenSearchIndexer extends Indexer {
     Set<Document> failedDocs = new HashSet<>();
 
     BulkResponse response = client.bulk(br.build());
+
     if (response != null) {
       for (BulkResponseItem item : response.items()) {
         if (item.error() != null) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -120,11 +120,11 @@ public class SolrIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
 
     if (solrClient == null) {
       log.debug("sendToSolr bypassed for documents: " + documents);
-      return;
+      return null;
     }
 
     Map<String, SolrDocRequests> solrDocRequestsByCollection = new HashMap<>();
@@ -192,6 +192,8 @@ public class SolrIndexer extends Indexer {
           collection, solrDocRequestsByCollection.get(collection).getAddUpdateDocs());
       sendDeletionBatch(collection, solrDocRequestsByCollection.get(collection));
     }
+
+    return null;
   }
 
   private void sendAddUpdateBatch(String collection, List<SolrInputDocument> solrDocs)

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -174,7 +174,7 @@ public class SolrIndexer extends Indexer {
         }
 
       } else {
-        docsUploaded.put(doc.getId(), doc);
+        docsUploaded.put(solrId, doc);
         // note that solrDoc after this code block does not guarantee that "id" field is in document
         SolrInputDocument solrDoc = toSolrDoc(doc, idOverride, collection);
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
@@ -120,7 +121,7 @@ public class SolrIndexer extends Indexer {
   }
 
   @Override
-  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
 
     if (solrClient == null) {
       log.debug("sendToSolr bypassed for documents: " + documents);
@@ -193,7 +194,7 @@ public class SolrIndexer extends Indexer {
       sendDeletionBatch(collection, solrDocRequestsByCollection.get(collection));
     }
 
-    return null;
+    return Set.of();
   }
 
   private void sendAddUpdateBatch(String collection, List<SolrInputDocument> solrDocs)

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -4,10 +4,8 @@ import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Indexer;
 import com.kmwllc.lucille.core.IndexerException;
 import com.kmwllc.lucille.message.IndexerMessenger;
-import com.kmwllc.lucille.message.KafkaIndexerMessenger;
 import com.kmwllc.lucille.util.SolrUtils;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,7 +25,6 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.misc.Signal;
 
 public class SolrIndexer extends Indexer {
 
@@ -198,12 +195,11 @@ public class SolrIndexer extends Indexer {
 
     for (String collection : solrDocRequestsByCollection.keySet()) {
       try {
-        sendAddUpdateBatch(
-            collection, solrDocRequestsByCollection.get(collection).getAddUpdateDocs());
+        sendAddUpdateBatch(collection, solrDocRequestsByCollection.get(collection).getAddUpdateDocs());
       } catch (Exception e) {
         // Add all the docs to failed docs
         for (SolrInputDocument d : solrDocRequestsByCollection.get(collection).getAddUpdateDocs()) {
-          String docId = d.getField(Document.ID_FIELD).toString();
+          String docId = d.getFieldValue(Document.ID_FIELD).toString();
 
           if (docsUploaded.containsKey(docId)) {
             failedDocs.add(docsUploaded.get(docId));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -209,20 +209,7 @@ public class SolrIndexer extends Indexer {
         }
       }
 
-      try {
-        sendDeletionBatch(collection, solrDocRequestsByCollection.get(collection));
-      } catch (Exception e) {
-        // Add all the docs to failed docs
-        for (SolrInputDocument d : solrDocRequestsByCollection.get(collection).getAddUpdateDocs()) {
-          String docId = d.getField(Document.ID_FIELD).toString();
-
-          if (docsUploaded.containsKey(docId)) {
-            failedDocs.add(docsUploaded.get(docId));
-          } else {
-            throw e;
-          }
-        }
-      }
+      sendDeletionBatch(collection, solrDocRequestsByCollection.get(collection));
     }
 
     return failedDocs;

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -23,6 +23,7 @@ import com.kmwllc.lucille.message.TestMessenger;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Arrays;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.Before;
@@ -696,7 +697,7 @@ public class ElasticsearchIndexerTest {
     }
 
     @Override
-    public List<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -696,7 +696,7 @@ public class ElasticsearchIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -219,7 +219,6 @@ public class OpenSearchIndexerTest {
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient2, "testing");
     Set<Document> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
-    System.out.println(failedDocs);
     assertEquals(2, failedDocs.size());
     assertTrue(failedDocs.contains(doc));
     assertFalse(failedDocs.contains(doc2));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -838,7 +838,7 @@ public class OpenSearchIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.Before;
@@ -838,7 +839,7 @@ public class OpenSearchIndexerTest {
     }
 
     @Override
-    public List<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -205,17 +205,21 @@ public class OpenSearchIndexerTest {
 
     when(mockItemDoc1.id()).thenReturn("doc1");
     when(mockItemDoc2.id()).thenReturn("doc2");
-    when(mockItemDoc3.id()).thenReturn("doc3");
+    // testing that the idOverride field doesn't prevent a document from being returned in failed docs
+    // the "id" will be set to be the override field. The exception would be thrown (instead of adding to failed docs)
+    // if the id returned here doesn't match the id the doc gets indexed with.
+    when(mockItemDoc3.id()).thenReturn("something_else");
 
     List<BulkResponseItem> bulkResponseItems = Arrays.asList(mockItemDoc1, mockItemDoc2, mockItemDoc3);
     Mockito.when(mockResponse.items()).thenReturn(bulkResponseItems);
 
     TestMessenger messenger = new TestMessenger();
-    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf");
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/testOverride.conf");
 
     Document doc = Document.create("doc1", "test_run");
     Document doc2 = Document.create("doc2", "test_run");
     Document doc3 = Document.create("doc3", "test_run");
+    doc3.setField("other_id", "something_else");
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient2, "testing");
     Set<Document> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -150,6 +150,7 @@ public class OpenSearchIndexerTest {
     }
   }
 
+  // When the method throws an exception, all documents fail
   @Test
   public void testOpenSearchIndexerException() throws Exception {
     TestMessenger messenger = new TestMessenger();
@@ -175,6 +176,54 @@ public class OpenSearchIndexerTest {
       assertEquals("doc" + i, events.get(i - 1).getDocumentId());
       assertEquals(Event.Type.FAIL, events.get(i - 1).getType());
     }
+  }
+
+  // When specific documents have an error, they are returned by sendToIndex & the method does not throw an Exception
+  @Test
+  public void testOpensearchDocumentErrors() throws Exception {
+    OpenSearchClient mockClient2 = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(mockClient2.ping()).thenReturn(mockBooleanResponse);
+
+    // make first call to validateConnection succeed but subsequent calls to fail
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true, false);
+
+    BulkRequest.Builder mockRequestBuilder = Mockito.mock(BulkRequest.Builder.class);
+    BulkResponse mockResponse = Mockito.mock(BulkResponse.class);
+    BulkRequest mockBulkRequest = Mockito.mock(BulkRequest.class);
+    Mockito.when(mockRequestBuilder.build()).thenReturn(mockBulkRequest);
+    Mockito.when(mockClient2.bulk(any(BulkRequest.class))).thenReturn(mockResponse);
+
+    // mocking for the bulk response items and error causes
+    BulkResponseItem mockItemDoc1 = Mockito.mock(BulkResponseItem.class);
+    BulkResponseItem mockItemDoc2 = Mockito.mock(BulkResponseItem.class);
+    BulkResponseItem mockItemDoc3 = Mockito.mock(BulkResponseItem.class);
+    ErrorCause mockError = new ErrorCause.Builder().reason("mock reason").type("mock-type").build();
+    Mockito.when(mockItemDoc1.error()).thenReturn(mockError);
+    Mockito.when(mockItemDoc3.error()).thenReturn(mockError);
+
+    when(mockItemDoc1.id()).thenReturn("doc1");
+    when(mockItemDoc2.id()).thenReturn("doc2");
+    when(mockItemDoc3.id()).thenReturn("doc3");
+
+    List<BulkResponseItem> bulkResponseItems = Arrays.asList(mockItemDoc1, mockItemDoc2, mockItemDoc3);
+    Mockito.when(mockResponse.items()).thenReturn(bulkResponseItems);
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf");
+
+    Document doc = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+    Document doc3 = Document.create("doc3", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient2, "testing");
+    Set<Document> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
+    System.out.println(failedDocs);
+    assertEquals(2, failedDocs.size());
+    assertTrue(failedDocs.contains(doc));
+    assertFalse(failedDocs.contains(doc2));
+    assertTrue(failedDocs.contains(doc3));
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
@@ -971,7 +971,7 @@ public class SolrIndexerTest {
     }
 
     @Override
-    public List<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to Solr are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
@@ -971,7 +971,7 @@ public class SolrIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to Solr are correctly handled");
     }
   }

--- a/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
+++ b/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
@@ -99,7 +99,7 @@ public class PineconeIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws IndexerException {
+  protected List<Document> sendToIndex(List<Document> documents) throws IndexerException {
     // retrieve documents to delete & upload, mapping id to document
     Map<String, Document> deleteMap = new LinkedHashMap<>();
     Map<String, Document> uploadMap = new LinkedHashMap<>();
@@ -141,6 +141,8 @@ public class PineconeIndexer extends Indexer {
         uploadDocuments(new ArrayList<>(uploadMap.values()), defaultEmbeddingField, PineconeUtils.getDefaultNamespace());
       }
     }
+
+    return null;
   }
 
   private void validateUploadRequirements() throws IndexerException {

--- a/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
+++ b/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
@@ -99,7 +99,7 @@ public class PineconeIndexer extends Indexer {
   }
 
   @Override
-  protected List<Document> sendToIndex(List<Document> documents) throws IndexerException {
+  protected Set<Document> sendToIndex(List<Document> documents) throws IndexerException {
     // retrieve documents to delete & upload, mapping id to document
     Map<String, Document> deleteMap = new LinkedHashMap<>();
     Map<String, Document> uploadMap = new LinkedHashMap<>();
@@ -142,7 +142,7 @@ public class PineconeIndexer extends Indexer {
       }
     }
 
-    return null;
+    return Set.of();
   }
 
   private void validateUploadRequirements() throws IndexerException {

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -102,7 +102,7 @@ public class WeaviateIndexer extends Indexer {
   }
 
   @Override
-  protected void sendToIndex(List<Document> documents) throws Exception {
+  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
 
     try (ObjectsBatcher batcher = client.batch().objectsBatcher()) {
       for (Document doc : documents) {
@@ -149,6 +149,8 @@ public class WeaviateIndexer extends Indexer {
     } catch (Exception e) {
       throw new IndexerException(e.toString());
     }
+
+    return null;
   }
 
   public static String generateDocumentUUID(Document document) {

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -24,6 +24,7 @@ import io.weaviate.client.v1.misc.model.Meta;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +103,7 @@ public class WeaviateIndexer extends Indexer {
   }
 
   @Override
-  protected List<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
 
     try (ObjectsBatcher batcher = client.batch().objectsBatcher()) {
       for (Document doc : documents) {
@@ -150,7 +151,7 @@ public class WeaviateIndexer extends Indexer {
       throw new IndexerException(e.toString());
     }
 
-    return null;
+    return Set.of();
   }
 
   public static String generateDocumentUUID(Document document) {

--- a/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
+++ b/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
@@ -179,7 +179,7 @@ public class WeaviateIndexerTest {
     }
 
     @Override
-    public void sendToIndex(List<Document> docs) throws Exception {
+    public List<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
+++ b/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
@@ -23,6 +23,7 @@ import io.weaviate.client.v1.misc.api.MetaGetter;
 import io.weaviate.client.v1.misc.model.Meta;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -179,7 +180,7 @@ public class WeaviateIndexerTest {
     }
 
     @Override
-    public List<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }


### PR DESCRIPTION
using some existing POC-style changes, `Indexer.sendToIndex` now returns a `Set<Document>` representing the Documents that were _not_ successfully indexed. Exceptions are only thrown in more exceptional circumstances now. 
Internally, the Indexers maintain a `Map<String, Document>` to easily retrieve the specific Documents that failed based on the IDs returned by the errors (which will be a DocID / ID Override value).

One note w.r.t. the ID Override is that there isn't support for multiple documents with the same ID Override value. I'm not sure if this is an allowed / supported behavior. We could use a List to mitigate this, it would just cause a bit of overhead.