### PR TITLE
LC-667: Add sts dependency for WebIdentityTokenFileCredentialsProvider

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -259,17 +259,23 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.29.1</version>
+      <version>${aws-sdk.version}</version>
     </dependency>
+    <!-- The following 3 dependencies are needed for the AWS SDK S3Client default credentials provider -->
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sso</artifactId>
-        <version>2.29.1</version>
+        <version>${aws-sdk.version}</version>
     </dependency>
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ssooidc</artifactId>
-        <version>2.29.1</version>
+        <version>${aws-sdk.version}</version>
+    </dependency>
+    <dependency>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>sts</artifactId>
+          <version>${aws-sdk.version}</version>
     </dependency>
 
     <dependency>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -65,6 +65,7 @@
     <dropwizard-core.version>4.0.12</dropwizard-core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit4.version>4.13.2</junit4.version>
+    <aws-sdk.version>2.29.1</aws-sdk.version>
 
   </properties>
 


### PR DESCRIPTION
We are using the AWS S3 S3Client to connect to S3 buckets. With the S3Client, we are using the [Default Credentials Provider](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html). For the third provider in the chain, `WebIdentityTokenFileCredentialsProvider`, the `software.amazon.awssdk:sts` dependency must be included in the classpath. Rather than making the user include that dependency in their own pom, we are adding it here.

Additionally, I have just extracted out the aws sdk versions since there are 4 with the same version of 2.29.1.