### PR TITLE
LC-661: Small FileReference Refactor

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
@@ -162,7 +162,7 @@ public abstract class BaseStorageClient implements StorageClient {
             if (params.supportedFileType(resolvedExtension)) {
               handleStreamExtensionFiles(publisher, compressorStream, resolvedExtension, filePathFormat);
             } else {
-              Document doc = fileReference.asDoc(compressorStream, filePathFormat, params);
+              Document doc = fileReference.decompressedFileAsDoc(compressorStream, filePathFormat, params);
               try (MDCCloseable mdc = MDC.putCloseable(Document.ID_FIELD, doc.getId())) {
                 docLogger.info("StorageClient to publish Document {}.", doc.getId());
               }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/FileReference.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/FileReference.java
@@ -45,14 +45,14 @@ public interface FileReference {
 
   /**
    * @return A Lucille Document from this file reference. Will retrieve the file's contents if params.shouldGetFileContent()
-   * is true.
+   * is true. Will include the file's path, and may include the file's last modified time, size, and creation time, if specified.
    */
   Document asDoc(TraversalParams params);
 
   /**
    * @return A Lucille Document for an archive or compressed file that came from this file reference.
    * The Document's ID will be a hash of the given path, and the Document's "file_path" will be the given path. However,
-   * the Document's lastModified, size, and creation time will be that of this FileReference.
+   * the Document's lastModified, size, and creation time will be that of this FileReference (if specified).
    * The input stream will be used to get the file's content, if {@link TraversalParams#shouldGetFileContent()} is true.
    */
   Document decompressedFileAsDoc(InputStream in, String decompressedFullPathStr, TraversalParams params) throws IOException;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/FileReference.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/FileReference.java
@@ -31,7 +31,7 @@ public interface FileReference {
   boolean isValidFile();
 
   /**
-   * @return The instant at which this FileReference was last modified.
+   * @return The instant at which this FileReference was last modified. May be null.
    */
   Instant getLastModified();
 
@@ -44,14 +44,16 @@ public interface FileReference {
   InputStream getContentStream(TraversalParams params);
 
   /**
-   * @return A Lucille Document from this file reference. Will get the file's contents if params.shouldGetFileContent()
+   * @return A Lucille Document from this file reference. Will retrieve the file's contents if params.shouldGetFileContent()
    * is true.
    */
   Document asDoc(TraversalParams params);
 
   /**
-   * @return A Lucille Document from this file reference, using the given full path string to create the Document's ID / path,
-   * and reading all bytes from the given input stream if params.shouldGetFileContent() is true.
+   * @return A Lucille Document for an archive or compressed file that came from this file reference.
+   * The Document's ID will be a hash of the given path, and the Document's "file_path" will be the given path. However,
+   * the Document's lastModified, size, and creation time will be that of this FileReference.
+   * The input stream will be used to get the file's content, if {@link TraversalParams#shouldGetFileContent()} is true.
    */
-  Document asDoc(InputStream in, String decompressedFullPathStr, TraversalParams params) throws IOException;
+  Document decompressedFileAsDoc(InputStream in, String decompressedFullPathStr, TraversalParams params) throws IOException;
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClient.java
@@ -113,7 +113,9 @@ public class GoogleStorageClient extends BaseStorageClient {
 
     public GoogleFileReference(Blob blob) {
       // This is an inexpensive call that doesn't involve networking / RPC.
-      super(blob.getUpdateTimeOffsetDateTime().toInstant());
+      super(blob.getUpdateTimeOffsetDateTime() == null ? null : blob.getUpdateTimeOffsetDateTime().toInstant(),
+          blob.getSize(),
+          blob.getCreateTimeOffsetDateTime() == null ? null : blob.getCreateTimeOffsetDateTime().toInstant());
 
       this.blob = blob;
     }
@@ -141,45 +143,8 @@ public class GoogleStorageClient extends BaseStorageClient {
     }
 
     @Override
-    public Document asDoc(TraversalParams params) {
-      Document doc = createEmptyDocument(params);
-
-      doc.setField(FileConnector.FILE_PATH, getFullPath(params));
-      doc.setField(FileConnector.MODIFIED, getLastModified());
-
-      if (blob.getCreateTimeOffsetDateTime() != null) {
-        doc.setField(FileConnector.CREATED, blob.getCreateTimeOffsetDateTime().toInstant());
-      }
-
-      doc.setField(FileConnector.SIZE, blob.getSize());
-
-      if (params.shouldGetFileContent()) {
-        doc.setField(FileConnector.CONTENT, blob.getContent());
-      }
-
-      return doc;
-    }
-
-    @Override
-    public Document asDoc(InputStream in, String decompressedFullPathStr, TraversalParams params) throws IOException {
-      Document doc = createEmptyDocument(params, decompressedFullPathStr);
-
-      doc.setField(FileConnector.FILE_PATH, decompressedFullPathStr);
-
-      if (getLastModified() != null) {
-        doc.setField(FileConnector.MODIFIED, getLastModified());
-      }
-
-      if (blob.getCreateTimeOffsetDateTime() != null) {
-        doc.setField(FileConnector.CREATED, blob.getCreateTimeOffsetDateTime().toInstant());
-      }
-
-      // unable to get decompressed file size
-      if (params.shouldGetFileContent()) {
-        doc.setField(FileConnector.CONTENT, in.readAllBytes());
-      }
-
-      return doc;
+    protected byte[] getFileContent(TraversalParams params) {
+      return blob.getContent();
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClient.java
@@ -105,17 +105,11 @@ public class LocalStorageClient extends BaseStorageClient {
 
     private final Path path;
 
-    // information that other FileReferences usually have access to via the storage object.
-    private final Instant creationTime;
-    private final long size;
-
     // The given path will become absolute and will be normalized.
     public LocalFileReference(Path path, BasicFileAttributes attributes) {
-      super(attributes.lastModifiedTime().toInstant());
+      super(attributes.lastModifiedTime().toInstant(), attributes.size(), attributes.creationTime().toInstant());
 
       this.path = path.toAbsolutePath().normalize();
-      this.creationTime = attributes.creationTime().toInstant();
-      this.size = attributes.size();
     }
 
     @Override
@@ -141,44 +135,12 @@ public class LocalStorageClient extends BaseStorageClient {
     }
 
     @Override
-    public Document asDoc(TraversalParams params) {
-      Document doc = createEmptyDocument(params);
-
-      doc.setField(FILE_PATH, getFullPath(params));
-      doc.setField(SIZE, size);
-      doc.setField(MODIFIED, getLastModified());
-
-      if (creationTime != null) {
-        doc.setField(CREATED, creationTime);
+    protected byte[] getFileContent(TraversalParams params) {
+      try {
+        return Files.readAllBytes(path);
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Unable to get file contents from '" + path + "' for document", e);
       }
-
-      if (params.shouldGetFileContent()) {
-        try {
-          doc.setField(CONTENT, Files.readAllBytes(path));
-        } catch (IOException e) {
-          throw new IllegalArgumentException("Unable to get file contents from '" + path + "' for document", e);
-        }
-      }
-
-      return doc;
-    }
-
-    @Override
-    public Document asDoc(InputStream in, String decompressedFullPathStr, TraversalParams params) throws IOException {
-      Document doc = createEmptyDocument(params, decompressedFullPathStr);
-
-      // setting fields on document
-      // remove Extension to show that we have decompressed the file and obtained its information
-      doc.setField(FILE_PATH, decompressedFullPathStr);
-      doc.setField(MODIFIED, getLastModified());
-      doc.setField(CREATED, creationTime);
-      // unable to get decompressed file size
-
-      if (params.shouldGetFileContent()) {
-        doc.setField(CONTENT, in.readAllBytes());
-      }
-
-      return doc;
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/S3StorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/S3StorageClient.java
@@ -128,8 +128,9 @@ public class S3StorageClient extends BaseStorageClient {
     private final S3Object s3Obj;
 
     public S3FileReference(S3Object s3Obj) {
-      // This is an inexpensive call, this is stored inside the S3Object
-      super(s3Obj.lastModified());
+      // These are inexpensive calls - information stored in the s3 object.
+      // "null" for creation time - this isn't available in a S3Object
+      super(s3Obj.lastModified(), s3Obj.size(), null);
 
       this.s3Obj = s3Obj;
     }
@@ -158,38 +159,10 @@ public class S3StorageClient extends BaseStorageClient {
     }
 
     @Override
-    public Document asDoc(TraversalParams params) {
-      Document doc = createEmptyDocument(params);
-
-      doc.setField(FileConnector.FILE_PATH, getFullPath(params));
-      doc.setField(FileConnector.MODIFIED, getLastModified());
-      // s3 doesn't have object creation date
-      doc.setField(FileConnector.SIZE, s3Obj.size());
-
-      if (params.shouldGetFileContent()) {
-        byte[] content = s3.getObjectAsBytes(
-            GetObjectRequest.builder().bucket(getBucketOrContainerName(params)).key(s3Obj.key()).build()
-        ).asByteArray();
-        doc.setField(FileConnector.CONTENT, content);
-      }
-
-      return doc;
-    }
-
-    @Override
-    public Document asDoc(InputStream in, String decompressedFullPathStr, TraversalParams params) throws IOException {
-      Document doc = createEmptyDocument(params, decompressedFullPathStr);
-
-      doc.setField(FileConnector.FILE_PATH, decompressedFullPathStr);
-      doc.setField(FileConnector.MODIFIED, getLastModified());
-
-      // no creation date in S3. no compressor size. Would normally be set here...
-
-      if (params.shouldGetFileContent()) {
-        doc.setField(FileConnector.CONTENT, in.readAllBytes());
-      }
-
-      return doc;
+    protected byte[] getFileContent(TraversalParams params) {
+      return s3.getObjectAsBytes(
+          GetObjectRequest.builder().bucket(getBucketOrContainerName(params)).key(s3Obj.key()).build()
+      ).asByteArray();
     }
   }
 }


### PR DESCRIPTION
Hold more properties in the `BaseFileReference`, expose a direct way to get file contents, allowing `asDoc` methods to be reused in `BaseFileReference`. Renamed `asDoc` to `decompressedFileAsDoc` to be a bit clearer on the use of the method.

Use a special method for `getFileContent`, returning a `byte[]`, instead of `getContentStream` to avoid 
1. Having to throw an IOException 
2. The overhead associated with opening an InputStream just to immediately exhaust it
instead of just reading the `InputStream` from `getContentStream` which was already available. 