### PR TITLE
LC-674 - Upgrade parquet-avro for CVE

### DIFF
--- a/lucille-plugins/lucille-parquet/pom.xml
+++ b/lucille-plugins/lucille-parquet/pom.xml
@@ -41,6 +41,11 @@
       <version>3.4.1</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>

--- a/lucille-plugins/lucille-parquet/pom.xml
+++ b/lucille-plugins/lucille-parquet/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>1.15.0</version>
+      <version>1.15.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Upgrade org.apache.parquet:parquet-avro from 1.15.0 to 1.15.1.

[NVD - CVE-2025-30065](https://nvd.nist.gov/vuln/detail/CVE-2025-30065)