### PR TITLE
Minor Ollama Enhancements

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -372,7 +372,7 @@
     <dependency>
         <groupId>io.github.ollama4j</groupId>
         <artifactId>ollama4j</artifactId>
-        <version>1.0.93</version>
+        <version>1.0.100</version>
     </dependency>
   </dependencies>
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/PromptOllama.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/PromptOllama.java
@@ -44,7 +44,8 @@ import org.slf4j.LoggerFactory;
  *  <p> timeout (Long, Optional): How long you want to wait for a request to be processed before failing. Passed directly to Ollama.
  *  Uses Ollama's default of 10 seconds when not specified.
  *
- *  <p> systemPrompt (String): The system prompt you want to provide to your LLM.
+ *  <p> systemPrompt (String, Optional): The system prompt you want to provide to your LLM. Defaults to using no system prompt,
+ *  as you may be using a model created from a Modelfile with a System Prompt already specified.
  *  <p> <b>Note:</b> It is recommended that you instruct your LLM to format its output as a JSON object, even if you are only
  *  asking for a single piece of information (like a summary).
  *
@@ -53,7 +54,8 @@ import org.slf4j.LoggerFactory;
  *
  *  <p> requireJSON (Boolean, Optional): Whether you are requiring and expecting the LLM to output a JSON-only response. When true,
  *  Lucille will throw an Exception upon receiving a non-JSON response from the LLM. When false, Lucille will place the response's
- *  raw contents into the "ollamaResponse" field. Defaults to false.
+ *  raw contents into the "ollamaResponse" field. Additionally, when set to true, your Ollama chat request will have <code>format: "json"</code>
+ *  to prevent errors with Markdown formatting. Defaults to false.
  *
  *  <p> update_mode (String, Optional): How you want Lucille to update the fields in your Document, based on what it extracts from a JSON
  *  based response. Has no effect on a textual response placed in "ollamaResponse" - that will always overwrite any existing data.
@@ -79,14 +81,14 @@ public class PromptOllama extends Stage {
 
   public PromptOllama(Config config) {
     super(config, Spec.stage()
-        .withRequiredProperties("hostURL", "modelName", "systemPrompt")
-        .withOptionalProperties("timeout", "fields", "requireJSON", "update_mode"));
+        .withRequiredProperties("hostURL", "modelName")
+        .withOptionalProperties("systemPrompt", "timeout", "fields", "requireJSON", "update_mode"));
 
     this.hostURL = config.getString("hostURL");
     this.modelName = config.getString("modelName");
-    this.timeout = ConfigUtils.getOrDefault(config, "timeout", null);
+    this.timeout = config.hasPath("timeout") ? config.getLong("timeout") : null;
 
-    this.systemPrompt = config.getString("systemPrompt");
+    this.systemPrompt = ConfigUtils.getOrDefault(config, "systemPrompt", null);
     this.fields = ConfigUtils.getOrDefault(config, "fields", List.of());
     this.requireJSON = ConfigUtils.getOrDefault(config, "requireJSON", false);
 
@@ -96,9 +98,11 @@ public class PromptOllama extends Stage {
   @Override
   public void start() throws StageException {
     this.ollamaAPI = new OllamaAPI(hostURL);
-    this.chatBuilder = OllamaChatRequestBuilder
-        .getInstance(modelName)
-        .withMessage(OllamaChatMessageRole.SYSTEM, systemPrompt);
+    this.chatBuilder = OllamaChatRequestBuilder.getInstance(modelName);
+
+    if (systemPrompt != null) {
+      chatBuilder = chatBuilder.withMessage(OllamaChatMessageRole.SYSTEM, systemPrompt);
+    }
 
     if (timeout != null) {
       ollamaAPI.setRequestTimeoutSeconds(timeout);
@@ -108,6 +112,7 @@ public class PromptOllama extends Stage {
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     OllamaChatRequest request = createRequestWithSpecifiedFields(doc);
+    request.setReturnFormatJson(requireJSON);
 
     OllamaChatResult chatResult;
     try {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/PromptOllama.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/PromptOllama.java
@@ -42,7 +42,8 @@ import org.slf4j.LoggerFactory;
  *  <p> modelName (String): The name of the model you want to communicate with. See https://ollama.ai/library for available models/
  *  the appropriate names to use.
  *  <p> timeout (Long, Optional): How long you want to wait for a request to be processed before failing. Passed directly to Ollama.
- *  Uses Ollama's default of 10 seconds when not specified.
+ *  Uses Ollama's default of 10 seconds when not specified. You may want to increase the timeout if your Lucille Configuration
+ *  uses multiple Worker threads (and you are working with Ollama locally).
  *
  *  <p> systemPrompt (String, Optional): The system prompt you want to provide to your LLM. Defaults to using no system prompt,
  *  as you may be using a model created from a Modelfile with a System Prompt already specified.


### PR DESCRIPTION
Just a few things to enhance with Ollama I noticed while using it in an actual pipeline.
1. Updated the Ollama4j version
2. System prompt is optional, since you may be using a model with a System prompt "built into" it (Modelfile)
3. Sets `format: "json"` in the API request, preventing errors with the LLM outputting JSON in Markdown + preventing parsing the response
4. Retrieving the timeout correctly - casting error took place using `ConfigUtils.getOrDefault`. 
5. Putting a warning about potentially increasing the timeout if you have a multithreaded Pipeline

I have some stashed changes that use the `generate` endpoint instead of the `chat` endpoint which creates more reliable results, especially when lots of Documents are in the pipeline. But we do run into an issue with the formatting of the JSON response because it uses the markdown formatting, which Jackson doesn't handle. So I have a bit of a "hack" for this and was hesitant to actually include it in this PR. 
I also wanted to just open a PR for improved generate JSON handling in `Ollama4j` over the weekend but did not find the time to do so.