### PR TITLE
LC-545: Safe Singletons 

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
@@ -60,7 +60,6 @@ public class DictionaryLookup extends Stage {
   private Map<String, List<String>> dict;
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  // Dummy value to indicate that a key is present in the HashMap
 
   public DictionaryLookup(Config config) throws StageException {
     super(config, Spec.stage().withRequiredProperties("source", "dest", "dict_path")

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
@@ -57,7 +57,7 @@ public class DictionaryLookup extends Stage {
   private final boolean setOnly;
   private final boolean ignoreMissingSource;
 
-  private Map<String, String[]> dict;
+  private Map<String, List<String>> dict;
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   // Dummy value to indicate that a key is present in the HashMap
@@ -136,7 +136,7 @@ public class DictionaryLookup extends Stage {
           }
           if (dict.containsKey(value)) {
             if (usePayloads) {
-              outputValues.addAll(Arrays.asList(dict.get(value)));
+              outputValues.addAll(dict.get(value));
             } else {
               outputValues.add(value);
             }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/QueryOpensearch.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/QueryOpensearch.java
@@ -66,6 +66,7 @@ public class QueryOpensearch extends Stage {
 
   private static final Logger log = LoggerFactory.getLogger(QueryOpensearch.class);
   private static final ObjectMapper mapper = new ObjectMapper();
+  private static final HttpClient httpClient = HttpClient.newHttpClient();
 
   private final URI searchURI;
 
@@ -75,8 +76,6 @@ public class QueryOpensearch extends Stage {
   private final List<String> optionalParamNames;
   private final JsonPointer opensearchResponsePath;
   private final String destinationField;
-
-  private final HttpClient httpClient;
 
   private JsonNode searchTemplateJson;
 
@@ -106,8 +105,6 @@ public class QueryOpensearch extends Stage {
     }
 
     this.destinationField = ConfigUtils.getOrDefault(config, "destinationField", "response");
-
-    httpClient = HttpClient.newHttpClient();
   }
 
   @Override

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/util/DictionaryManagerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/util/DictionaryManagerTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.kmwllc.lucille.core.StageException;
 import com.typesafe.config.ConfigFactory;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
@@ -14,33 +15,33 @@ public class DictionaryManagerTest {
 
   @Test
   public void testDictionaryInitializedOnceOnly() throws StageException {
-    Map<String, String[]> dict1 =
+    Map<String, List<String>> dict1 =
         DictionaryManager.getDictionary("classpath:DictionaryLookupTest/dictionary.txt", false, false, ConfigFactory.empty());
     assertTrue(dict1.containsKey("Canada"));
     assertFalse(dict1.containsKey("canada"));
 
     // the same dictionary instance is returned for the same setting of path and ignoreCase
-    Map<String, String[]> dict2 =
+    Map<String, List<String>> dict2 =
         DictionaryManager.getDictionary("classpath:DictionaryLookupTest/dictionary.txt", false, false, ConfigFactory.empty());
     assertSame(dict1, dict2);
 
     // a different dictionary is initialized for a different setting of ignoreCase
-    Map<String, String[]> dict3 =
+    Map<String, List<String>> dict3 =
         DictionaryManager.getDictionary("classpath:DictionaryLookupTest/dictionary.txt", true, false, ConfigFactory.empty());
     assertNotSame(dict1, dict3);
     assertFalse(dict3.containsKey("Canada"));
     assertTrue(dict3.containsKey("canada"));
 
-    Map<String, String[]> dict4 =
+    Map<String, List<String>> dict4 =
         DictionaryManager.getDictionary("classpath:DictionaryLookupTest/dictionary.txt", true, false, ConfigFactory.empty());
     assertSame(dict3, dict4);
   }
 
   @Test(expected = UnsupportedOperationException.class)
   public void testDictionaryIsUnmofidiable() throws StageException {
-    Map<String, String[]> dict =
+    Map<String, List<String>> dict =
         DictionaryManager.getDictionary("classpath:DictionaryLookupTest/dictionary.txt", false, false, ConfigFactory.empty());
     assertTrue(dict.containsKey("Canada"));
-    dict.put("Canada", new String[]{"abc"});
+    dict.put("Canada", List.of("abc"));
   }
 }


### PR DESCRIPTION
1. `DictionaryManager` / "dictionaries" in general use a `List<String>` instead of `String[]` to prevent the contents from being modified.
2. `QueryOpensearch` has a shared `HttpClient` to improve its scalability. (This is in line with the recommended usage of `HttpClient`, evidently. It is thread safe.) The issue here would be running a Pipeline that uses `QueryOpensearch` - potentially multiple times - either on multiple threads or in multiple concurrent runs. Each instance of the Stage in each Thread/Run will open an HTTPClient, and since this is done _at the same time_, it'll cause issues.