### PR TITLE
LC-551: Improved Exception Handling in ParseJson

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseJson.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/ParseJson.java
@@ -72,15 +72,20 @@ public class ParseJson extends Stage {
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     DocumentContext ctx;
-    if (this.sourceIsBase64) {
-      try (InputStream stream = new ByteArrayInputStream(DECODER.decode(doc.getString(this.src)))) {
-        ctx = this.jsonParseCtx.parse(stream);
-      } catch (IOException e) {
-        //do nothing this is a byte array stream close is a no-op. Throw stage exception just in case / futureproof.
-        throw new StageException("Unexpected error parsing JSON.", e);
+    try {
+      if (this.sourceIsBase64) {
+        try (InputStream stream = new ByteArrayInputStream(DECODER.decode(doc.getString(this.src)))) {
+          ctx = this.jsonParseCtx.parse(stream);
+        } catch (IOException e) {
+          //do nothing this is a byte array stream close is a no-op. Throw stage exception just in case / futureproof.
+          throw new StageException("Unexpected error parsing JSON.", e);
+        }
+      } else {
+        ctx = this.jsonParseCtx.parse(doc.getString(this.src));
       }
-    } else {
-      ctx = this.jsonParseCtx.parse(doc.getString(this.src));
+    } catch (IllegalArgumentException e) {
+      // Using a more specific Exception message. Primarily triggered when the Document is missing the JSON src field.
+      throw new StageException("Couldn't run ParseJson on Document " + doc.getId() + ".", e);
     }
     for (Entry<String, Object> entry : this.jsonFieldPaths.entrySet()) {
       JsonNode val = ctx.read((String) entry.getValue(), JsonNode.class);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
@@ -17,8 +17,6 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -238,6 +236,24 @@ public class ParseJsonTest {
     }
   }
 
+  @Test
+  public void testMissingSourceField() throws Exception {
+    Stage stage = factory.get("ParseJson/emptyJsonValue.conf");
+    Document doc = Document.create("parent");
+    Document childDoc = Document.create("child");
+    doc.addChild(childDoc);
+
+    try (InputStream in = ParseJsonTest.class.getClassLoader().getResourceAsStream("ParseJson/testEmptyValue.json")) {
+      childDoc.setField("json", (String) null);
+      doc.setField("json", IOUtils.toString(in, StandardCharsets.UTF_8));
+
+      stage.processDocument(doc);
+
+      // child document is missing the JSON. should throw a StageException (we catch + change the message).
+      // would normally be IllegalArgument.
+      assertThrows(StageException.class, () -> stage.processDocument(childDoc));
+    }
+  }
   @Test
   public void testGetLegalProperties() throws StageException {
     Stage stage = factory.get("ParseJson/config.conf");


### PR DESCRIPTION
When a Document is missing the source field, `this.jsonParseCtx.parse` throws an `IllegalArgumentException`. Now we just catch it and reference the Document's in a `StageException`. This makes the Stage's `Exception` a bit clearer when child documents are in play.