### PR TITLE
LC-569: Improved JavaDocs on Connectors

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/AbstractConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/AbstractConnector.java
@@ -10,8 +10,18 @@ import com.typesafe.config.Config;
  * for obtaining connector name, pipeline name, doc ID prefix, and collapsing mode.
  *
  * All Connectors will have their configuration validated by {@link Spec#validate(Config, String)}. In the Connector's constructor,
- * define the required/optional properties/parents via a ConnectorSpec. Validation errors will mention the connector's name.
- * A {@link Spec#connector()} always has "name", "class", "pipeline", "docIdPrefix", and "collapse" as legal properties.
+ * define the required/optional properties/parents in a {@link Spec#connector()}. Validation errors will mention the connector's <code>name</code>.
+ *
+ * <br> A {@link Spec#connector()} always has "name", "class", "pipeline", "docIdPrefix", and "collapse" as legal properties.
+ *
+ * <br> Base Config Parameters:
+ * <ul>
+ *   <li>name (String): The name of the Connector. Connector names should be unique (within your Lucille Config).</li>
+ *   <li>class (String): The class for the Connector your want to use.</li>
+ *   <li>pipeline (String, Optional): The name of the pipeline to feed Documents to. Defaults to null (no pipeline).</li>
+ *   <li>docIdPrefix (String, Optional): A String to prepend to Document IDs originating from this Connector. Defaults to an empty string (no prefix).</li>
+ *   <li>collapse (Boolean, Optional): Whether this Connector is "collapsing". Defaults to false.</li>
+ * </ul>
  */
 public abstract class AbstractConnector implements Connector {
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/CSVConnector.java
@@ -18,6 +18,8 @@ import java.nio.file.Path;
 
 /**
  * Connector implementation that produces documents from the rows in a given CSV file.
+ *
+ * <br> The CSVConnector has been deprecated. Use {@link FileConnector} with a {@link CSVFileHandler}.
  */
 @Deprecated
 public class CSVConnector extends AbstractConnector {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -24,8 +24,7 @@ import org.slf4j.LoggerFactory;
  *
  * <br> Config Parameters:
  * <ul>
- *   <li>docIdPrefix (string, Optional): prefix to add to the docId when not handled by a file handler, defaults to empty string. To configure docIdPrefix for CSV, JSON or XML files, configure it in its respective file handler config in fileOptions</li>
- *   <li>pathToStorage (string): path to storage, can be local file system or cloud bucket/container. Examples:
+ *   <li>pathToStorage (String): path to storage, can be local file system or cloud bucket/container. Examples:
  *    <ul>
  *       <li>/path/to/storage/in/local/filesystem</li>
  *       <li>gs://bucket-name/folder/</li>
@@ -35,7 +34,7 @@ import org.slf4j.LoggerFactory;
  *   </li>
  *   <li>filterOptions (Map, Optional): configuration for <i>which</i> files should/shouldn't be processed in your traversal. Example of filterOptions below.</li>
  *   <li>fileOptions (Map, Optional): configuratino for <i>how</i> you handle/process certain types of files in your traversal. Example of fileOptions below.</li>
- *   <li>gcp (Map, Optional): options for handling GoogleCloud files. See example below.</li>
+ *   <li>gcp (Map, Optional): options for handling Google Cloud files. See example below.</li>
  *   <li>s3 (Map, Optional): options for handling S3 files. See example below.</li>
  *   <li>azure (Map, Optional): options for handling Azure files. See example below.</li>
  * </ul>
@@ -44,9 +43,9 @@ import org.slf4j.LoggerFactory;
  *
  * <code>filterOptions</code>:
  * <ul>
- *   <li>includes (list of strings, Optional): list of regex patterns to include files.</li>
- *   <li>excludes (list of strings, Optional): list of regex patterns to exclude files.</li>
- *   <li>modificationCutoff (Duration, Optional): Filter files that haven't been modified since a certain amount of time.</li>
+ *   <li>includes (List&lt;String&gt;, Optional): list of regex patterns to include files.</li>
+ *   <li>excludes (List&lt;String&gt;, Optional): list of regex patterns to exclude files.</li>
+ *   <li>modificationCutoff (Duration, Optional): Filter files that haven't been modified since a certain amount of time. For example, specify "1h", and only files that were modified more than an hour ago will be published.</li>
  * </ul>
  *
  * See the HOCON documentation for examples of a Duration - strings like "1h", "2d" and "3s" are accepted, for example.
@@ -55,37 +54,47 @@ import org.slf4j.LoggerFactory;
  * <p> <code>fileOptions</code>:
  * <ul>
  *   <li>getFileContent (boolean, Optional): option to fetch the file content or not, defaults to true. Setting this to false would speed up traversal significantly. Note that if you are traversing the cloud, setting this to true would download the file content. Ensure that you have enough resources if you expect file contents to be large.</li>
- *   <li>handleArchivedFiles (boolean, Optional): whether to handle archived files or not, defaults to false. Recurring not supported. Note: If this is enabled while traversing the cloud, it will force to fetch the file contents of the compressed file before processing. The file path field of extracted file will be in the format of "{path/to/archive/archive.zip}:{extractedFileName}" unless handled by fileHandler in which in that case will follow the id creation of that fileHandler</li>
- *   <li>handleCompressedFiles (boolean, Optional): whether to handle compressed files or not, defaults to false. Recurring not supported.Note: If this is enabled while traversing the cloud, it will force to fetch the file contents of the compressed file before processing.The file path field of decompressed file will be in the format of "{path/to/compressed/compressedFileName.gz}:{compressedFileName}" unless handled by fileHandler in which in that case will follow the id creation of that fileHandler</li>
+ *   <li>handleArchivedFiles (boolean, Optional): whether to handle archived files or not, defaults to false. See important notes below.</li>
+ *   <li>handleCompressedFiles (boolean, Optional): whether to handle compressed files or not, defaults to false. See important notes below.</li>
  *   <li>moveToAfterProcessing (string, Optional): path to move files to after processing, currently only supported for local file system</li>
  *   <li>moveToErrorFolder (string, Optional): path to move files to if an error occurs during processing, currently only supported for local file system</li>
- *   <li>csv (Map, Optional): csv config options for handling csv type files. Config will be passed to CSVFileHandler</li>
- *   <li>json (Map, Optional): json config options for handling json/jsonl type files. Config will be passed to JsonFileHandler</li>
- *   <li>xml (Map, Optional): xml config options for handling xml type files. Config will be passed to XMLFileHandler</li>
+ *   <li>csv (Map, Optional): config options for handling csv type files. Config will be passed to CSVFileHandler</li>
+ *   <li>json (Map, Optional): config options for handling json/jsonl type files. Config will be passed to JsonFileHandler</li>
+ *   <li>xml (Map, Optional): config options for handling xml type files. Config will be passed to XMLFileHandler</li>
+ *   <li>(To configure the docIdPrefix for CSV, JSON or XML files, configure it in its respective config in <code>fileOptions</code>.)</li>
+ *
+ *   <li> <b>Notes</b> on archive / compressed files:
+ *      <ul>
+ *         <li>Recurring is not supported.</li>
+ *         <li>If enabled during a cloud traversal, the file's contents <b>will</b> be downloaded before processing.</li>
+ *         <li>For archive files, the file path field of the extracted file's Document will be in the format of "{path/to/archive/archive.zip}!{extractedFileName}".</li>
+ *         <li>For compressed files, the file path follows the format of "{path/to/compressed/compressedFileName.gz}!{compressedFileName}".</li>
+ *       </ul>
+ *    </li>
  * </ul>
  *
  * <code>gcp</code>:
  * <ul>
- *   <li>"pathToServiceKey" : "path/To/Service/Key.json"</li>
+ *   <li>"pathToServiceKey": "path/To/Service/Key.json"</li>
  *   <li>"maxNumOfPages" (Int, Optional): The maximum number of file references to hold in memory at once. Defaults to 100.</li>
  * </ul>
  *
  * <code>s3</code>:
  * <ul>
- *   <li>"accessKeyId" : s3 key id. Not needed if secretAccessKey is not specified (using default credentials).</li>
- *   <li>"secretAccessKey" : secret access key. Not needed if accessKeyId is not specified (using default credentials).</li>
- *   <li>"region" : s3 storage region</li>
+ *   <li>"accessKeyId": s3 key id. Not needed if secretAccessKey is not specified (using default credentials).</li>
+ *   <li>"secretAccessKey": secret access key. Not needed if accessKeyId is not specified (using default credentials).</li>
+ *   <li>"region": s3 storage region</li>
  *   <li>"maxNumOfPages" (Int, Optional): The maximum number of file references to hold in memory at once. Defaults to 100.</li>
  * </ul>
  *
  * <code>azure</code>:
  * <ul>
- *   <li>"connectionString" : azure connection string</li>
+ *   <li>"connectionString": azure connection string</li>
  * </ul>
  * <b>Or</b>
  * <ul>
- *   <li>"accountName" : azure account name</li>
- *   <li>"accountKey" : azure account key</li>
+ *   <li>"accountName": azure account name</li>
+ *   <li>"accountKey": azure account key</li>
  *   <li>"maxNumOfPages" (Int, Optional): The maximum number of file references to hold in memory at once. Defaults to 100.</li>
  * </ul>
  */

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -25,13 +25,14 @@ import org.slf4j.LoggerFactory;
  * <br> Config Parameters:
  * <ul>
  *   <li>docIdPrefix (string, Optional): prefix to add to the docId when not handled by a file handler, defaults to empty string. To configure docIdPrefix for CSV, JSON or XML files, configure it in its respective file handler config in fileOptions</li>
- *   <li>pathToStorage (string): path to storage, can be local file system or cloud bucket/container.</li>
- *   <ul>
- *     <li>/path/to/storage/in/local/filesystem</li>
- *     <li>gs://bucket-name/folder/</li>
- *     <li>s3://bucket-name/folder/</li>
- *     <li>https://accountName.blob.core.windows.net/containerName/prefix/</li>
- *   </ul>
+ *   <li>pathToStorage (string): path to storage, can be local file system or cloud bucket/container. Examples:
+ *    <ul>
+ *       <li>/path/to/storage/in/local/filesystem</li>
+ *       <li>gs://bucket-name/folder/</li>
+ *       <li>s3://bucket-name/folder/</li>
+ *      <li>https://accountName.blob.core.windows.net/containerName/prefix/</li>
+ *    </ul>
+ *   </li>
  *   <li>filterOptions (Map, Optional): configuration for <i>which</i> files should/shouldn't be processed in your traversal. Example of filterOptions below.</li>
  *   <li>fileOptions (Map, Optional): Options for <i>how</i> you handle/process certain types of files in your traversal. Example of fileOptions below.</li>
  *   <li>gcp (Map, Optional): options for handling GoogleCloud files. See example below.</li>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -19,53 +19,74 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Config parameters:
- *  docIdPrefix (string, Optional): prefix to add to the docId when not handled by a file handler, defaults to empty string. To configure docIdPrefix for CSV, JSON or XML files, configure it in its respective file handler config in fileOptions
- *  pathToStorage (string): path to storage, can be local file system or cloud bucket/container
- *  e.g.
- *    /path/to/storage/in/local/filesystem
- *    gs://bucket-name/folder/
- *    s3://bucket-name/folder/
- *    https://accountName.blob.core.windows.net/containerName/prefix/
- *  filterOptions (Map, Optional): configuration for <i>which</i> files should/shouldn't be processed in your traversal. Example of filterOptions below.
- *  fileOptions (Map, Optional): Options for <i>how</i> you handle/process certain types of files in your traversal. Example of fileOptions below.
- *  gcp (Map, Optional): options for handling GoogleCloud files. See example below.
- *  s3 (Map, Optional): options for handling S3 files. See example below.
- *  azure (Map, Optional): options for handling Azure files. See example below.
+ * The <code>FileConnector</code> traverses through a file system, starting at a given directory, and publishes a Document for each
+ * file it encounters. It can traverse through the local file system, Azure Blob Storage, Google Cloud, and S3.
  *
- * FilterOptions:
- *  includes (list of strings, Optional): list of regex patterns to include files.
- *  excludes (list of strings, Optional): list of regex patterns to exclude files.
- *  modificationCutoff (Duration, Optional): Filter files that haven't been modified since a certain amount of time.
- *  See the HOCON documentation for examples of a Duration - strings like "1h", "2d" and "3s" are accepted, for example.
- *  Note that, for archive files, this cutoff applies to both the archive file itself and its individual contents.
+ * <br> Config Parameters:
+ * <ul>
+ *   <li>docIdPrefix (string, Optional): prefix to add to the docId when not handled by a file handler, defaults to empty string. To configure docIdPrefix for CSV, JSON or XML files, configure it in its respective file handler config in fileOptions</li>
+ *   <li>pathToStorage (string): path to storage, can be local file system or cloud bucket/container.</li>
+ *   <ul>
+ *     <li>/path/to/storage/in/local/filesystem</li>
+ *     <li>gs://bucket-name/folder/</li>
+ *     <li>s3://bucket-name/folder/</li>
+ *     <li>https://accountName.blob.core.windows.net/containerName/prefix/</li>
+ *   </ul>
+ *   <li>filterOptions (Map, Optional): configuration for <i>which</i> files should/shouldn't be processed in your traversal. Example of filterOptions below.</li>
+ *   <li>fileOptions (Map, Optional): Options for <i>how</i> you handle/process certain types of files in your traversal. Example of fileOptions below.</li>
+ *   <li>gcp (Map, Optional): options for handling GoogleCloud files. See example below.</li>
+ *   <li>s3 (Map, Optional): options for handling S3 files. See example below.</li>
+ *   <li>azure (Map, Optional): options for handling Azure files. See example below.</li>
+ * </ul>
  *
- * FileOptions:
- *  getFileContent (boolean, Optional): option to fetch the file content or not, defaults to true. Setting this to false would speed up traversal significantly. Note that if you are traversing the cloud, setting this to true would download the file content. Ensure that you have enough resources if you expect file contents to be large.
- *  handleArchivedFiles (boolean, Optional): whether to handle archived files or not, defaults to false. Recurring not supported. Note: If this is enabled while traversing the cloud, it will force to fetch the file contents of the compressed file before processing. The file path field of extracted file will be in the format of "{path/to/archive/archive.zip}:{extractedFileName}" unless handled by fileHandler in which in that case will follow the id creation of that fileHandler
- *  handleCompressedFiles (boolean, Optional): whether to handle compressed files or not, defaults to false. Recurring not supported.Note: If this is enabled while traversing the cloud, it will force to fetch the file contents of the compressed file before processing.The file path field of decompressed file will be in the format of "{path/to/compressed/compressedFileName.gz}:{compressedFileName}" unless handled by fileHandler in which in that case will follow the id creation of that fileHandler
- *  moveToAfterProcessing (string, Optional): path to move files to after processing, currently only supported for local file system
- *  moveToErrorFolder (string, Optional): path to move files to if an error occurs during processing, currently only supported for local file system
- *  csv (Map, Optional): csv config options for handling csv type files. Config will be passed to CSVFileHandler
- *  json (Map, Optional): json config options for handling json/jsonl type files. Config will be passed to JsonFileHandler
- *  xml (Map, Optional): xml config options for handling xml type files. Config will be passed to XMLFileHandler
+ * <br>
  *
- * <br> gcp:
- * "pathToServiceKey" : "path/To/Service/Key.json"
- * "maxNumOfPages" : number of references of the files loaded into memory in a single fetch request. Optional, defaults to 100
+ * <code>FilterOptions</code>:
+ * <ul>
+ *   <li>includes (list of strings, Optional): list of regex patterns to include files.</li>
+ *   <li>excludes (list of strings, Optional): list of regex patterns to exclude files.</li>
+ *   <li>modificationCutoff (Duration, Optional): Filter files that haven't been modified since a certain amount of time.</li>
+ * </ul>
  *
- * <br> s3:
- * "accessKeyId" : s3 key id. Not needed if secretAccessKey is not specified (using default credentials).
- * "secretAccessKey" : secret access key. Not needed if accessKeyId is not specified (using default credentials).
- * "region" : s3 storage region
- * "maxNumOfPages" : number of references of the files loaded into memory in a single fetch request. Optional, defaults to 100
+ * See the HOCON documentation for examples of a Duration - strings like "1h", "2d" and "3s" are accepted, for example.
+ * <br> Note that, for archive files, this cutoff applies to both the archive file itself and its individual contents.
  *
- * <br> azure:
- * "connectionString" : azure connection string
+ * <p> <code>FileOptions</code>:
+ * <ul>
+ *   <li>getFileContent (boolean, Optional): option to fetch the file content or not, defaults to true. Setting this to false would speed up traversal significantly. Note that if you are traversing the cloud, setting this to true would download the file content. Ensure that you have enough resources if you expect file contents to be large.</li>
+ *   <li>handleArchivedFiles (boolean, Optional): whether to handle archived files or not, defaults to false. Recurring not supported. Note: If this is enabled while traversing the cloud, it will force to fetch the file contents of the compressed file before processing. The file path field of extracted file will be in the format of "{path/to/archive/archive.zip}:{extractedFileName}" unless handled by fileHandler in which in that case will follow the id creation of that fileHandler</li>
+ *   <li>handleCompressedFiles (boolean, Optional): whether to handle compressed files or not, defaults to false. Recurring not supported.Note: If this is enabled while traversing the cloud, it will force to fetch the file contents of the compressed file before processing.The file path field of decompressed file will be in the format of "{path/to/compressed/compressedFileName.gz}:{compressedFileName}" unless handled by fileHandler in which in that case will follow the id creation of that fileHandler</li>
+ *   <li>moveToAfterProcessing (string, Optional): path to move files to after processing, currently only supported for local file system</li>
+ *   <li>moveToErrorFolder (string, Optional): path to move files to if an error occurs during processing, currently only supported for local file system</li>
+ *   <li>csv (Map, Optional): csv config options for handling csv type files. Config will be passed to CSVFileHandler</li>
+ *   <li>json (Map, Optional): json config options for handling json/jsonl type files. Config will be passed to JsonFileHandler</li>
+ *   <li>xml (Map, Optional): xml config options for handling xml type files. Config will be passed to XMLFileHandler</li>
+ * </ul>
+ *
+ * <code>gcp</code>:
+ * <ul>
+ *   <li>"pathToServiceKey" : "path/To/Service/Key.json"</li>
+ *   <li>"maxNumOfPages" (Int, Optional): The maximum number of file references to hold in memory at once. Defaults to 100.</li>
+ * </ul>
+ *
+ * <code>s3</code>:
+ * <ul>
+ *   <li>"accessKeyId" : s3 key id. Not needed if secretAccessKey is not specified (using default credentials).</li>
+ *   <li>"secretAccessKey" : secret access key. Not needed if accessKeyId is not specified (using default credentials).</li>
+ *   <li>"region" : s3 storage region</li>
+ *   <li>"maxNumOfPages" (Int, Optional): The maximum number of file references to hold in memory at once. Defaults to 100.</li>
+ * </ul>
+ *
+ * <code>azure</code>:
+ * <ul>
+ *   <li>"connectionString" : azure connection string</li>
+ * </ul>
  * <b>Or</b>
- * "accountName" : azure account name
- * "accountKey" : azure account key
- * "maxNumOfPages" : number of references of the files loaded into memory in a single fetch request. Optional, defaults to 100
+ * <ul>
+ *   <li>"accountName" : azure account name</li>
+ *   <li>"accountKey" : azure account key</li>
+ *   <li>"maxNumOfPages" (Int, Optional): The maximum number of file references to hold in memory at once. Defaults to 100.</li>
+ * </ul>
  */
 
 public class FileConnector extends AbstractConnector {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  *    </ul>
  *   </li>
  *   <li>filterOptions (Map, Optional): configuration for <i>which</i> files should/shouldn't be processed in your traversal. Example of filterOptions below.</li>
- *   <li>fileOptions (Map, Optional): Options for <i>how</i> you handle/process certain types of files in your traversal. Example of fileOptions below.</li>
+ *   <li>fileOptions (Map, Optional): configuratino for <i>how</i> you handle/process certain types of files in your traversal. Example of fileOptions below.</li>
  *   <li>gcp (Map, Optional): options for handling GoogleCloud files. See example below.</li>
  *   <li>s3 (Map, Optional): options for handling S3 files. See example below.</li>
  *   <li>azure (Map, Optional): options for handling Azure files. See example below.</li>
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  *
  * <br>
  *
- * <code>FilterOptions</code>:
+ * <code>filterOptions</code>:
  * <ul>
  *   <li>includes (list of strings, Optional): list of regex patterns to include files.</li>
  *   <li>excludes (list of strings, Optional): list of regex patterns to exclude files.</li>
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * See the HOCON documentation for examples of a Duration - strings like "1h", "2d" and "3s" are accepted, for example.
  * <br> Note that, for archive files, this cutoff applies to both the archive file itself and its individual contents.
  *
- * <p> <code>FileOptions</code>:
+ * <p> <code>fileOptions</code>:
  * <ul>
  *   <li>getFileContent (boolean, Optional): option to fetch the file content or not, defaults to true. Setting this to false would speed up traversal significantly. Note that if you are traversing the cloud, setting this to true would download the file content. Ensure that you have enough resources if you expect file contents to be large.</li>
  *   <li>handleArchivedFiles (boolean, Optional): whether to handle archived files or not, defaults to false. Recurring not supported. Note: If this is enabled while traversing the cloud, it will force to fetch the file contents of the compressed file before processing. The file path field of extracted file will be in the format of "{path/to/archive/archive.zip}:{extractedFileName}" unless handled by fileHandler in which in that case will follow the id creation of that fileHandler</li>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -56,11 +56,11 @@ import org.slf4j.LoggerFactory;
  *   <li>getFileContent (boolean, Optional): option to fetch the file content or not, defaults to true. Setting this to false would speed up traversal significantly. Note that if you are traversing the cloud, setting this to true would download the file content. Ensure that you have enough resources if you expect file contents to be large.</li>
  *   <li>handleArchivedFiles (boolean, Optional): whether to handle archived files or not, defaults to false. See important notes below.</li>
  *   <li>handleCompressedFiles (boolean, Optional): whether to handle compressed files or not, defaults to false. See important notes below.</li>
- *   <li>moveToAfterProcessing (string, Optional): path to move files to after processing, currently only supported for local file system</li>
- *   <li>moveToErrorFolder (string, Optional): path to move files to if an error occurs during processing, currently only supported for local file system</li>
- *   <li>csv (Map, Optional): config options for handling csv type files. Config will be passed to CSVFileHandler</li>
- *   <li>json (Map, Optional): config options for handling json/jsonl type files. Config will be passed to JsonFileHandler</li>
- *   <li>xml (Map, Optional): config options for handling xml type files. Config will be passed to XMLFileHandler</li>
+ *   <li>moveToAfterProcessing (String, Optional): path to move files to after processing, currently only supported for local file system</li>
+ *   <li>moveToErrorFolder (String, Optional): path to move files to if an error occurs during processing, currently only supported for local file system</li>
+ *   <li>csv (Map, Optional): config options for handling csv type files. Config will be passed to CSVFileHandler.</li>
+ *   <li>json (Map, Optional): config options for handling json/jsonl type files. Config will be passed to JsonFileHandler.</li>
+ *   <li>xml (Map, Optional): config options for handling xml type files. Config will be passed to XMLFileHandler.</li>
  *   <li>(To configure the docIdPrefix for CSV, JSON or XML files, configure it in its respective config in <code>fileOptions</code>.)</li>
  *
  *   <li> <b>Notes</b> on archive / compressed files:

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/JSONConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/JSONConnector.java
@@ -3,6 +3,7 @@ package com.kmwllc.lucille.connector;
 import com.kmwllc.lucille.core.ConnectorException;
 import com.kmwllc.lucille.core.Publisher;
 import com.kmwllc.lucille.core.Spec;
+import com.kmwllc.lucille.core.fileHandler.CSVFileHandler;
 import com.kmwllc.lucille.core.fileHandler.JsonFileHandler;
 import com.kmwllc.lucille.util.FileContentFetcher;
 import com.typesafe.config.Config;
@@ -11,6 +12,11 @@ import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Connector implementation that produces documents from the rows in a given JSON or JSONL file.
+ *
+ * <br> The JSONConnector has been deprecated. Use {@link FileConnector} with a {@link JsonFileHandler}.
+ */
 @Deprecated
 public class JSONConnector extends AbstractConnector {
   private static final Logger log = LoggerFactory.getLogger(JSONConnector.class);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/SequenceConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/SequenceConnector.java
@@ -9,7 +9,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Connector implementation that produces blank documents given amount to produce
+ * Connector implementation that produces a certain number of empty Documents. Each Document will have a number for its ID
+ * (generated in order).
+ *
+ * <p> Config Parameters:
+ * <ul>
+ *   <li>numDocs (Long): The number of Documents you want to create.</li>
+ *   <li>startWith (Int, Optional): The ID you want the first Document to have. Defaults to zero.</li>
+ * </ul>
  */
 public class SequenceConnector extends AbstractConnector {
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/SolrConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/SolrConnector.java
@@ -22,18 +22,21 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Connector for issuing requests to Solr. Requests should be formatted as JSON Strings and can contain
- * the {runId} wildcard, which will be substituted for the current runId before the requests are issued.
- * This is the only wildcard supported. XML can be used instead of JSON with the useXml=true parameter.
+ * Connector for issuing requests to Solr. Requests should be formatted as JSON Strings. They can contain
+ * the <code>{runId}</code> wildcard, which will be substituted with the current runId in the actual request.
+ * (This is the only wildcard supported.)
  *
- * Connector Parameters:
+ * <br> You can use XML in lieu of JSON by setting <code>useXML</code> to <code>true</code>.
  *
- *   - preActions (List&lt;String&gt;, Optional) : A list of requests to be issued to Solr. These actions will be performed first.
- *   - postActions (List&lt;String&gt;, Optional) : A list of requests to be issued to Solr. These actions will be performed second.
- *   - solr.url (String) : The url of the Solr instance for this Connector to issue its requests to.
- *   - useXml (boolean, Optional) : indicates whether actions are in xml or json format; defaults to json; note that
- *     Solr does more validation on json commands than xml ones (e.g. it rejects unrecognized JSON commands but
- *     accepts unrecognized XML commands and reports success); therefore, json is preferable
+ * <br> Config Parameters:
+ * <ul>
+ *   <li>preActions (List&lt;String&gt;, Optional): A list of requests to be issued to Solr. These actions will be performed first.</li>
+ *   <li>postActions (List&lt;String&gt;, Optional): A list of requests to be issued to Solr. These actions will be performed second.</li>
+ *   <li>solr (Map): Configuration for connecting to your Solr instance. See {@link SolrUtils#SOLR_PARENT_SPEC} for parameters.</li>
+ *   <li>useXML (Boolean, Optional): Whether your requests use XML or not. Defaults to JSON requests (<code>false</code>).</li>
+ * </ul>
+ *
+ * <b>Note:</b> As Solr performs more validation on JSON commands than XML, it is recommended you use JSON requests.
  */
 // TODO : Honor and return children documents
 public class SolrConnector extends AbstractConnector {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnector.java
@@ -21,34 +21,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Database Connector - This connector can run a select statement and return the rows
- * from the database as documents which are published to a topic for processing.
- * If "otherSQLs" are set, the sql and otherSQLs must all be ordered by their join key
- * and the otherJoinFields must be populated.  If those parameters are populated
- * this connector will run the otherSQL statements in parallel and flatten the rows from
- * the otherSQL statements onto the Document as a child document
- * <p>
- * Note: currently this connector with otherSQL statements only supports integers as a
- * join key.
+ * Database Connector - This connector can run a <code>SELECT</code> statement and return the rows from the database as published Documents.
+ * If <code>otherSQLs</code> is set, the <code>sql</code> and <code>otherSQLs</code> must all be ordered by their join key, and
+ * <code>otherJoinFields</code> must be populated. If those parameters are populated, this connector will run the <code>otherSQL</code>
+ * statements in parallel, flattening the rows from the <code>otherSQL</code> statements onto the Document as a child document.
+ * <p> <b>Note:</b> With <code>otherSQL</code> statements, the Connector only supports integer join keys.
  *
- * Config Parameters:
- * - driver (String) : Driver used for creating a connection to database
- * - connectionString (String) : used for establishing a connection to the right database
- * - jdbcUser (String) : username to access database
- * - jdbcPassword (String) : password to access database
- * - sql (String) : SQL statement to query the database.
- * - idField (String) : column name used for id in the database
- * - fetchSize (Integer, Optional): returns the desired resultSet size if set
- * - preSQL (String, Optional): SQL statement that returns nothing. Performed before sql is executed.
- *    e.g. INSERT, DELETE, UPDATE, SQL DDL statement.
- * - postSQL (String, Optional): SQL statement that returns nothing. Performed after sql is executed.
- *    e.g. INSERT, DELETE, UPDATE, SQL DDL statement.
- * - otherSQLs (List&lt;String&gt;, Optional): list of SQL statements to query and retrieve another result set of size fetchSize if set.
- *    For joining result sets.
- * - otherJoinFields (String, Optional, required if otherSQL is provided) : join field used for other result sets retrieved from otherSQLs
- * - ignoreColumns (List&lt;String&gt;, Optional) : list of columns to ignore when populating Lucille document from sql result set.
- * - connectionRetries (Integer, Optional) : number of retries allowed to connect to database, defaults to 1
- * - connectionRetryPause (Integer, Optional) : duration of pause between retries in milliseconds, defaults to 10000 or 10 seconds
+ * <p> Config Parameters:
+ * <ul>
+ *   <li>driver (String): Driver used for creating a connection to database</li>
+ *   <li>connectionString (String): used for establishing a connection to the right database</li>
+ *   <li>jdbcUser (String): username to access database</li>
+ *   <li>jdbcPassword (String): password to access database</li>
+ *   <li>sql (String): SQL statement to query the database.</li>
+ *   <li>idField (String): column name used for id in the database</li>
+ *   <li>fetchSize (Integer, Optional): returns the desired resultSet size if set</li>
+ *   <li>preSQL (String, Optional): SQL statement that returns nothing. Performed before sql is executed. e.g. INSERT, DELETE, UPDATE, SQL DDL statement.</li>
+ *   <li>postSQL (String, Optional): SQL statement that returns nothing. Performed after sql is executed. e.g. INSERT, DELETE, UPDATE, SQL DDL statement.</li>
+ *   <li>otherSQLs (List&lt;String&gt;, Optional): list of SQL statements to query and retrieve another result set of size fetchSize if set. For joining result sets.</li>
+ *   <li>otherJoinFields (String, Optional): join field used for other result sets retrieved from otherSQLs. <b>Required if otherSQL is provided.</b></li>
+ *   <li>ignoreColumns (List&lt;String&gt;, Optional): list of columns to ignore when populating Lucille document from sql result set.</li>
+ *   <li>connectionRetries (Integer, Optional): number of retries allowed to connect to database, defaults to 1</li>
+ *   <li>connectionRetryPause (Integer, Optional): duration of pause between retries in milliseconds, defaults to 10000 or 10 seconds</li>
+ * </ul>
  *
  * @author kwatters
  */

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/xml/XMLConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/xml/XMLConnector.java
@@ -1,9 +1,11 @@
 package com.kmwllc.lucille.connector.xml;
 
 import com.kmwllc.lucille.connector.AbstractConnector;
+import com.kmwllc.lucille.connector.FileConnector;
 import com.kmwllc.lucille.core.ConnectorException;
 import com.kmwllc.lucille.core.Publisher;
 import com.kmwllc.lucille.core.Spec;
+import com.kmwllc.lucille.core.fileHandler.CSVFileHandler;
 import com.kmwllc.lucille.core.fileHandler.XMLFileHandler;
 import com.kmwllc.lucille.util.FileContentFetcher;
 import com.typesafe.config.Config;
@@ -16,15 +18,17 @@ import java.util.List;
 
 /**
  * Connector implementation that produces documents from a given XML file.
- * Config Parameters:
+ * <p> Config Parameters:
  * <ul>
- * <li>filePaths (List&lt;String&gt;): The list of file paths to parse through.</li>
- * <li>xmlRootPath (String): The path to the XML chunk to separate as a document.</li>
- * <li>xmlIdPath (String): The path to the id for each document.</li>
- * <li>urlFiles (List&lt;String&gt;): The list of URL file paths to parse. If specified along with filePaths, urlFiles takes precedence.</li>
- * <li>encoding (String): The encoding of the XML document to parse: defaults to utf-8.</li>
- * <li>outputField (String): The field to place the XML into: defaults to "xml".</li>
+ *  <li>filePaths (List&lt;String&gt;): The list of file paths to parse through.</li>
+ *  <li>xmlRootPath (String): The path to the XML chunk to separate as a document.</li>
+ *  <li>xmlIdPath (String): The path to the id for each document.</li>
+ *  <li>urlFiles (List&lt;String&gt;): The list of URL file paths to parse. If specified along with filePaths, urlFiles takes precedence.</li>
+ *  <li>encoding (String): The encoding of the XML document to parse: defaults to utf-8.</li>
+ *  <li>outputField (String): The field to place the XML into: defaults to "xml".</li>
  * </ul>
+ *
+ * The XMLConnector has been deprecated. Use {@link FileConnector} with an {@link XMLFileHandler}.
  */
 @Deprecated
 public class XMLConnector extends AbstractConnector {


### PR DESCRIPTION
The `ParquetConnector` isn't included... I have some JavaDocs for it in the refactor PR.