### PR TITLE
LC-621: improved unit tests for CSVFileHandler

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
@@ -136,13 +136,15 @@ public class CSVFileHandler extends BaseFileHandler {
           return getDocumentFromLine(idColumns, header, line, filename, path, lineNum);
         } catch (Exception e) {
           log.error("Error processing CSV line {}", lineNum, e);
+
           try {
             csvReader.close();
           } catch (IOException ex) {
             throw new RuntimeException(ex);
           }
+
+          return null;
         }
-        return null;
       }
     };
   }
@@ -196,6 +198,12 @@ public class CSVFileHandler extends BaseFileHandler {
 
   private HashMap<String, Integer> getColumnIndexMap(String[] header) {
     HashMap<String, Integer> columnIndexMap = new HashMap<String, Integer>();
+
+    // If header is null, just return an empty map. (Allows for graceful handling of empty files)
+    if (header == null) {
+      return columnIndexMap;
+    }
+
     for (int i = 0; i < header.length; i++) {
       // check for BOM
       if (i == 0) {
@@ -220,7 +228,7 @@ public class CSVFileHandler extends BaseFileHandler {
         } catch (IOException e) {
           log.error("Error closing CSVReader", e);
         }
-        log.warn("CSV does not contain header row, skipping csv file");
+        log.warn("CSV does not contain header row, no Documents will be published for the file.");
       }
       if (lowercaseFields) {
         for (int i = 0; i < header.length; i++) {

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customDocIDFormat.conf
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customDocIDFormat.conf
@@ -1,0 +1,4 @@
+{
+  idFields: ["field1", "field2", "field3"]
+  docIdFormat: "%s_%s_%s"
+}

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customFilenameField.conf
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customFilenameField.conf
@@ -1,0 +1,3 @@
+{
+  filenameField: "file_name_here"
+}

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customFilepathField.conf
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customFilepathField.conf
@@ -1,0 +1,3 @@
+{
+  filePathField: "path_to_file"
+}

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customLineNumberField.conf
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/customLineNumberField.conf
@@ -1,0 +1,3 @@
+{
+  lineNumberField: "line_number"
+}

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/ignoredTerms.conf
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/ignoredTerms.conf
@@ -1,0 +1,3 @@
+{
+  ignoredTerms: ["b", "e,f", "y"]
+}

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/lowercaseFields.conf
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/config/lowercaseFields.conf
@@ -1,0 +1,5 @@
+{
+  lowercaseFields: true
+  idFields: ["FIELD1", "fiELD2", "fielD3"]
+  docIdFormat: "%s_%s_%s"
+}

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/defaultsExtraTerms.csv
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/defaultsExtraTerms.csv
@@ -1,0 +1,4 @@
+field1,field2,field3
+a,b,c
+d,"e,f",g,h,i,j
+x,y,z

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/defaultsWithEmptiesAndBlanks.csv
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/defaultsWithEmptiesAndBlanks.csv
@@ -1,0 +1,8 @@
+field1,field2,field3
+a,b,c
+
+
+d,"e,f",g
+
+
+x,y,z

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/headerOnly.csv
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/headerOnly.csv
@@ -1,0 +1,1 @@
+field1,field2,field3

--- a/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/reservedFields.csv
+++ b/lucille-core/src/test/resources/FileHandlerTest/CSVFileHandlerTest/reservedFields.csv
@@ -1,0 +1,4 @@
+id,run_id,value
+"abc","run-1",1
+"def","run-2",2
+"ghi","run-3",3


### PR DESCRIPTION
Mostly just unit tests. One small code change in the actual `CSVFileHandler` - when `header` is `null` we return an empty `columnIndexMap` which allows us to safely skip the file. Without doing so, before, an empty CSV file caused a `NullPointerException` to be thrown.