### PR TITLE
LC-688: Causes of Document Indexer Failures are Logged

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -14,7 +14,9 @@ import com.kmwllc.lucille.util.LogUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.StopWatch;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,12 +170,12 @@ public abstract class Indexer implements Runnable {
    * each document individually.
    *
    * @param documents The documents to send to the destination.
-   * @return A set of the Documents that were not successfully indexed. Return an empty set if no documents fail / if not
-   * supported by the Indexer implementation. Must not return null.
-   * @throws Exception In the event of a considerable error causing indexing to fail. Does not throw
-   * Exceptions just because some Documents may have not been indexed successfully.
+   * @return A set of Pairs, containing the Documents that were not successfully indexed, along with String of information about why they failed.
+   * Returns an empty set if no documents fail, or if this information is not supported by the Indexer implementation. Does not return null.
+   * @throws Exception In the event of a considerable error causing indexing to fail. (Does not throw
+   * Exceptions just because some Documents were not successfully indexed.)
    */
-  protected abstract Set<Document> sendToIndex(List<Document> documents) throws Exception;
+  protected abstract Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception;
 
   /** Close the client or connection to the destination search engine. */
   public abstract void closeConnection();
@@ -265,24 +267,26 @@ public abstract class Indexer implements Runnable {
     try {
       stopWatch.reset();
       stopWatch.start();
-      Set<Document> failedDocs = sendToIndex(batchedDocs);
+      Set<Pair<Document, String>> failedDocPairs = sendToIndex(batchedDocs);
       stopWatch.stop();
       histogram.update(stopWatch.getNanoTime() / batchedDocs.size());
       meter.mark(batchedDocs.size());
 
-      if (!failedDocs.isEmpty()) {
-        log.warn("{} Documents were not indexed successfully.", failedDocs.size());
+      if (!failedDocPairs.isEmpty()) {
+        log.warn("{} Documents were not indexed successfully.", failedDocPairs.size());
       }
 
       // Mark all the documents in failedDoc as failed
-      for (Document d : failedDocs) {
+      for (Pair<Document, String> pair : failedDocPairs) {
         try {
-          messenger.sendEvent(d, "FAILED", Event.Type.FAIL);
-          docLogger.error("Sent failure message for doc {}.", d.getId());
+          messenger.sendEvent(pair.getLeft(), "FAILED: " + pair.getRight(), Event.Type.FAIL);
+          docLogger.error("Sent failure message for doc {}. Reason: {}", pair.getLeft().getId(), pair.getRight());
         } catch (Exception e) {
-          log.error("Couldn't send failure event for doc {}", d.getId(), e);
+          log.error("Couldn't send failure event for doc {}", pair.getLeft().getId(), e);
         }
       }
+
+      Set<Document> failedDocs = failedDocPairs.stream().map(Pair::getLeft).collect(Collectors.toSet());
 
       for (Document d : batchedDocs) {
         if (failedDocs.contains(d)) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -9,6 +9,7 @@ import com.opencsv.ICSVWriter;
 import com.typesafe.config.Config;
 import java.io.File;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +109,7 @@ public class CSVIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
     for (Document doc : documents) {
       writer.writeNext(getLine(doc), true);
     }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -20,6 +20,7 @@ import com.typesafe.config.Config;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ public class ElasticsearchIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
       return Set.of();
@@ -181,7 +182,7 @@ public class ElasticsearchIndexer extends Indexer {
       }
     }
 
-    Set<Document> failedDocs = new HashSet<>();
+    Set<Pair<Document, String>> failedDocs = new HashSet<>();
 
     BulkResponse response = client.bulk(br.build());
     if (response != null) {
@@ -191,7 +192,7 @@ public class ElasticsearchIndexer extends Indexer {
           // If not, we don't know what the error is, and opt to throw an actual IndexerException instead.
           if (documentsUploaded.containsKey(item.id())) {
             Document failedDoc = documentsUploaded.get(item.id());
-            failedDocs.add(failedDoc);
+            failedDocs.add(Pair.of(failedDoc, item.error().reason()));
           } else {
             throw new IndexerException(item.error().reason());
           }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -7,6 +7,7 @@ import com.kmwllc.lucille.message.IndexerMessenger;
 import com.typesafe.config.Config;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * The NopIndexer performs no operations and does not send documents to any index. It is intended to be used for testing or
@@ -31,7 +32,7 @@ public class NopIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
     // no-op
     return Set.of();
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.BulkIndexByScrollFailure;
 import org.opensearch.client.opensearch._types.FieldValue;
@@ -115,7 +116,7 @@ public class OpenSearchIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (client == null) {
       return Set.of();
@@ -148,7 +149,7 @@ public class OpenSearchIndexer extends Indexer {
       }
     }
 
-    Set<Document> failedDocs = uploadDocuments(documentsToUpload.values());
+    Set<Pair<Document, String>> failedDocs = uploadDocuments(documentsToUpload.values());
     deleteById(new ArrayList<>(idsToDelete));
     deleteByQuery(termsToDeleteByQuery);
 
@@ -246,7 +247,7 @@ public class OpenSearchIndexer extends Indexer {
     }
   }
 
-  private Set<Document> uploadDocuments(Collection<Document> documentsToUpload) throws IOException, IndexerException {
+  private Set<Pair<Document, String>> uploadDocuments(Collection<Document> documentsToUpload) throws IOException, IndexerException {
     if (documentsToUpload.isEmpty()) {
       return Set.of();
     }
@@ -309,7 +310,7 @@ public class OpenSearchIndexer extends Indexer {
       }
     }
 
-    Set<Document> failedDocs = new HashSet<>();
+    Set<Pair<Document, String>> failedDocs = new HashSet<>();
 
     BulkResponse response = client.bulk(br.build());
 
@@ -320,7 +321,7 @@ public class OpenSearchIndexer extends Indexer {
           // If not, we don't know what the error is, and opt to throw an actual IndexerException instead.
           if (uploadedDocuments.containsKey(item.id())) {
             Document failedDoc = uploadedDocuments.get(item.id());
-            failedDocs.add(failedDoc);
+            failedDocs.add(Pair.of(failedDoc, item.error().reason()));
           } else {
             throw new IndexerException(item.error().reason());
           }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -24,6 +24,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Arrays;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.Before;
@@ -202,11 +203,11 @@ public class ElasticsearchIndexerTest {
     doc3.setField("other_id", "something_else");
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, mockClient2, "testing");
-    Set<Document> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
+    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
     assertEquals(2, failedDocs.size());
-    assertTrue(failedDocs.contains(doc));
-    assertFalse(failedDocs.contains(doc2));
-    assertTrue(failedDocs.contains(doc3));
+    assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc)));
+    assertFalse(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc2)));
+    assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc3)));
   }
 
   @Test
@@ -744,7 +745,7 @@ public class ElasticsearchIndexerTest {
     }
 
     @Override
-    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.Before;
@@ -222,11 +223,11 @@ public class OpenSearchIndexerTest {
     doc3.setField("other_id", "something_else");
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, mockClient2, "testing");
-    Set<Document> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
+    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
     assertEquals(2, failedDocs.size());
-    assertTrue(failedDocs.contains(doc));
-    assertFalse(failedDocs.contains(doc2));
-    assertTrue(failedDocs.contains(doc3));
+    assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc)));
+    assertFalse(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc2)));
+    assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc3)));
   }
 
   @Test
@@ -891,7 +892,7 @@ public class OpenSearchIndexerTest {
     }
 
     @Override
-    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
@@ -11,6 +11,7 @@ import com.kmwllc.lucille.util.SolrUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
@@ -754,13 +755,14 @@ public class SolrIndexerTest {
 
     SolrIndexer indexer = new SolrIndexer(config, messenger, solrClient, "");
 
-    Set<Document> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
+    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
     assertEquals(2, failedDocs.size());
-    assertTrue(failedDocs.contains(doc));
+    assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc)));
 
     // not sure what is, internally to solr, controlling the ordering behind which document is sent first/not.
     // so, will just check that both of them do not have the same status (failed/succeeded)
-    assertNotEquals(failedDocs.contains(doc2), failedDocs.contains(doc3));
+    assertNotEquals(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc2)),
+        failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc3)));
   }
 
   @Test
@@ -1036,7 +1038,7 @@ public class SolrIndexerTest {
     }
 
     @Override
-    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to Solr are correctly handled");
     }
   }

--- a/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
+++ b/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.protobuf.Struct;
@@ -107,7 +108,7 @@ public class PineconeIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Document> sendToIndex(List<Document> documents) throws IndexerException {
+  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws IndexerException {
     // retrieve documents to delete & upload, mapping id to document
     Map<String, Document> deleteMap = new LinkedHashMap<>();
     Map<String, Document> uploadMap = new LinkedHashMap<>();

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,8 +113,8 @@ public class WeaviateIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Document> sendToIndex(List<Document> documents) throws Exception {
-    Set<Document> failedDocs = new HashSet<>();
+  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
+    Set<Pair<Document, String>> failedDocs = new HashSet<>();
 
     try (ObjectsBatcher batcher = client.batch().objectsBatcher()) {
       Map<String, Document> docGeneratedUUIDMap = new HashMap<>();
@@ -160,7 +161,7 @@ public class WeaviateIndexer extends Indexer {
 
         if (errorResponse != null) {
           Document docWithResponseUUID = docGeneratedUUIDMap.get(response.getId());
-          failedDocs.add(docWithResponseUUID);
+          failedDocs.add(Pair.of(docWithResponseUUID, errorResponse.toString()));
         }
       }
     } catch (Exception e) {

--- a/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
+++ b/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -203,11 +204,12 @@ public class WeaviateIndexerTest {
     Document failedDoc2 = Document.create("failedDoc2", "test_run");
 
     WeaviateIndexer indexer = new WeaviateIndexer(config, messenger, mockClient, "testing");
-    Set<Document> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3, failedDoc1, failedDoc2));
+    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3, failedDoc1, failedDoc2));
 
     assertEquals(2, failedDocs.size());
-    assertTrue(failedDocs.contains(failedDoc1));
-    assertTrue(failedDocs.contains(failedDoc2));
+
+    assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(failedDoc1)));
+    assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(failedDoc2)));
   }
 
   @Test
@@ -266,7 +268,7 @@ public class WeaviateIndexerTest {
     }
 
     @Override
-    public Set<Document> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }


### PR DESCRIPTION
`Indexer.sendToIndex` now returns a `Set` of `Pair`s containing failed Documents as well as a message about why they failed. 