### PR TITLE
LC-691: Document.getFieldNames Preserves Insertion Order

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -528,6 +529,9 @@ public interface Document {
     return Collections.singleton(this).iterator();
   }
 
+  /**
+   * @return A set of field names found on the Document. Preserves insertion order.
+   */
   Set<String> getFieldNames();
 
   Map<String, Object> asMap();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
@@ -641,7 +641,8 @@ public class HashMapDocument implements Document, Serializable {
 
   @Override
   public Set<String> getFieldNames() {
-    return data.getKeys();
+    // will follow the order of iteration
+    return new LinkedHashSet<>(data.getKeys());
   }
 
   @Override

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
@@ -875,12 +875,9 @@ public class JsonDocument implements Document {
 
   @Override
   public Set<String> getFieldNames() {
-    Set<String> fieldNames = new HashSet<String>();
-    Iterator<String> it = data.fieldNames();
-    while (it.hasNext()) {
-      String fieldName = it.next();
-      fieldNames.add(fieldName);
-    }
+    LinkedHashSet<String> fieldNames = new LinkedHashSet<String>();
+    // ObjectNode uses a LinkedHashMap internally, so this iteration will follow insertion order into the ObjectNode.
+    data.fieldNames().forEachRemaining(fieldNames::add);
     return fieldNames;
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/JsonDocumentTest.java
@@ -7,7 +7,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
+import java.util.Set;
 import org.junit.Test;
 
 import java.util.Base64;
@@ -248,4 +252,41 @@ public class JsonDocumentTest extends DocumentTest.NodeDocumentTest {
     assertEquals("r", doc.getString("foo"));
     assertArrayEquals(new byte[]{1, 2, 3}, doc.getBytes("bytes"));
   }
+
+  @Test
+  public void testGetFieldNamesInsertionOrder() {
+    List<Integer> numbers = new ArrayList<>();
+
+    for (int i = 1; i <= 40; i++) {
+      numbers.add(i);
+    }
+
+    // add fields named "1" through "40" in a random order.
+    Collections.shuffle(numbers);
+
+    Document doc = Document.create("test");
+
+    for (Integer num : numbers) {
+      doc.setField(String.valueOf(num), "something");
+    }
+
+    Set<String> fieldNames = doc.getFieldNames();
+
+    Iterator<String> fieldNamesIterator = fieldNames.iterator();
+    // always the first field added to the Document
+    assertEquals("id", fieldNamesIterator.next());
+
+    int fieldNamesParsed = 0;
+
+    while (fieldNamesIterator.hasNext()) {
+      // making sure that the Set returned by getFieldNames preserves insertion order -
+      // should be the same order that they were added above.
+      int currentNum = Integer.parseInt(fieldNamesIterator.next());
+      assertEquals(numbers.get(fieldNamesParsed), Integer.valueOf(currentNum));
+      fieldNamesParsed++;
+    }
+
+    assertEquals(40, fieldNamesParsed);
+  }
+
 }


### PR DESCRIPTION
`ObjectNode` uses a `LinkedHashMap` internally, so we can preserve the ordering by using a `LinkedHashSet` in `getFieldNames`. I added the same behavior to `HashMapDocument` just in case...