### PR TITLE
LC-702: Support "Any Matching" in DictionaryLookup

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
@@ -38,8 +38,9 @@ import org.slf4j.LoggerFactory;
  * <p>  - use_payloads (Boolean, Optional) : denotes whether payloads from the dictionary should be used or not. Defaults to true.
  * <p>  - update_mode (String, Optional) : Determines how writing will be handling if the destination field is already populated.
  *      Can be 'overwrite', 'append' or 'skip'. Defaults to 'overwrite'.
- * <p>  - set_only (Boolean, Optional) : If true, the destination field will be set to true if all values in the source field
- *      are present in the dictionary.
+ * <p>  - set_only (Boolean, Optional) : If true, the destination field will be set to true when a match is found (instead of
+ *      outputting the match itself). You can control this behavior with <code>use_any_match</code> and <code>ignore_missing_source</code>.
+ *      <code>set_only</code> defaults to false.
  * <p>  - use_any_match (Boolean, Optional) : Use in combination with set_only. If true, the destination field will
  *      be set to true if any values in the source field are present in the dictionary. If false, the destination field
  *      will be set to true if all the values in the source field are present in the dictionary. Defaults to false.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,12 +35,15 @@ import org.slf4j.LoggerFactory;
  *       for a 1-1 mapping of results or supply one destination field for all of the source fields to be mapped into.
  * <p>  - dict_path (String) : The path the dictionary to use for matching. If the dict_path begins with "classpath:" the classpath
  *       will be searched for the file. Otherwise, the local file system will be searched.
- * <p>  - use_payloads (Boolean, Optional) : denotes whether paylaods from the dictionary should be used or not. Defaults to true.
+ * <p>  - use_payloads (Boolean, Optional) : denotes whether payloads from the dictionary should be used or not. Defaults to true.
  * <p>  - update_mode (String, Optional) : Determines how writing will be handling if the destination field is already populated.
  *      Can be 'overwrite', 'append' or 'skip'. Defaults to 'overwrite'.
  * <p>  - set_only (Boolean, Optional) : If true, the destination field will be set to true if all values in the source field
  *      are present in the dictionary.
- * <p>  - ignore_missing_source (Boolean, Optional) : Intended to be used in combination with set_only. If true, the destination field
+ * <p>  - use_any_match (Boolean, Optional) : Use in combination with set_only. If true, the destination field will
+ *      be set to true if any values in the source field are present in the dictionary. If false, the destination field
+ *      will be set to true if all the values in the source field are present in the dictionary. Defaults to false.
+ * <p>  - ignore_missing_source (Boolean, Optional) : Use in combination with set_only. If true, the destination field
  *      will be set to true if the source field is missing. Defaults to false.
  *
  * <p>  - s3 (Map, Optional) : If your dictionary files are held in S3. See FileConnector for the appropriate arguments to provide.
@@ -55,6 +59,7 @@ public class DictionaryLookup extends Stage {
   private final UpdateMode updateMode;
   private final boolean ignoreCase;
   private final boolean setOnly;
+  private final boolean useAnyMatch;
   private final boolean ignoreMissingSource;
 
   private Map<String, List<String>> dict;
@@ -63,7 +68,7 @@ public class DictionaryLookup extends Stage {
 
   public DictionaryLookup(Config config) throws StageException {
     super(config, Spec.stage().withRequiredProperties("source", "dest", "dict_path")
-        .withOptionalProperties("use_payloads", "update_mode", "ignore_case", "set_only", "ignore_missing_source")
+        .withOptionalProperties("use_payloads", "update_mode", "ignore_case", "set_only", "use_any_match", "ignore_missing_source")
         .withOptionalParents(FileConnector.S3_PARENT_SPEC, FileConnector.GCP_PARENT_SPEC, FileConnector.AZURE_PARENT_SPEC));
 
     this.sourceFields = config.getStringList("source");
@@ -72,6 +77,7 @@ public class DictionaryLookup extends Stage {
     this.updateMode = UpdateMode.fromConfig(config);
     this.ignoreCase = ConfigUtils.getOrDefault(config, "ignore_case", false);
     this.setOnly = ConfigUtils.getOrDefault(config, "set_only", false);
+    this.useAnyMatch = ConfigUtils.getOrDefault(config, "use_any_match", false);
     this.ignoreMissingSource = ConfigUtils.getOrDefault(config, "ignore_missing_source", false);
     this.dictPath = config.getString("dict_path");
   }
@@ -82,9 +88,14 @@ public class DictionaryLookup extends Stage {
     StageUtils.validateFieldNumNotZero(destFields, "Dictionary Lookup");
     StageUtils.validateFieldNumsSeveralToOne(sourceFields, destFields, "Dictionary Lookup");
 
-    if (ignoreMissingSource && !setOnly) {
+    if (config.hasPath("use_any_match") && !setOnly) {
       log.warn("ignore_missing_source is only valid when set_only is true. Ignoring.");
     }
+
+    if (config.hasPath("ignore_missing_source") && !setOnly) {
+      log.warn("ignore_missing_source is only valid when set_only is true. Ignoring.");
+    }
+
     if (setOnly && updateMode != UpdateMode.OVERWRITE) {
       throw new StageException("when set_only is true, update_mode must be set to overwrite");
     }
@@ -114,10 +125,14 @@ public class DictionaryLookup extends Stage {
           // if ignoreMissingSource is true, set the destination field to true if the source field is missing
           currentValue = ignoreMissingSource;
         } else {
-          // check if all values in the source field are in the dictionary
-          currentValue = doc.getStringList(sourceField).stream()
-              .map(ignoreCase ? String::toLowerCase : String::toString)
-              .allMatch(dict::containsKey);
+          Stream<String> sourceStream = doc.getStringList(sourceField).stream()
+              .map(ignoreCase ? String::toLowerCase : String::toString);
+
+          if (useAnyMatch) {
+            currentValue = sourceStream.anyMatch(dict::containsKey);
+          } else {
+            currentValue = sourceStream.allMatch(dict::containsKey);
+          }
         }
 
         doc.update(destField, updateMode, defaultValue && currentValue);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/DictionaryLookup.java
@@ -88,12 +88,12 @@ public class DictionaryLookup extends Stage {
     StageUtils.validateFieldNumNotZero(destFields, "Dictionary Lookup");
     StageUtils.validateFieldNumsSeveralToOne(sourceFields, destFields, "Dictionary Lookup");
 
-    if (config.hasPath("use_any_match") && !setOnly) {
+    if (config.hasPath("ignore_missing_source") && !setOnly) {
       log.warn("ignore_missing_source is only valid when set_only is true. Ignoring.");
     }
 
-    if (config.hasPath("ignore_missing_source") && !setOnly) {
-      log.warn("ignore_missing_source is only valid when set_only is true. Ignoring.");
+    if (config.hasPath("use_any_match") && !setOnly) {
+      log.warn("use_any_match is only valid when set_only is true. Ignoring.");
     }
 
     if (setOnly && updateMode != UpdateMode.OVERWRITE) {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DictionaryLookupTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DictionaryLookupTest.java
@@ -85,6 +85,7 @@ public class DictionaryLookupTest {
             "class",
             "dict_path",
             "set_only",
+            "use_any_match",
             "ignore_missing_source",
             "conditionPolicy"),
         stage.getLegalProperties());
@@ -113,6 +114,40 @@ public class DictionaryLookupTest {
     doc2.setField("field", "a");
     stage.processDocument(doc2);
     assertTrue(doc2.getBoolean("setContains"));
+
+    // default to using all match - "SOMETHING_ELSE" not in the dictionary
+    Document doc3 = Document.create("doc3");
+    doc3.setOrAdd("field", "a");
+    doc3.setOrAdd("field", "SOMETHING_ELSE");
+    stage.processDocument(doc3);
+    assertFalse(doc3.getBoolean("setContains"));
+  }
+
+  @Test
+  public void testSetLookupAnyMatch() throws StageException {
+    Stage stage = factory.get("DictionaryLookupTest/set_config_any_match.conf");
+
+    Document doc = Document.create("id");
+    doc.setField("field", "a");
+    stage.processDocument(doc);
+    assertTrue(doc.getBoolean("setContains"));
+
+    doc.setField("field", "hello world");
+    stage.processDocument(doc);
+    assertFalse(doc.getBoolean("setContains"));
+
+    // value preserved in the set after it was found
+    Document doc2 = Document.create("id2");
+    doc2.setField("field", "a");
+    stage.processDocument(doc2);
+    assertTrue(doc2.getBoolean("setContains"));
+
+    // default to using any match - "SOMETHING_ELSE" not in the dictionary
+    Document doc3 = Document.create("doc3");
+    doc3.setOrAdd("field", "a");
+    doc3.setOrAdd("field", "SOMETHING_ELSE");
+    stage.processDocument(doc3);
+    assertTrue(doc3.getBoolean("setContains"));
   }
 
   @Test

--- a/lucille-core/src/test/resources/DictionaryLookupTest/set_config_any_match.conf
+++ b/lucille-core/src/test/resources/DictionaryLookupTest/set_config_any_match.conf
@@ -1,0 +1,8 @@
+{
+  class = "com.kmwllc.lucille.stage.DictionaryLookup"
+  source = ["field"]
+  dest = ["setContains"]
+  dict_path = "classpath:DictionaryLookupTest/set.txt"
+  set_only = true
+  use_any_match = true
+}


### PR DESCRIPTION
When you use `set_only`, you can control whether it uses any or all matching with the optional `use_any_match` parameter. It defaults to `false`, so existing configs will not be changed.