### PR TITLE
LC-705: Update FileConnector Configs in lucille-example

### DIFF
--- a/lucille-examples/lucille-distributed-example/conf/main.conf
+++ b/lucille-examples/lucille-distributed-example/conf/main.conf
@@ -4,7 +4,7 @@ connectors: [
     name: "file_connector_for_csv"
     pipeline: "simple_pipeline"
     pathsToStorage: ["conf/source.csv", "conf/source.jsonl"]
-    fileOptions: {
+    fileHandlers: {
       csv { }
       json { }
     }

--- a/lucille-examples/lucille-file-to-file-example/conf/csv-connector.conf
+++ b/lucille-examples/lucille-file-to-file-example/conf/csv-connector.conf
@@ -3,6 +3,6 @@ class: "com.kmwllc.lucille.connector.FileConnector"
 name: "csv_connector"
 pathsToStorage: ["conf/source.csv"]
 pipeline: "simple_pipeline"
-fileOptions: {
+fileHandlers: {
   csv: { }
 }

--- a/lucille-examples/lucille-file-to-file-example/conf/json-connector.conf
+++ b/lucille-examples/lucille-file-to-file-example/conf/json-connector.conf
@@ -3,6 +3,6 @@ class: "com.kmwllc.lucille.connector.FileConnector"
 name: "json_connector"
 pathsToStorage: ["conf/source.jsonl"]
 pipeline: "simple_pipeline"
-fileOptions: {
+fileHandlers: {
   json: { }
 }

--- a/lucille-examples/lucille-simple-csv-solr-example/conf/simple-csv-solr-example.conf
+++ b/lucille-examples/lucille-simple-csv-solr-example/conf/simple-csv-solr-example.conf
@@ -6,7 +6,7 @@ connectors: [
     pathsToStorage: ["conf/songs.csv"],
     name: "connector1",
     pipeline: "pipeline1"
-    fileOptions: {
+    fileHandlers: {
       csv: { }
     }
   }

--- a/lucille-examples/lucille-vector-ingest-example/conf/10M-parquet-pinecone.conf
+++ b/lucille-examples/lucille-vector-ingest-example/conf/10M-parquet-pinecone.conf
@@ -86,7 +86,7 @@ log {
   seconds: 30 # how often components (Publisher, Worker, Indexer) should log a status update
 }
 runner {
-  #umncomment to output detailed metrics to the main lucille log at the end of each run
+  #uncomment to output detailed metrics to the main lucille log at the end of each run
   #metricsLoggingLevel: "INFO"
 }
 # solr {


### PR DESCRIPTION
Since we merged in a lot of tickets - which included a lot of changes, especially to the FileConnector - some of the configs in lucille-example are technically invalid, but sneak through the ConfigValidationTest. For example, in the simple CSV Solr example:
```hocon
{
    class: "com.kmwllc.lucille.connector.FileConnector",
    pathsToStorage: ["conf/songs.csv"],
    name: "connector1",
    pipeline: "pipeline1"
    fileOptions: {
      csv: { }
   }
}
```

This PR updates the FileConnector configs in the `lucille-examples`