### PR TITLE
LC-710: Update top level README to link to documentation website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-
 # Lucille
 
 Lucille is a production-grade Search ETL solution.
 
-Search ETL is a category of ETL problem where data must be extracted from a source system, transformed, and loaded into a *search engine*.
+Search ETL is a category of ETL problem where data must be extracted from a source system, transformed, and loaded into a _search engine_.
 
-A Search ETL solution must speak the language of search: it must represent data in the form of search-engine-ready Documents, it must know how to *enrich* Documents to support common search use cases, and it must follow best practices for interacting with search engines including support for batching, routing, and versioning. 
+A Search ETL solution must speak the language of search: it must represent data in the form of search-engine-ready Documents, it must know how to _enrich_ Documents to support common search use cases, and it must follow best practices for interacting with search engines including support for batching, routing, and versioning.
 
-To be production-grade, a search ETL solution must be scalable, reliable, and easy to use. It should support parallel Document processing, it should be observable, it should be easy to configure, it should have extensive test coverage, and it should have been hardened through multiple challenging real-world deployments. 
+To be production-grade, a search ETL solution must be scalable, reliable, and easy to use. It should support parallel Document processing, it should be observable, it should be easy to configure, it should have extensive test coverage, and it should have been hardened through multiple challenging real-world deployments.
 
 Lucille handles all of these things so you don't have to. Lucille helps you get your data into Lucene-based search engines like Apache Solr, Elasticsearch, or OpenSearch as well as vector-based search engines like Pinecone and Weaviate, and it helps you keep that search engine content up-to-date as your backend data changes. Lucille does this in a way that scales as your data volume grows, and in a way that's easy to evolve as your data transformation requirements become more complex. Lucille implements search best practices so you can stay focused on your data itself and what you want to do with it.
 
@@ -21,12 +20,11 @@ At the top level of the project, run:
 
 `mvn clean install`
 
-
 ## Getting Started
 
-Lucille includes a few examples in the `lucille-examples` module to help you get started. 
+Lucille includes a few examples in the `lucille-examples` module to help you get started.
 
-To see how to ingest the contents of a local CSV file into an instance of Apache Solr, refer to `lucille-examples/simple-csv-solr-example`. 
+To see how to ingest the contents of a local CSV file into an instance of Apache Solr, refer to `lucille-examples/simple-csv-solr-example`.
 
 To run this example, start an instance of Apache Solr on port 8983 and create a collection called `quickstart`. For more information about how to use Solr, see the [Apache Solr Reference Guide](https://solr.apache.org/guide/solr/latest/getting-started/introduction.html)).
 
@@ -44,8 +42,7 @@ Run a commit with `openSearcher=true` on your `quickstart` collection to make th
 
 ## More Information
 
-The Lucille project is developed and maintained by KMW Technology ([kmwllc.com](https://kmwllc.com/)). 
+The Lucille project is developed and maintained by KMW Technology ([kmwllc.com](https://kmwllc.com/)).
 For more information regarding Lucille, please [contact us](https://kmwllc.com/index.php/contact-us/).
 
-
-
+For documentation, setup information, and configuration reference, please visit the Lucille [documentation site](https://kmwtechnology.github.io/lucille/docs/introduction/).


### PR DESCRIPTION
Added a new line under the 'More Information' section of the top level README to point users towards the documentation website.