### PR TITLE
LC-717: Upgraded elasticsearch-java version to 8.18.4, removed rest-high-level-client

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -40,22 +40,7 @@
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
-      <version>8.6.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-high-level-client</artifactId>
-      <version>${elasticsearch-rest-high-level-client.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.elasticsearch</groupId>
-          <artifactId>elasticsearch</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.elasticsearch.client</groupId>
-          <artifactId>elasticsearch-rest-client</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>${elasticsearch.version}</version>
     </dependency>
 
   <!-- dependency to allow json logging for log4j -->

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -51,8 +51,7 @@
     <opensearch-java.version>2.11.1</opensearch-java.version>
     <httpcore5.version>5.2.4</httpcore5.version>
     <httpclient5.version>5.3.1</httpclient5.version>
-    <elasticsearch-rest-high-level-client.version>7.17.3</elasticsearch-rest-high-level-client.version>
-    <elasticsearch.version>7.17.3</elasticsearch.version>
+    <elasticsearch.version>8.18.4</elasticsearch.version>
     <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>
     <aws-java-sdk.version>1.12.769</aws-java-sdk.version>
     <log4j.version>2.20.0</log4j.version>


### PR DESCRIPTION
Upgraded the elasticsearch version to 8.18.4 and removed the elasticsearch-rest-high-level-client dependency.