### PR TITLE
LC-719: JsonFileHandler Id Fields

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
@@ -1,15 +1,22 @@
 package com.kmwllc.lucille.core.fileHandler;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.Spec.ParentSpec;
 import com.typesafe.config.Config;
+import dev.langchain4j.agent.tool.P;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.UnaryOperator;
 import org.apache.commons.io.IOUtils;
@@ -19,14 +26,28 @@ import org.slf4j.LoggerFactory;
 
 public class JsonFileHandler extends BaseFileHandler {
 
-  public static final Spec SPEC = Spec.fileHandler();
+  public static final Spec SPEC = Spec.fileHandler()
+      .optionalString("docIdFormat", "idField")
+      .optionalList("idFields", new TypeReference<List<String>>() {
+      });
 
   private static final Logger log = LoggerFactory.getLogger(JsonFileHandler.class);
 
   private final UnaryOperator<String> idUpdater;
+  private final List<String> idFields;
+  private final String docIdFormat;
+  private final ObjectMapper mapper = new ObjectMapper();
 
   public JsonFileHandler(Config config) {
     super(config);
+
+    if (config.hasPath("idField")) {
+      this.idFields = List.of(config.getString("idField"));
+    } else {
+      this.idFields = config.hasPath("idFields") ? config.getStringList("idFields") : List.of();
+    }
+
+    this.docIdFormat = config.hasPath("docIdFormat") ? config.getString("docIdFormat") : null;
 
     this.idUpdater = (id) -> docIdPrefix + id;
   }
@@ -70,12 +91,28 @@ public class JsonFileHandler extends BaseFileHandler {
 
         String line = it.next();
         try {
-          return Document.createFromJson(line, idUpdater);
+          if (!idFields.isEmpty()) {
+            ObjectNode node = (ObjectNode) mapper.readTree(line);
+            List<String> parts = new ArrayList<>(idFields.size());
+
+            for (String f : idFields) {
+              JsonNode v = node.get(f);
+              parts.add((v != null && !v.isNull()) ? v.asText() : "");
+            }
+
+            String rawId = (docIdFormat != null) ? String.format(docIdFormat, parts.toArray()) : String.join("_", parts);
+            node.put(Document.ID_FIELD, docIdPrefix + rawId);
+
+            return Document.create(node);
+          } else {
+            return Document.createFromJson(line, idUpdater);
+          }
         } catch (Exception e) {
           // any errors that occur during the process of creating a document, we close the LineIterator
           // cannot close iterator in finally, as we will called next() again if there are more elements.
           IOUtils.closeQuietly(it);
-          throw new RuntimeException("Error creating document, make sure that you have 'id' key within each line of json", e);
+          throw new RuntimeException(
+              "Error creating document, make sure that you have id field(s) properly configured within each line of json", e);
         }
       }
     };

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
@@ -91,7 +91,9 @@ public class JsonFileHandler extends BaseFileHandler {
 
         String line = it.next();
         try {
-          if (!idFields.isEmpty()) {
+          if (idFields.isEmpty()) {
+            return Document.createFromJson(line, idUpdater);
+          } else {
             ObjectNode node = (ObjectNode) mapper.readTree(line);
             List<String> parts = new ArrayList<>(idFields.size());
 
@@ -104,8 +106,6 @@ public class JsonFileHandler extends BaseFileHandler {
             node.put(Document.ID_FIELD, docIdPrefix + rawId);
 
             return Document.create(node);
-          } else {
-            return Document.createFromJson(line, idUpdater);
           }
         } catch (Exception e) {
           // any errors that occur during the process of creating a document, we close the LineIterator

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
@@ -8,7 +8,6 @@ import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.SpecBuilder;
 import com.typesafe.config.Config;
-import dev.langchain4j.agent.tool.P;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -24,6 +23,14 @@ import org.apache.commons.io.LineIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A file handler for JSON lines.
+ * <p>
+ * Reads each line as a JSON object and builds a {@link Document}.
+ * <p>
+ * <b>Note:</b> if your input JSON has its own "id" field but you've configured a different field for IDs, your original
+ * "id" will be overwritten by the generated one in the documents.
+ */
 public class JsonFileHandler extends BaseFileHandler {
 
   public static final Spec SPEC = SpecBuilder.fileHandler()
@@ -97,9 +104,9 @@ public class JsonFileHandler extends BaseFileHandler {
             ObjectNode node = (ObjectNode) mapper.readTree(line);
             List<String> parts = new ArrayList<>(idFields.size());
 
-            for (String f : idFields) {
-              JsonNode v = node.get(f);
-              parts.add((v != null && !v.isNull()) ? v.asText() : "");
+            for (String fieldName : idFields) {
+              JsonNode valueNode = node.get(fieldName);
+              parts.add((valueNode != null && !valueNode.isNull()) ? valueNode.asText() : "");
             }
 
             String rawId = (docIdFormat != null) ? String.format(docIdFormat, parts.toArray()) : String.join("_", parts);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandlerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandlerTest.java
@@ -146,35 +146,35 @@ public class JsonFileHandlerTest {
   @Test
   public void testSingleIdField() throws Exception {
     Config config = ConfigFactory.parseMap(Map.of(
-        "json", Map.of("idField", "id", "docIdPrefix", "")
+        "json", Map.of("idField", "field1", "docIdPrefix", "")
     ));
     FileHandler handler = FileHandler.create("json", config);
 
-    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/default.jsonl";
+    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl";
     File file = new File(filePath);
 
     Iterator<Document> docs = handler.processFile(new FileInputStream(file), filePath);
     Document d1 = docs.next(), d2 = docs.next(), d3 = docs.next();
-    assertEquals("1", d1.getId());
-    assertEquals("2", d2.getId());
-    assertEquals("3", d3.getId());
+    assertEquals("one", d1.getId());
+    assertEquals("two", d2.getId());
+    assertEquals("three", d3.getId());
     assertFalse(docs.hasNext());
   }
 
   @Test
   public void testCompositeIdFieldsDefaultJoin() throws Exception {
     Config config = ConfigFactory.parseMap(Map.of(
-        "json", Map.of("idFields", List.of("id", "id"), "docIdPrefix", "")
+        "json", Map.of("idFields", List.of("field1", "field2"), "docIdPrefix", "")
     ));
     FileHandler handler = FileHandler.create("json", config);
 
-    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/default.jsonl";
+    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl";
     File file = new File(filePath);
 
     Iterator<Document> docs = handler.processFile(new FileInputStream(file), filePath);
-    assertEquals("1_1", docs.next().getId());
-    assertEquals("2_2", docs.next().getId());
-    assertEquals("3_3", docs.next().getId());
+    assertEquals("one_1", docs.next().getId());
+    assertEquals("two_2", docs.next().getId());
+    assertEquals("three_3", docs.next().getId());
     assertFalse(docs.hasNext());
   }
 
@@ -182,14 +182,14 @@ public class JsonFileHandlerTest {
   public void testCompositeWithDocIdFormat() throws Exception {
     Config config = ConfigFactory.parseMap(Map.of(
         "json", Map.of(
-            "idFields", List.of("id", "id"),
+            "idFields", List.of("field2", "field2"),
             "docIdFormat", "%s-%s",
             "docIdPrefix", ""
         )
     ));
     FileHandler handler = FileHandler.create("json", config);
 
-    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/default.jsonl";
+    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl";
     File file = new File(filePath);
 
     Iterator<Document> docs = handler.processFile(new FileInputStream(file), filePath);
@@ -203,36 +203,36 @@ public class JsonFileHandlerTest {
   public void testIdFieldPrecedenceOverIdFields() throws Exception {
     Config config = ConfigFactory.parseMap(Map.of(
         "json", Map.of(
-            "idField", "id",
-            "idFields", List.of("field1", "id")
+            "idField", "field1",
+            "idFields", List.of("field2", "field2")
         )
     ));
     FileHandler handler = FileHandler.create("json", config);
 
-    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/default.jsonl";
+    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl";
     File file = new File(filePath);
 
     Iterator<Document> docs = handler.processFile(new FileInputStream(file), filePath);
-    assertEquals("1", docs.next().getId());
-    assertEquals("2", docs.next().getId());
-    assertEquals("3", docs.next().getId());
+    assertEquals("one", docs.next().getId());
+    assertEquals("two", docs.next().getId());
+    assertEquals("three", docs.next().getId());
     assertFalse(docs.hasNext());
   }
 
   @Test
   public void testMissingCompositeFieldProducesBlankSegment() throws Exception {
     Config config = ConfigFactory.parseMap(Map.of(
-        "json", Map.of("idFields", List.of("field1", "id"))
+        "json", Map.of("idFields", List.of("field2", "field3"))
     ));
     FileHandler handler = FileHandler.create("json", config);
 
-    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/default.jsonl";
+    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl";
     File file = new File(filePath);
 
     Iterator<Document> docs = handler.processFile(new FileInputStream(file), filePath);
-    assertEquals("val1-1_1", docs.next().getId()); // first line has field1
-    assertEquals("_2", docs.next().getId()); // second line missing field1
-    assertEquals("_3", docs.next().getId()); // third line missing field1
+    assertEquals("1_test", docs.next().getId()); // first line has field3
+    assertEquals("2_", docs.next().getId()); // second line missing field3
+    assertEquals("3_", docs.next().getId()); // third line missing field3
     assertFalse(docs.hasNext());
   }
 
@@ -241,18 +241,18 @@ public class JsonFileHandlerTest {
     Config config = ConfigFactory.parseMap(Map.of(
         "json", Map.of(
             "docIdPrefix", "PREFIX-",
-            "idFields", List.of("id", "id")
+            "idFields", List.of("field1", "field2")
         )
     ));
     FileHandler handler = FileHandler.create("json", config);
 
-    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/default.jsonl";
+    String filePath = "src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl";
     File file = new File(filePath);
 
     Iterator<Document> docs = handler.processFile(new FileInputStream(file), filePath);
-    assertEquals("PREFIX-1_1", docs.next().getId());
-    assertEquals("PREFIX-2_2", docs.next().getId());
-    assertEquals("PREFIX-3_3", docs.next().getId());
+    assertEquals("PREFIX-one_1", docs.next().getId());
+    assertEquals("PREFIX-two_2", docs.next().getId());
+    assertEquals("PREFIX-three_3", docs.next().getId());
     assertFalse(docs.hasNext());
   }
 }

--- a/lucille-core/src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl
+++ b/lucille-core/src/test/resources/FileHandlerTest/JsonFileHandlerTest/noids.jsonl
@@ -1,0 +1,3 @@
+{"field1":"one", "field2":"1", "field3":"test"}
+{"field1":"two", "field2":"2"}
+{"field1":"three", "field2":"3"}


### PR DESCRIPTION
Added functionality to JsonFileHandler to declare a single or composite id field and an id format similar to that of CsvFileHandler.