### PR TITLE
LC-722: FileHandler warning on empty or null idFields

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/CSVFileHandler.java
@@ -161,6 +161,20 @@ public class CSVFileHandler extends BaseFileHandler {
       for (Integer idx : idColumns) {
         idColumnData.add(line[idx]);
       }
+
+      List<String> blankIdFields = new ArrayList<>();
+      for (int fieldIndex = 0; fieldIndex < idColumnData.size(); fieldIndex++) {
+        String fieldValue = idColumnData.get(fieldIndex);
+        if (StringUtils.isBlank(fieldValue)) {
+          String fieldName = (fieldIndex < idFields.size()) ? idFields.get(fieldIndex) : ("index:" + fieldIndex);
+          blankIdFields.add(fieldName);
+        }
+      }
+
+      if (!blankIdFields.isEmpty()) {
+        log.warn("Missing/blank idFields {} at logical row {}. ({})", blankIdFields, lineNum, path);
+      }
+
       docId = createDocId(idColumnData);
     } else {
       // a default unique id for a csv file is filename + line num

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/fileHandler/JsonFileHandler.java
@@ -112,10 +112,20 @@ public class JsonFileHandler extends BaseFileHandler {
           } else {
             ObjectNode node = (ObjectNode) mapper.readTree(line);
             List<String> parts = new ArrayList<>(idFields.size());
+            List<String> blankIdFields = new ArrayList<>();
 
             for (String fieldName : idFields) {
               JsonNode valueNode = node.get(fieldName);
               parts.add((valueNode != null && !valueNode.isNull()) ? valueNode.asText() : "");
+              String value = (valueNode != null && !valueNode.isNull()) ? valueNode.asText() : null;
+              parts.add(value != null ? value : "");
+              if (StringUtils.isBlank(value)) {
+                blankIdFields.add(fieldName);
+              }
+            }
+
+            if (!blankIdFields.isEmpty()) {
+              log.warn("Missing/blank idFields {} at line {}. ({})", blankIdFields, lineNum, path);
             }
 
             String rawId = (docIdFormat != null) ? String.format(docIdFormat, parts.toArray()) : String.join("_", parts);


### PR DESCRIPTION
Added warnings to CSV and JSON file handlers for when an id field is either empty or null. Not implemented for XML since it doesn't support multiple idFields.