### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -236,8 +236,8 @@
     <!-- SSL Context Kickstart -->
     <dependency>
       <groupId>io.github.hakky54</groupId>
-      <artifactId>sslcontext-kickstart</artifactId>
-      <version>${sslcontext-kickstart.version}</version>
+      <artifactId>ayza</artifactId>
+      <version>${ayza.version}</version>
     </dependency>
 
     <!-- FileConnector -->

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -52,7 +52,7 @@
     <httpcore5.version>5.2.4</httpcore5.version>
     <httpclient5.version>5.3.1</httpclient5.version>
     <elasticsearch.version>8.18.4</elasticsearch.version>
-    <sslcontext-kickstart.version>8.1.6</sslcontext-kickstart.version>
+    <ayza.version>10.0.0</ayza.version>
     <aws-java-sdk.version>1.12.769</aws-java-sdk.version>
     <log4j.version>2.20.0</log4j.version>
     <slf4j.version>2.0.7</slf4j.version>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience