### PR TITLE
FIX - FileConnector: it always pushes already published files even if they haven't been modified since last publish

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -1,6 +1,20 @@
 package com.kmwllc.lucille.connector;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.kmwllc.lucille.connector.storageclient.BaseFileReference;
 import com.kmwllc.lucille.connector.storageclient.StorageClient;
 import com.kmwllc.lucille.connector.storageclient.TraversalParams;
 import com.kmwllc.lucille.connector.storageclient.TraversalParams.PublishMode;
@@ -9,15 +23,6 @@ import com.kmwllc.lucille.core.Publisher;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.SpecBuilder;
 import com.typesafe.config.Config;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Traverses local and cloud storage (S3, GCP, Azure) from one or more roots and publishes a Document for each file encountered.
@@ -77,6 +82,7 @@ public class FileConnector extends AbstractConnector {
   public static final String CREATED = "file_creation_date";
   public static final String SIZE = "file_size_bytes";
   public static final String CONTENT = "file_content";
+  public static final String EXPIRED = "file_expired";
   public static final String ARCHIVE_FILE_SEPARATOR = "!";
 
   // cloudOption Keys
@@ -175,56 +181,133 @@ public class FileConnector extends AbstractConnector {
   @Override
   public void execute(Publisher publisher) throws ConnectorException {
     try {
-      try {
-        for (StorageClient client : storageClientMap.values()) {
-          client.init();
-        }
-      } catch (IOException e) {
-        throw new ConnectorException("Error initializing a StorageClient.", e);
-      }
+        initialize();
 
-      if (stateManager != null) {
-        try {
-          stateManager.init();
-        } catch (Exception e) {
-          throw new ConnectorException("Error occurred initializing StorageClientStateManager.", e);
-        }
-      }
-
-      for (URI pathToTraverse : storageURIs) {
-        String clientKey = pathToTraverse.getScheme() != null ? pathToTraverse.getScheme() : "file";
-        StorageClient storageClient = storageClientMap.get(clientKey);
-
-        if (storageClient == null) {
-          throw new ConnectorException("No StorageClient was available for (" + pathToTraverse + "). Did you include the necessary configuration?");
+        // discover and publish all valid file candidates
+        for (URI resource : storageURIs) {
+          traverseStoragePath(publisher, resource);
         }
 
-        // creating a new traversal params for each path, which includes rereading file/filterOptions and
-        // creating the FileHandlers map. FileHandlers are lightweight, so this is not an intensive operation.
-        TraversalParams params = new TraversalParams(config, pathToTraverse, getDocIdPrefix());
+        // find files no longer in datastore that need to be removed from index
+        sendExpiredFileTombstones(publisher);
 
-        try {
-          storageClient.traverse(publisher, params, stateManager);
-        } catch (Exception e) {
-          throw new ConnectorException("Error occurred while traversing " + pathToTraverse + ".", e);
-        }
-      }
     } finally {
-      for (StorageClient client : storageClientMap.values()) {
+        shutdown();
+    }
+  }
+
+  // stateful only: publish tombstones for files seen during prior ingests but not the current
+  // todo: add 'missing' count column to track how many times we've not seen document
+  // so there is an option to not instantly delete it the first time but only if it
+  // has been missing from multiple runs. Or attach a TTL timestamp or LAST_SEEN 
+  // timestamp so a delete policy can be set like "send tombstone if document has been
+  // gone for more than 16 hours", etc. Just a tunable safety measure.
+  private void sendExpiredFileTombstones(Publisher publisher) throws ConnectorException {
+    // skip if state not being managed
+    if (stateManager == null) return;
+
+    try {
+      List<URI> expiredFileUris = stateManager.listExpiredFiles();
+      if (expiredFileUris.isEmpty()) return;
+      var expiredFileCount = expiredFileUris.size();
+      var publishedFileCount = 0;
+      // indexer.idOverrideField: "docId"
+      log.info("{} previously published files now missing/expired, publishing document tombstones...", expiredFileCount);
+      for (URI uri : expiredFileUris) {
+        var ref = TombstoneFileReference.of(uri);
+        var doc = ref.asDoc(buildTraversalParams(uri));
+        doc.setField(EXPIRED, true);
         try {
-          client.shutdown();
-        } catch (IOException e) {
-          log.warn("Error shutting down StorageClient.", e);
+          publisher.publish(doc);
+          publishedFileCount++;
+        } catch (Exception e) {
+          log.warn("Error occurred while publishing document tombstone for file: %s".formatted(uri), e);
         }
       }
+      log.info("Published {} of {} document tombstones for tracking and index removal", publishedFileCount, expiredFileCount);
+    } catch (SQLException e) {
+      log.warn("Error occurred while publishing missing document tombstones.", e);
+    }
 
-      if (stateManager != null) {
-        try {
-          stateManager.shutdown();
-        } catch (SQLException e) {
-          log.warn("Error occurred while shutting down FileConnectorStateManager.", e);
-        }
+  }
+
+  private void initialize() throws ConnectorException {
+    try {
+      for (StorageClient client : storageClientMap.values()) {
+        client.init();
+      }
+    } catch (IOException e) {
+      throw new ConnectorException("Error initializing a StorageClient.", e);
+    }
+    try {
+      stateManager.init();
+    } catch (Exception e) {
+      throw new ConnectorException("Error occurred initializing StorageClientStateManager.", e);
+    }
+  }
+
+  private void shutdown() {
+    if (stateManager != null) {
+      try {
+        stateManager.shutdown();
+      } catch (SQLException e) {
+        log.warn("Error occurred while shutting down FileConnectorStateManager.", e);
+      }
+    }
+    for (StorageClient client : storageClientMap.values()) {
+      try {
+        client.shutdown();
+      } catch (IOException e) {
+        log.warn("Error shutting down StorageClient.", e);
       }
     }
   }
+
+  private void traverseStoragePath(Publisher publisher, URI pathToTraverse) throws ConnectorException {
+    String clientKey = pathToTraverse.getScheme() != null ? pathToTraverse.getScheme() : "file";
+    StorageClient storageClient = storageClientMap.get(clientKey);
+
+    if (storageClient == null) {
+      throw new ConnectorException("No StorageClient was available for (" + pathToTraverse +
+          "). Did you include the necessary configuration?");
+    }
+
+    TraversalParams params = buildTraversalParams(pathToTraverse);
+
+    try {
+      storageClient.traverse(publisher, params, (FileConnectorStateManager) stateManager);
+    } catch (Exception e) {
+      throw new ConnectorException("Error occurred while traversing " + pathToTraverse + ".", e);
+    }
+  }
+
+  private TraversalParams buildTraversalParams(URI pathToTraverse) {
+    return new TraversalParams(config, pathToTraverse, getDocIdPrefix());
+  }
+
+  // helper class for building document tombstones
+  protected static class TombstoneFileReference extends BaseFileReference {
+
+    public TombstoneFileReference(URI pathToFile, Instant lastModified, Long size, Instant created) {
+      super(pathToFile, lastModified, size, created);
+    }
+
+    public static TombstoneFileReference of(URI uri) {
+      Instant now = Instant.now();
+      return new TombstoneFileReference(uri, now, 0L, now);
+    }
+
+    @Override
+    public String getName() { throw new UnsupportedOperationException("Unimplemented method 'getName'"); }
+
+    @Override
+    public boolean isValidFile() { return true; }
+
+    @Override
+    public InputStream getContentStream(TraversalParams params) { return InputStream.nullInputStream(); }
+
+    @Override
+    protected byte[] getFileContent(TraversalParams params) { return new byte[0]; }
+  }
+
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -160,11 +160,11 @@ public class FileConnector extends AbstractConnector {
 
     this.storageClientMap = StorageClient.createClients(config);
 
-    // if publishMode was specifically defined as "incremental", throw a warning if state not defined
+    // incremental mode requires state tracking in order to function correctly
     if (config.hasPath("filterOptions.publishMode")) {
       var mode = PublishMode.fromString(config.getString("filterOptions.publishMode"));
       if (mode == PublishMode.INCREMENTAL && !config.hasPath("state")) {
-        log.warn("filterOptions.publishMode of 'incremental' was specified, but no state configuration was provided. Incremental mode not supported with current config.");        
+        throw new IllegalArgumentException("filterOptions.publishMode of 'incremental' requires state configuration.");
       }
     }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -239,10 +239,12 @@ public class FileConnector extends AbstractConnector {
     } catch (IOException e) {
       throw new ConnectorException("Error initializing a StorageClient.", e);
     }
-    try {
-      stateManager.init();
-    } catch (Exception e) {
-      throw new ConnectorException("Error occurred initializing StorageClientStateManager.", e);
+    if (stateManager != null) {
+      try {
+        stateManager.init();
+      } catch (Exception e) {
+        throw new ConnectorException("Error occurred initializing StorageClientStateManager.", e);
+      }
     }
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
@@ -8,8 +8,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,7 +59,7 @@ public class FileConnectorStateManager {
   private final boolean performDeletions;
   private final int pathLength;
 
-  private final Timestamp traversalTimestamp = Timestamp.from(Instant.now());
+  private final Instant traversalInstant = Instant.now();
 
   private Connection jdbcConnection;
   private PreparedStatement queryStatement;
@@ -104,7 +104,7 @@ public class FileConnectorStateManager {
       if (!rs.next()) {
         try (Statement statement = jdbcConnection.createStatement()) {
           statement.executeUpdate("CREATE TABLE \"" + tableName + "\" (name VARCHAR(" + pathLength
-              + ") PRIMARY KEY, last_published TIMESTAMP, encountered BOOLEAN)");
+              + ") PRIMARY KEY, last_published TIMESTAMP WITH TIME ZONE, encountered BOOLEAN)");
         }
       }
     }
@@ -174,9 +174,9 @@ public class FileConnectorStateManager {
    * Needed to support publishing document tombstones suggestion: we should add
    * options for setting what is "expired" to include as a safety measure so
    * transient upstream source flakiness doesn't immediately cause content to be
-   * deleted from index 
+   * deleted from index
    * - expiredFileRetryCutoff [1..N]
-   *   file has to be missing N times before marked as expired) 
+   *   file has to be missing N times before marked as expired)
    * - expiredFileDurationCutoff [Duration]
    *   Amount if time file must be missing before marked as expired)
    */
@@ -232,11 +232,9 @@ public class FileConnectorStateManager {
       queryStatement.setString(1, fullPathStr);
       try (ResultSet rs = queryStatement.executeQuery()) {
         if (rs.next()) {
-          Timestamp timestamp = rs.getTimestamp("last_published");
-
-          if (timestamp != null) {
-            return timestamp.toInstant();
-          }
+          // map TIMESTAMP WITH TIME ZONE to OffsetDateTime
+          OffsetDateTime odt = rs.getObject("last_published", OffsetDateTime.class);
+          if (odt != null) { return odt.toInstant(); }
         }
       }
     } catch (SQLException e) {
@@ -254,7 +252,7 @@ public class FileConnectorStateManager {
     String updateSQL = "UPDATE \"" + tableName + "\" SET last_published = ? WHERE name = ?";
 
     try (PreparedStatement statement = jdbcConnection.prepareStatement(updateSQL)) {
-      statement.setTimestamp(1, traversalTimestamp);
+      statement.setObject(1, traversalInstant);
       statement.setString(2, fullPathStr);
 
       int rowsChanged = statement.executeUpdate();

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public class FileConnectorStateManager {
   private final boolean performDeletions;
   private final int pathLength;
 
-  private final Instant traversalInstant = Instant.now();
+  private final Instant traversalInstant;
 
   private Connection jdbcConnection;
   private PreparedStatement queryStatement;
@@ -72,6 +73,10 @@ public class FileConnectorStateManager {
    * @param connectorName The name of the connector using this connection. Uses the name for tableName, if it is not specified.
    */
   public FileConnectorStateManager(Config config, String connectorName) {
+    this(config, connectorName, Instant.now());
+  }
+
+  FileConnectorStateManager(Config config, String connectorName, Instant traversalInstant) {
     this.driver = ConfigUtils.getOrDefault(config, "driver", "org.h2.Driver");
     this.connectionString = ConfigUtils.getOrDefault(config, "connectionString", "jdbc:h2:./state/" + connectorName);
     this.jdbcUser = ConfigUtils.getOrDefault(config, "jdbcUser", "");
@@ -80,6 +85,7 @@ public class FileConnectorStateManager {
     this.tableName = ConfigUtils.getOrDefault(config, "tableName", connectorName).toUpperCase();
     this.performDeletions = ConfigUtils.getOrDefault(config, "performDeletions", true);
     this.pathLength = ConfigUtils.getOrDefault(config, "pathLength", 200);
+    this.traversalInstant = Objects.requireNonNull(traversalInstant, "traversalInstant cannot be null");
   }
 
   /**

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/TraversalParams.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/TraversalParams.java
@@ -103,7 +103,10 @@ public class TraversalParams {
    * and the last time it was modified.
    */
   public boolean includeFile(String fileName, Instant fileLastModified, Instant fileLastPublished) {
-    return patternsAllowFile(fileName) && cutoffsAllowFile(fileLastModified, fileLastPublished);
+    if (fileLastPublished != null && !fileLastModified.isAfter(fileLastPublished)) {
+      return false;
+    }
+    return applyPatternFilters(fileName) && applyTimestampFilters(fileLastModified, fileLastPublished);
   }
 
   public boolean supportedFileExtension(String fileExtension) {
@@ -117,7 +120,7 @@ public class TraversalParams {
   /**
    * Returns whether a file with the given name should be processed, based on the includes/excludes patterns.
    */
-  private boolean patternsAllowFile(String fileName) {
+  private boolean applyPatternFilters(String fileName) {
     return excludes.stream().noneMatch(pattern -> pattern.matcher(fileName).matches())
         && (includes.isEmpty() || includes.stream().anyMatch(pattern -> pattern.matcher(fileName).matches()));
   }
@@ -126,7 +129,7 @@ public class TraversalParams {
    * Returns whether the given lastModified and lastPublished instants comply with lastModifiedCutoff / lastPublishedCutoff,
    * if they are specified.
    */
-  private boolean cutoffsAllowFile(Instant fileLastModified, Instant fileLastPublished) {
+  private boolean applyTimestampFilters(Instant fileLastModified, Instant fileLastPublished) {
     // If lastModifiedCutoff is specified, return false if it is violated
     if (lastModifiedCutoff != null) {
       Instant cutoffPoint = Instant.now().minus(lastModifiedCutoff);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/TraversalParams.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/TraversalParams.java
@@ -103,10 +103,18 @@ public class TraversalParams {
    * and the last time it was modified.
    */
   public boolean includeFile(String fileName, Instant fileLastModified, Instant fileLastPublished) {
+    // file mush pass include/exclude path patterns, if specified, to even be a publishing candidate
+    if (!applyPatternFilters(fileName)) {
+      return false;
+    }
+
+    // incremental support: do not publish if 1) file already published and 2) it hasn't been modified since
     if (fileLastPublished != null && !fileLastModified.isAfter(fileLastPublished)) {
       return false;
     }
-    return applyPatternFilters(fileName) && applyTimestampFilters(fileLastModified, fileLastPublished);
+
+    // incremental support: publish file unless a timestamp filter is triggered
+    return applyTimestampFilters(fileLastModified, fileLastPublished);
   }
 
   public boolean supportedFileExtension(String fileExtension) {
@@ -180,4 +188,5 @@ public class TraversalParams {
   public URI getMoveToErrorFolder() {
     return moveToErrorFolder;
   }
+
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/TraversalParams.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/TraversalParams.java
@@ -110,19 +110,24 @@ public class TraversalParams {
     if (!applyPatternFilters(fileName)) {
       return false;
     }
-    
-    // if path is valid and publishMode is "full", immediately return true so all are published
+
+    // apply lastModified filter regardless of mode
+    if (!applyLastModifiedFilter(fileLastModified)) {
+      return false;
+    }
+
+    // if path is valid and publishMode is "full", publish file
     if (publishMode == PublishMode.FULL) {
       return true;
     }
 
-    // incremental support: do not publish if 1) file already published and 2) it hasn't been modified since
-    if (fileLastPublished != null && !fileLastModified.isAfter(fileLastPublished)) {
+    // incremental support: do not publish if file already published and not modified since
+    if (!modifiedSinceLastPublish(fileLastModified, fileLastPublished)) {
       return false;
     }
 
-    // incremental support: publish file unless a timestamp filter is triggered
-    return applyTimestampFilters(fileLastModified, fileLastPublished);
+    // incremental support: if lastPublishedCutoff is specified, require it to pass
+    return applyLastPublishedFilter(fileLastPublished);
   }
 
   public boolean supportedFileExtension(String fileExtension) {
@@ -141,11 +146,7 @@ public class TraversalParams {
         && (includes.isEmpty() || includes.stream().anyMatch(pattern -> pattern.matcher(fileName).matches()));
   }
 
-  /**
-   * Returns whether the given lastModified and lastPublished instants comply with lastModifiedCutoff / lastPublishedCutoff,
-   * if they are specified.
-   */
-  private boolean applyTimestampFilters(Instant fileLastModified, Instant fileLastPublished) {
+  private boolean applyLastModifiedFilter(Instant fileLastModified) {
     // If lastModifiedCutoff is specified, return false if it is violated
     if (lastModifiedCutoff != null) {
       Instant cutoffPoint = Instant.now().minus(lastModifiedCutoff);
@@ -155,7 +156,10 @@ public class TraversalParams {
         return false;
       }
     }
+    return true;
+  }
 
+  private boolean applyLastPublishedFilter(Instant fileLastPublished) {
     // If lastPublishedCutoff is specified, and we found a lastPublished Instant for the file, return false if it is violated
     if (lastPublishedCutoff != null && fileLastPublished != null) {
       Instant cutoffPoint = Instant.now().minus(lastPublishedCutoff);
@@ -167,6 +171,10 @@ public class TraversalParams {
     }
 
     return true;
+  }
+
+  private boolean modifiedSinceLastPublish(Instant fileLastModified, Instant fileLastPublished) {
+    return fileLastPublished == null || fileLastModified.isAfter(fileLastPublished);
   }
 
   public URI getURI() {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -161,7 +161,7 @@ public class OpenSearchIndexer extends Indexer {
         if (!isMarkedForDeletionByField(doc)) {
           idsToDelete.add(indexAndId);
         } else {
-          Pair<String, String> indexAndDeleteByField = Pair.of(indexToSend, doc.getString(deleteByFieldField));
+          Pair<String, String> indexAndDeleteByField = Pair.of(indexToSend, deleteByFieldField);
           if (!termsToDeleteByQuery.containsKey(indexAndDeleteByField)) {
             termsToDeleteByQuery.put(indexAndDeleteByField, new ArrayList<>());
           }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -144,7 +144,8 @@ public class OpenSearchIndexer extends Indexer {
     // else if document is marked for deletion ONLY, then only add to idsToDelete
     // else document is marked for deletion AND contains deleteByFieldField and deleteByFieldValue, only add to termsToDeleteByQuery
     for (Document doc : documents) {
-      String id = doc.getId();
+      // use doc id override if specified, otherwise delete will try to delete wrong id
+      String id = Optional.ofNullable(getDocIdOverride(doc)).orElse(doc.getId());
 
       // if an index override field has been specified, use its value as the index to send to opensearch,
       String indexOverride = getIndexOverride(doc);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorStateManagerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorStateManagerTest.java
@@ -6,13 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.kmwllc.lucille.connector.jdbc.DBTestHelper;
-import com.kmwllc.lucille.core.Connector;
-import com.kmwllc.lucille.core.Publisher;
-import com.kmwllc.lucille.core.PublisherImpl;
-import com.kmwllc.lucille.message.TestMessenger;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import java.io.File;
 import java.io.StringReader;
 import java.nio.file.Files;
@@ -24,11 +17,22 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+
 import org.h2.tools.RunScript;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import com.kmwllc.lucille.connector.jdbc.DBTestHelper;
+import com.kmwllc.lucille.core.Connector;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Publisher;
+import com.kmwllc.lucille.core.PublisherImpl;
+import com.kmwllc.lucille.message.TestMessenger;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 public class FileConnectorStateManagerTest {
 
@@ -86,6 +90,22 @@ public class FileConnectorStateManagerTest {
 
     manager.shutdown();
     assertEquals(1, dbHelper.checkNumConnections());
+  }
+
+  @Test
+  public void testStateManagerUsesProvidedTraversalInstant() throws Exception {
+    // constructor seam for deterministic timestamp assertions.
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorStateManagerTest/config.conf");
+    Instant fixedTraversalInstant = Instant.parse("2026-02-16T00:00:00Z");
+    FileConnectorStateManager manager = new FileConnectorStateManager(config, null, fixedTraversalInstant);
+    manager.init();
+
+    manager.markFileEncountered(helloFile);
+    manager.successfullyPublishedFile(helloFile);
+
+    assertEquals(fixedTraversalInstant, manager.getLastPublished(helloFile));
+
+    manager.shutdown();
   }
 
   @Test
@@ -247,10 +267,9 @@ public class FileConnectorStateManagerTest {
       }
     }
 
-    // and now... do it again... but should only have the two files that we manually modified above get processed.
+    // second run in default full mode republishes all docs.
     connector.execute(publisher2);
-    // 1 doc from json, 3 from the csv in the archive
-    assertEquals(4, messenger2.getDocsSentForProcessing().size());
+    assertEquals(18, messenger2.getDocsSentForProcessing().size());
   }
 
   // empty state configuration should mean we create a database for the user.
@@ -262,8 +281,6 @@ public class FileConnectorStateManagerTest {
 
     assertFalse(stateDirectory.isDirectory());
     assertFalse(dbFile.isFile());
-
-
     Config emptyConfig = ConfigFactory.empty();
 
     FileConnectorStateManager stateMgr = new FileConnectorStateManager(emptyConfig, "connector");
@@ -318,11 +335,77 @@ public class FileConnectorStateManagerTest {
     connector.execute(publisher);
     assertEquals(21, messenger.getDocsSentForProcessing().size());
 
-    // second run, nothing should get published
+    // second run in default full mode republishes everything.
     messenger = new TestMessenger();
     publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
 
     connector.execute(publisher);
-    assertEquals(0, messenger.getDocsSentForProcessing().size());
+    assertEquals(21, messenger.getDocsSentForProcessing().size());
   }
+
+  @Test
+  public void testTraversalWithStateIncremental() throws Exception {
+    // incremental mode should only publish changed/new docs plus tombstones.
+    String fileConnectorExampleDir = Paths.get("src/test/resources/FileConnectorTest/example").toUri().toString();
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/state.conf")
+        .withValue("filterOptions.publishMode", ConfigValueFactory.fromAnyRef("incremental"));
+
+    TestMessenger messenger1 = new TestMessenger();
+    TestMessenger messenger2 = new TestMessenger();
+    Publisher publisher1 = new PublisherImpl(config, messenger1, "run", "pipeline1");
+    Publisher publisher2 = new PublisherImpl(config, messenger2, "run", "pipeline1");
+
+    Connector connector = new FileConnector(config);
+    connector.execute(publisher1);
+    assertEquals(18, messenger1.getDocsSentForProcessing().size());
+
+    String baseQuery = "SELECT * FROM \"FILE-CONNECTOR-1\" WHERE name = '" + fileConnectorExampleDir;
+    try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:test", "", "");
+        ResultSet aJSONResults = RunScript.execute(connection, new StringReader(baseQuery + "a.json'"));
+        ResultSet subdirCSVResults = RunScript.execute(connection, new StringReader(baseQuery + "subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv'"))) {
+      assertTrue(aJSONResults.next());
+      assertTrue(subdirCSVResults.next());
+      String baseUpdate = "UPDATE \"FILE-CONNECTOR-1\" SET last_published='2022-01-01 14:30:00' WHERE name='" + fileConnectorExampleDir;
+      try (Statement statement = connection.createStatement()) {
+        statement.executeUpdate(baseUpdate + "a.json'");
+        statement.executeUpdate(baseUpdate + "subdirWith1csv1xml.tar.gz'");
+        statement.executeUpdate(baseUpdate + "subdirWith1csv1xml.tar.gz!subdirWith1csv1xml/default.csv'");
+      }
+    }
+
+    connector.execute(publisher2);
+    List<Document> secondRunDocs = messenger2.getDocsSentForProcessing();
+    long tombstoneCount = secondRunDocs.stream()
+        .filter(doc -> Boolean.TRUE.equals(doc.getBoolean(FileConnector.EXPIRED)))
+        .count();
+    // 4 reprocessed docs + 6 tombstones.
+    assertEquals(10, secondRunDocs.size());
+    assertEquals(6, tombstoneCount);
+  }
+
+  @Test
+  public void testTraversalWithStateAndMultiplePathsIncremental() throws Exception {
+    // incremental mode across multiple paths should emit only tombstones here.
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/stateMultiplePaths.conf")
+        .withValue("filterOptions.publishMode", ConfigValueFactory.fromAnyRef("incremental"));
+
+    TestMessenger messenger = new TestMessenger();
+    Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
+
+    Connector connector = new FileConnector(config);
+    connector.execute(publisher);
+    assertEquals(21, messenger.getDocsSentForProcessing().size());
+
+    messenger = new TestMessenger();
+    publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
+
+    connector.execute(publisher);
+    List<Document> secondRunDocs = messenger.getDocsSentForProcessing();
+    long tombstoneCount = secondRunDocs.stream()
+        .filter(doc -> Boolean.TRUE.equals(doc.getBoolean(FileConnector.EXPIRED)))
+        .count();
+    assertEquals(9, secondRunDocs.size());
+    assertEquals(9, tombstoneCount);
+  }
+
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorStateManagerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorStateManagerTest.java
@@ -408,4 +408,30 @@ public class FileConnectorStateManagerTest {
     assertEquals(9, tombstoneCount);
   }
 
+  @Test
+  public void testTraversalWithPathRemovedFullModePublishesTombstones() throws Exception {
+    // full mode still emits tombstones when previously tracked files disappear.
+    Config configWithTwoPaths = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/stateMultiplePaths.conf");
+    Config configSinglePath = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/state.conf");
+
+    TestMessenger messenger1 = new TestMessenger();
+    Publisher publisher1 = new PublisherImpl(configWithTwoPaths, messenger1, "run", "pipeline1");
+    Connector connector1 = new FileConnector(configWithTwoPaths);
+    connector1.execute(publisher1);
+    assertEquals(21, messenger1.getDocsSentForProcessing().size());
+
+    TestMessenger messenger2 = new TestMessenger();
+    Publisher publisher2 = new PublisherImpl(configSinglePath, messenger2, "run", "pipeline1");
+    Connector connector2 = new FileConnector(configSinglePath);
+    connector2.execute(publisher2);
+
+    List<Document> secondRunDocs = messenger2.getDocsSentForProcessing();
+    long tombstoneCount = secondRunDocs.stream()
+        .filter(doc -> Boolean.TRUE.equals(doc.getBoolean(FileConnector.EXPIRED)))
+        .count();
+    assertTrue(tombstoneCount > 0);
+    assertEquals(19, secondRunDocs.size());
+    assertEquals(1, tombstoneCount);
+  }
+
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -14,7 +14,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.mockito.MockedStatic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.kmwllc.lucille.connector.storageclient.LocalStorageClient;
 import com.kmwllc.lucille.connector.storageclient.StorageClient;
@@ -27,33 +40,11 @@ import com.kmwllc.lucille.core.PublisherImpl;
 import com.kmwllc.lucille.message.TestMessenger;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.mockito.MockedStatic;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 public class FileConnectorTest {
 
   private static final Logger log = LoggerFactory.getLogger(FileConnectorTest.class);
-
-  FileSystem mockFileSystem;
-
-  @Before
-  public void setUp() throws Exception {
-    mockFileSystem = mock(FileSystem.class);
-    when(mockFileSystem.getPath(any())).thenReturn(mock(Path.class));
-  }
 
   @Test
   public void testExecuteSuccessful() throws Exception {
@@ -367,6 +358,15 @@ public class FileConnectorTest {
     assertThrows(IllegalArgumentException.class, () -> new FileConnector(config2));
   }
 
+  @Test
+  public void testIncrementalWithoutStateFailsFast() {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/example.conf")
+        .withValue("filterOptions.publishMode", ConfigValueFactory.fromAnyRef("incremental"));
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new FileConnector(config));
+    assertTrue(e.getMessage().contains("incremental"));
+    assertTrue(e.getMessage().contains("state configuration"));
+  }
+
   // There is a unit test for "traversalWithState" in FileConnectorStateManagerTest.java, which already had a database for testing.
 
   // Testing when the state configuration is empty.
@@ -399,10 +399,8 @@ public class FileConnectorTest {
 
       connector.execute(publisher);
 
-      // filtered out by state database
-      assertEquals(0, messenger.getDocsSentForProcessing().size());
-    } catch (Exception e) {
-      log.error("Exception thrown in testTraversalWithStateEmbedded.", e);
+      // default full mode republishes all docs on subsequent runs
+      assertEquals(18, messenger.getDocsSentForProcessing().size());
     } finally {
       try {
         Files.delete(dbFile.toPath());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClientTest.java
@@ -6,13 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import com.kmwllc.lucille.connector.FileConnector;
-import com.kmwllc.lucille.core.Document;
-import com.kmwllc.lucille.core.Publisher;
-import com.kmwllc.lucille.core.PublisherImpl;
-import com.kmwllc.lucille.message.TestMessenger;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
@@ -22,8 +15,17 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.kmwllc.lucille.connector.FileConnector;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Publisher;
+import com.kmwllc.lucille.core.PublisherImpl;
+import com.kmwllc.lucille.message.TestMessenger;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 public class LocalStorageClientTest {
 
@@ -432,8 +434,9 @@ public class LocalStorageClientTest {
   @Test
   public void testCutoff() throws Exception {
     Config connectorConfig = ConfigFactory.parseMap(Map.of(
-        // Only including files modified in the last 10 hours
-        "filterOptions", Map.of("lastModifiedCutoff", "10h")
+        // cutoff behavior should match under incremental mode.
+        // only including files modified in the last 10 hours
+        "filterOptions", Map.of("lastModifiedCutoff", "10h", "publishMode", "incremental")
     ));
 
     File oldFile = new File("src/test/resources/StorageClientTest/modifiedDateFiles/old.txt");

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/TraversalParamsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/TraversalParamsTest.java
@@ -1,0 +1,290 @@
+package com.kmwllc.lucille.connector.storageclient;
+
+import static org.junit.Assert.*;
+
+import com.typesafe.config.ConfigFactory;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+public class TraversalParamsTest {
+
+  private static final URI DEFAULT_URI = URI.create("s3://bucket/");
+  private static final String DEFAULT_PREFIX = "test-";
+  private static final Instant BASE_TIME = Instant.parse("2026-01-15T10:00:00Z");
+  private static final Instant LATER_TIME = Instant.parse("2026-01-19T14:30:00Z");
+
+  private TraversalParams params(Map<String, Object> config) {
+    // helper to construct params with a small config override
+    return new TraversalParams(ConfigFactory.parseMap(config), DEFAULT_URI, DEFAULT_PREFIX);
+  }
+
+  private TraversalParams emptyParams() {
+    // baseline params with no config at all
+    return new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
+  }
+
+  // basics tests
+  @Test
+  public void preservesDocIdPrefix() {
+    // doc id prefix passed to the constructor should be used as-is
+    TraversalParams params = new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, "prefix-");
+    assertEquals("prefix-", params.getDocIdPrefix());
+  }
+
+  @Test
+  public void preservesUri() {
+    // traversal should retain the exact URI it was constructed with
+    URI uri = URI.create("s3://my-bucket/path/");
+    TraversalParams params = new TraversalParams(ConfigFactory.empty(), uri, "");
+    assertEquals(uri, params.getURI());
+  }
+
+  // file handlers tests
+
+  @Test
+  public void noExtensionsByDefault() {
+    // with no handler config, no file extensions should be accepted
+    assertFalse(emptyParams().supportedFileExtension("json"));
+  }
+
+  @Test
+  public void extensionsFromConfig() {
+    // configured handlers should be recognized, everything else rejected
+    TraversalParams params =
+        params(Map.of("fileHandlers", Map.of("json", Map.of(), "csv", Map.of())));
+    assertTrue(params.supportedFileExtension("json"));
+    assertTrue(params.supportedFileExtension("csv"));
+    assertFalse(params.supportedFileExtension("xml"));
+  }
+
+  @Test
+  public void handlerLookup() {
+    // handler lookup should return a config entry only for known extensions
+    TraversalParams params = params(Map.of("fileHandlers", Map.of("json", Map.of())));
+    assertNotNull(params.handlerForExtension("json"));
+    assertNull(params.handlerForExtension("csv"));
+  }
+
+  // incremental logic tests
+
+  @Test
+  public void futurePublishSkips() {
+    // guardrail: if metadata claims a publish time in the future, skip the file
+    Instant now = Instant.now();
+    Instant future = now.plus(Duration.ofDays(1));
+    assertFalse(emptyParams().includeFile("doc.json", now, future));
+  }
+
+  @Test
+  public void nullPublishIncludes() {
+    // brand new file with no prior publish timestamp should be included
+    assertTrue(emptyParams().includeFile("doc.json", BASE_TIME, null));
+  }
+
+  @Test
+  public void olderModifiedSkips() {
+    // file modified before its last publish should not be reprocessed
+    assertFalse(emptyParams().includeFile("doc.json", BASE_TIME, LATER_TIME));
+  }
+
+  @Test
+  public void oneMsNewerIncludes() {
+    // even a tiny timestamp bump counts as a real change
+    assertTrue(emptyParams().includeFile("doc.json", BASE_TIME.plusMillis(1), BASE_TIME));
+  }
+
+  @Test
+  public void skewedModifiedSkips() {
+    // badly skewed timestamps far in the past should be treated as stale
+    assertFalse(
+        emptyParams().includeFile(
+            "doc.json",
+            Instant.parse("2020-01-01T00:00:00Z"),
+            BASE_TIME
+        )
+    );
+  }
+
+  // incremental scenarios
+
+  @Test
+  public void freshIngestIncludesAll() {
+    // first-time ingest should include every file
+    TraversalParams params = emptyParams();
+    for (String doc : List.of("doc_a.json", "doc_b.json", "doc_c.json")) {
+      assertTrue(doc, params.includeFile(doc, BASE_TIME, null));
+    }
+  }
+
+  @Test
+  public void unchangedReingestSkipsAll() {
+    // re-ingesting unchanged files should skip everything
+    TraversalParams params = emptyParams();
+    for (String doc : List.of("doc_a.json", "doc_b.json", "doc_c.json")) {
+      assertFalse(doc, params.includeFile(doc, BASE_TIME, BASE_TIME));
+    }
+  }
+
+  @Test
+  public void singleChangeOnly() {
+    // only the file with a newer modification should be included
+    TraversalParams params = emptyParams();
+    assertFalse(params.includeFile("doc_a.json", BASE_TIME, BASE_TIME));
+    assertTrue(params.includeFile("doc_b.json", LATER_TIME, BASE_TIME));
+    assertFalse(params.includeFile("doc_c.json", BASE_TIME, BASE_TIME));
+  }
+
+  @Test
+  public void mixedNewAndUpdated() {
+    // mix of unchanged, updated, and brand-new files in one pass
+    TraversalParams params = emptyParams();
+    Instant laterPub = Instant.parse("2026-01-17T14:00:00Z");
+    Instant modified = Instant.parse("2026-01-19T17:00:00Z");
+
+    assertFalse(params.includeFile("doc_a.json", BASE_TIME, BASE_TIME));
+    assertFalse(params.includeFile("doc_b.json", laterPub, laterPub));
+    assertTrue(params.includeFile("doc_c.json", modified, BASE_TIME));
+
+    // files with no prior publish timestamp are treated as new
+    for (String doc : List.of("doc_d.json", "doc_e.json", "doc_f.json")) {
+      assertTrue(doc, params.includeFile(doc, modified, null));
+    }
+  }
+
+  // edge cases
+
+  @Test
+  public void pathsWithSpecialChars() {
+    // unusual but valid paths should not affect inclusion logic
+    TraversalParams params = emptyParams();
+    for (String path : List.of(
+        "path/with spaces/doc.json",
+        "path/with-dashes/doc.json",
+        "path/with_underscores/doc.json"
+    )) {
+      assertTrue(path, params.includeFile(path, BASE_TIME, null));
+    }
+  }
+
+  // parameterized tests
+
+  @RunWith(Parameterized.class)
+  public static class BooleanDefaultsTest {
+
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Object[]> data() {
+      return List.of(new Object[][]{
+          {"handleArchivedFiles", false, "getHandleArchivedFiles"},
+          {"handleCompressedFiles", false, "getHandleCompressedFiles"},
+          {"getFileContent", true, "shouldGetFileContent"}
+      });
+    }
+
+    private final String key;
+    private final boolean expected;
+    private final String method;
+
+    public BooleanDefaultsTest(String key, boolean expected, String method) {
+      this.key = key;
+      this.expected = expected;
+      this.method = method;
+    }
+
+    @Test
+    public void usesDefault() throws Exception {
+      // boolean options should have sensible defaults when not configured
+      TraversalParams params =
+          new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
+      assertEquals(expected, TraversalParams.class.getMethod(method).invoke(params));
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class BooleanOverrideTest {
+
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Object[]> data() {
+      return List.of(new Object[][]{
+          {"handleArchivedFiles", false, "getHandleArchivedFiles"},
+          {"handleCompressedFiles", false, "getHandleCompressedFiles"},
+          {"getFileContent", true, "shouldGetFileContent"}
+      });
+    }
+
+    private final String key;
+    private final boolean defaultValue;
+    private final String method;
+
+    public BooleanOverrideTest(String key, boolean defaultValue, String method) {
+      this.key = key;
+      this.defaultValue = defaultValue;
+      this.method = method;
+    }
+
+    @Test
+    public void respectsOverride() throws Exception {
+      // explicit config values should override defaults
+      TraversalParams params =
+          new TraversalParams(
+              ConfigFactory.parseMap(
+                  Map.of("fileOptions", Map.of(key, !defaultValue))),
+              DEFAULT_URI,
+              DEFAULT_PREFIX);
+
+      assertEquals(!defaultValue,
+          TraversalParams.class.getMethod(method).invoke(params));
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class OptionalUriTest {
+
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Object[]> data() {
+      return List.of(new Object[][]{
+          {"moveToAfterProcessing", "getMoveToAfterProcessing"},
+          {"moveToErrorFolder", "getMoveToErrorFolder"}
+      });
+    }
+
+    private final String key;
+    private final String method;
+
+    public OptionalUriTest(String key, String method) {
+      this.key = key;
+      this.method = method;
+    }
+
+    @Test
+    public void uriDefaultsToNull() throws Exception {
+      // optional target URIs should default to null when unset
+      TraversalParams params =
+          new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
+      assertNull(TraversalParams.class.getMethod(method).invoke(params));
+    }
+
+    @Test
+    public void uriFromConfig() throws Exception {
+      // configured target URIs should be parsed and returned
+      TraversalParams params =
+          new TraversalParams(
+              ConfigFactory.parseMap(
+                  Map.of("fileOptions", Map.of(key, "s3://target/"))),
+              DEFAULT_URI,
+              DEFAULT_PREFIX);
+
+      assertEquals(
+          URI.create("s3://target/"),
+          TraversalParams.class.getMethod(method).invoke(params)
+      );
+    }
+  }
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/TraversalParamsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/storageclient/TraversalParamsTest.java
@@ -1,8 +1,11 @@
 package com.kmwllc.lucille.connector.storageclient;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import com.typesafe.config.ConfigFactory;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -10,9 +13,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+
+import com.typesafe.config.ConfigFactory;
 
 public class TraversalParamsTest {
 
@@ -20,6 +22,13 @@ public class TraversalParamsTest {
   private static final String DEFAULT_PREFIX = "test-";
   private static final Instant BASE_TIME = Instant.parse("2026-01-15T10:00:00Z");
   private static final Instant LATER_TIME = Instant.parse("2026-01-19T14:30:00Z");
+
+  // one table row for includefile behavior plus optional cutoff config.
+  private record IncludeFileCase(
+      String name, String publishMode,
+      Instant fileLastModified, Instant fileLastPublished,
+      String lastModifiedCutoff, String lastPublishedCutoff,
+      boolean expected) {}
 
   private TraversalParams params(Map<String, Object> config) {
     // helper to construct params with a small config override
@@ -31,7 +40,30 @@ public class TraversalParamsTest {
     return new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
   }
 
-  // basics tests
+  private TraversalParams incrementalParams() {
+    return params(Map.of("filterOptions", Map.of("publishMode", "incremental")));
+  }
+
+  private TraversalParams paramsWithFilterOptions(Map<String, Object> filterOptions) {
+    return params(Map.of("filterOptions", filterOptions));
+  }
+
+  private TraversalParams paramsWithFileOptions(Map<String, Object> fileOptions) {
+    return params(Map.of("fileOptions", fileOptions));
+  }
+
+  private void assertAllIncluded(TraversalParams params, Instant modified, Instant published, List<String> docs) {
+    for (String doc : docs) {
+      assertTrue(doc, params.includeFile(doc, modified, published));
+    }
+  }
+
+  private void assertAllExcluded(TraversalParams params, Instant modified, Instant published, List<String> docs) {
+    for (String doc : docs) {
+      assertFalse(doc, params.includeFile(doc, modified, published));
+    }
+  }
+
   @Test
   public void preservesDocIdPrefix() {
     // doc id prefix passed to the constructor should be used as-is
@@ -77,35 +109,34 @@ public class TraversalParamsTest {
 
   @Test
   public void futurePublishSkips() {
-    // guardrail: if metadata claims a publish time in the future, skip the file
-    Instant now = Instant.now();
-    Instant future = now.plus(Duration.ofDays(1));
-    assertFalse(emptyParams().includeFile("doc.json", now, future));
+    // if last published is in the future, treat it as already published and skip.
+    Instant future = BASE_TIME.plus(Duration.ofDays(1));
+    assertFalse(incrementalParams().includeFile("doc.json", BASE_TIME, future));
   }
 
   @Test
   public void nullPublishIncludes() {
-    // brand new file with no prior publish timestamp should be included
-    assertTrue(emptyParams().includeFile("doc.json", BASE_TIME, null));
+    // files with no publish history should be considered new.
+    assertTrue(incrementalParams().includeFile("doc.json", BASE_TIME, null));
   }
 
   @Test
   public void olderModifiedSkips() {
-    // file modified before its last publish should not be reprocessed
-    assertFalse(emptyParams().includeFile("doc.json", BASE_TIME, LATER_TIME));
+    // unchanged files should be skipped in incremental mode.
+    assertFalse(incrementalParams().includeFile("doc.json", BASE_TIME, LATER_TIME));
   }
 
   @Test
   public void oneMsNewerIncludes() {
-    // even a tiny timestamp bump counts as a real change
-    assertTrue(emptyParams().includeFile("doc.json", BASE_TIME.plusMillis(1), BASE_TIME));
+    // any forward movement in modified time should trigger inclusion.
+    assertTrue(incrementalParams().includeFile("doc.json", BASE_TIME.plusMillis(1), BASE_TIME));
   }
 
   @Test
   public void skewedModifiedSkips() {
     // badly skewed timestamps far in the past should be treated as stale
     assertFalse(
-        emptyParams().includeFile(
+        incrementalParams().includeFile(
             "doc.json",
             Instant.parse("2020-01-01T00:00:00Z"),
             BASE_TIME
@@ -117,26 +148,22 @@ public class TraversalParamsTest {
 
   @Test
   public void freshIngestIncludesAll() {
-    // first-time ingest should include every file
-    TraversalParams params = emptyParams();
-    for (String doc : List.of("doc_a.json", "doc_b.json", "doc_c.json")) {
-      assertTrue(doc, params.includeFile(doc, BASE_TIME, null));
-    }
+    // first traversal has no publish history, so all files should pass.
+    TraversalParams params = incrementalParams();
+    assertAllIncluded(params, BASE_TIME, null, List.of("doc_a.json", "doc_b.json", "doc_c.json"));
   }
 
   @Test
   public void unchangedReingestSkipsAll() {
-    // re-ingesting unchanged files should skip everything
-    TraversalParams params = emptyParams();
-    for (String doc : List.of("doc_a.json", "doc_b.json", "doc_c.json")) {
-      assertFalse(doc, params.includeFile(doc, BASE_TIME, BASE_TIME));
-    }
+    // second traversal with identical modified timestamps should skip all.
+    TraversalParams params = incrementalParams();
+    assertAllExcluded(params, BASE_TIME, BASE_TIME, List.of("doc_a.json", "doc_b.json", "doc_c.json"));
   }
 
   @Test
   public void singleChangeOnly() {
-    // only the file with a newer modification should be included
-    TraversalParams params = emptyParams();
+    // only the doc with a newer modified timestamp should pass.
+    TraversalParams params = incrementalParams();
     assertFalse(params.includeFile("doc_a.json", BASE_TIME, BASE_TIME));
     assertTrue(params.includeFile("doc_b.json", LATER_TIME, BASE_TIME));
     assertFalse(params.includeFile("doc_c.json", BASE_TIME, BASE_TIME));
@@ -144,8 +171,8 @@ public class TraversalParamsTest {
 
   @Test
   public void mixedNewAndUpdated() {
-    // mix of unchanged, updated, and brand-new files in one pass
-    TraversalParams params = emptyParams();
+    // unchanged, updated, and brand-new files should be handled in one pass.
+    TraversalParams params = incrementalParams();
     Instant laterPub = Instant.parse("2026-01-17T14:00:00Z");
     Instant modified = Instant.parse("2026-01-19T17:00:00Z");
 
@@ -153,10 +180,7 @@ public class TraversalParamsTest {
     assertFalse(params.includeFile("doc_b.json", laterPub, laterPub));
     assertTrue(params.includeFile("doc_c.json", modified, BASE_TIME));
 
-    // files with no prior publish timestamp are treated as new
-    for (String doc : List.of("doc_d.json", "doc_e.json", "doc_f.json")) {
-      assertTrue(doc, params.includeFile(doc, modified, null));
-    }
+    assertAllIncluded(params, modified, null, List.of("doc_d.json", "doc_e.json", "doc_f.json"));
   }
 
   // edge cases
@@ -165,126 +189,89 @@ public class TraversalParamsTest {
   public void pathsWithSpecialChars() {
     // unusual but valid paths should not affect inclusion logic
     TraversalParams params = emptyParams();
-    for (String path : List.of(
+    assertAllIncluded(params, BASE_TIME, null, List.of(
         "path/with spaces/doc.json",
         "path/with-dashes/doc.json",
         "path/with_underscores/doc.json"
-    )) {
-      assertTrue(path, params.includeFile(path, BASE_TIME, null));
-    }
+    ));
   }
 
-  // parameterized tests
+  @Test
+  public void includeFileModeMatrix() {
+    // cutoff filters are relative to now, so this matrix intentionally anchors around current time.
+    Instant now = Instant.now();
+    Instant modifiedOld = now.minus(Duration.ofDays(10));
+    Instant modifiedNew = now;
+    Instant publishedRecent = now.minus(Duration.ofHours(1));
+    Instant publishedOld = now.minus(Duration.ofDays(7));
 
-  @RunWith(Parameterized.class)
-  public static class BooleanDefaultsTest {
+    List<IncludeFileCase> cases = List.of(
+        new IncludeFileCase("full_includes_unchanged", "full", modifiedOld, publishedRecent, null, null, true),
+        new IncludeFileCase("incremental_skips_unchanged", "incremental", modifiedOld, publishedRecent, null, null, false),
+        new IncludeFileCase("incremental_includes_new", "incremental", modifiedOld, null, null, null, true),
+        new IncludeFileCase("incremental_includes_modified", "incremental", modifiedNew, publishedRecent, null, null, true),
+        new IncludeFileCase("full_respects_last_modified_cutoff", "full", modifiedOld, null, "24h", null, false),
+        new IncludeFileCase("incremental_respects_last_modified_cutoff", "incremental", modifiedOld, null, "24h", null, false),
+        new IncludeFileCase("full_ignores_last_published_cutoff", "full", modifiedNew, publishedRecent, null, "24h", true),
+        new IncludeFileCase("incremental_respects_last_published_cutoff", "incremental", modifiedNew, publishedRecent, null, "24h", false),
+        new IncludeFileCase("incremental_allows_old_publish_by_cutoff", "incremental", modifiedNew, publishedOld, null, "24h", true)
+    );
 
-    @Parameters(name = "{index}: {0}")
-    public static Iterable<Object[]> data() {
-      return List.of(new Object[][]{
-          {"handleArchivedFiles", false, "getHandleArchivedFiles"},
-          {"handleCompressedFiles", false, "getHandleCompressedFiles"},
-          {"getFileContent", true, "shouldGetFileContent"}
-      });
-    }
+    for (IncludeFileCase testCase : cases) {
+      Map<String, Object> filterOptions = new java.util.LinkedHashMap<>();
+      filterOptions.put("publishMode", testCase.publishMode());
+      if (testCase.lastModifiedCutoff() != null) {
+        filterOptions.put("lastModifiedCutoff", testCase.lastModifiedCutoff());
+      }
+      if (testCase.lastPublishedCutoff() != null) {
+        filterOptions.put("lastPublishedCutoff", testCase.lastPublishedCutoff());
+      }
 
-    private final String key;
-    private final boolean expected;
-    private final String method;
-
-    public BooleanDefaultsTest(String key, boolean expected, String method) {
-      this.key = key;
-      this.expected = expected;
-      this.method = method;
-    }
-
-    @Test
-    public void usesDefault() throws Exception {
-      // boolean options should have sensible defaults when not configured
-      TraversalParams params =
-          new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
-      assertEquals(expected, TraversalParams.class.getMethod(method).invoke(params));
-    }
-  }
-
-  @RunWith(Parameterized.class)
-  public static class BooleanOverrideTest {
-
-    @Parameters(name = "{index}: {0}")
-    public static Iterable<Object[]> data() {
-      return List.of(new Object[][]{
-          {"handleArchivedFiles", false, "getHandleArchivedFiles"},
-          {"handleCompressedFiles", false, "getHandleCompressedFiles"},
-          {"getFileContent", true, "shouldGetFileContent"}
-      });
-    }
-
-    private final String key;
-    private final boolean defaultValue;
-    private final String method;
-
-    public BooleanOverrideTest(String key, boolean defaultValue, String method) {
-      this.key = key;
-      this.defaultValue = defaultValue;
-      this.method = method;
-    }
-
-    @Test
-    public void respectsOverride() throws Exception {
-      // explicit config values should override defaults
-      TraversalParams params =
-          new TraversalParams(
-              ConfigFactory.parseMap(
-                  Map.of("fileOptions", Map.of(key, !defaultValue))),
-              DEFAULT_URI,
-              DEFAULT_PREFIX);
-
-      assertEquals(!defaultValue,
-          TraversalParams.class.getMethod(method).invoke(params));
-    }
-  }
-
-  @RunWith(Parameterized.class)
-  public static class OptionalUriTest {
-
-    @Parameters(name = "{index}: {0}")
-    public static Iterable<Object[]> data() {
-      return List.of(new Object[][]{
-          {"moveToAfterProcessing", "getMoveToAfterProcessing"},
-          {"moveToErrorFolder", "getMoveToErrorFolder"}
-      });
-    }
-
-    private final String key;
-    private final String method;
-
-    public OptionalUriTest(String key, String method) {
-      this.key = key;
-      this.method = method;
-    }
-
-    @Test
-    public void uriDefaultsToNull() throws Exception {
-      // optional target URIs should default to null when unset
-      TraversalParams params =
-          new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
-      assertNull(TraversalParams.class.getMethod(method).invoke(params));
-    }
-
-    @Test
-    public void uriFromConfig() throws Exception {
-      // configured target URIs should be parsed and returned
-      TraversalParams params =
-          new TraversalParams(
-              ConfigFactory.parseMap(
-                  Map.of("fileOptions", Map.of(key, "s3://target/"))),
-              DEFAULT_URI,
-              DEFAULT_PREFIX);
+      TraversalParams params = paramsWithFilterOptions(filterOptions);
 
       assertEquals(
-          URI.create("s3://target/"),
-          TraversalParams.class.getMethod(method).invoke(params)
-      );
+          testCase.name(),
+          testCase.expected(),
+          params.includeFile("doc.json", testCase.fileLastModified(), testCase.fileLastPublished()));
     }
+  }
+
+  @Test
+  public void booleanOptionDefaults() {
+    // verify defaults match expected file option behavior.
+    TraversalParams params = new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
+    assertFalse(params.getHandleArchivedFiles());
+    assertFalse(params.getHandleCompressedFiles());
+    assertTrue(params.shouldGetFileContent());
+  }
+
+  @Test
+  public void booleanOptionsRespectOverride() {
+    // explicit file option config should override defaults.
+    TraversalParams params = paramsWithFileOptions(Map.of(
+            "handleArchivedFiles", true,
+            "handleCompressedFiles", true,
+            "getFileContent", false));
+    assertTrue(params.getHandleArchivedFiles());
+    assertTrue(params.getHandleCompressedFiles());
+    assertFalse(params.shouldGetFileContent());
+  }
+
+  @Test
+  public void optionalUrisDefaultToNull() {
+    // optional file move targets are unset unless explicitly configured.
+    TraversalParams params = new TraversalParams(ConfigFactory.empty(), DEFAULT_URI, DEFAULT_PREFIX);
+    assertNull(params.getMoveToAfterProcessing());
+    assertNull(params.getMoveToErrorFolder());
+  }
+
+  @Test
+  public void optionalUrisReadFromConfig() {
+    // optional file move targets should parse when configured.
+    TraversalParams moveToAfter = paramsWithFileOptions(Map.of("moveToAfterProcessing", "s3://target/"));
+    assertEquals(URI.create("s3://target/"), moveToAfter.getMoveToAfterProcessing());
+
+    TraversalParams moveToError = paramsWithFileOptions(Map.of("moveToErrorFolder", "s3://target/"));
+    assertEquals(URI.create("s3://target/"), moveToError.getMoveToErrorFolder());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -2,6 +2,7 @@ package com.kmwllc.lucille.indexer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -9,24 +10,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kmwllc.lucille.core.Document;
-import com.kmwllc.lucille.core.Event;
-import com.kmwllc.lucille.core.Event.Type;
-import com.kmwllc.lucille.core.IndexerException;
-import com.kmwllc.lucille.core.KafkaDocument;
-import com.kmwllc.lucille.core.spec.Spec;
-import com.kmwllc.lucille.message.IndexerMessenger;
-import com.kmwllc.lucille.message.TestMessenger;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
@@ -51,6 +43,20 @@ import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.endpoints.BooleanResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.Event;
+import com.kmwllc.lucille.core.Event.Type;
+import com.kmwllc.lucille.core.IndexerException;
+import com.kmwllc.lucille.core.KafkaDocument;
+import com.kmwllc.lucille.core.spec.Spec;
+import com.kmwllc.lucille.message.IndexerMessenger;
+import com.kmwllc.lucille.message.TestMessenger;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 public class OpenSearchIndexerTest {
 
@@ -521,7 +527,7 @@ public class OpenSearchIndexerTest {
 
     assertEquals(1, deleteByQueryRequestArgumentCaptor.getAllValues().size());
     DeleteByQueryRequest deleteByQueryRequestValue = deleteByQueryRequestArgumentCaptor.getAllValues().get(0);
-    assert deleteByQueryRequestValue.query() != null;
+    assertNotNull(deleteByQueryRequestValue.query());
     BoolQuery query = deleteByQueryRequestValue.query().bool();
     assertEquals("1", query.minimumShouldMatch());
 
@@ -530,23 +536,64 @@ public class OpenSearchIndexerTest {
     assertEquals(0, query.must().size());
     assertEquals(0, query.mustNot().size());
 
-    // we expect 2 termQueries doc1field and doc2field
+    // with correct grouping by configured field name, we expect one terms query on "field"
+    // containing all deleteByFieldValue values from the batch.
     List<Query> queries = query.should();
-    assertEquals(2, queries.size());
+    assertEquals(1, queries.size());
     TermsQuery query1 = queries.get(0).terms();
-    TermsQuery query2 = queries.get(1).terms();
 
-    assertEquals("doc1field", query1.field());
-    assertEquals("doc2field", query2.field());
+    assertEquals("field", query1.field());
 
     List<FieldValue> fieldValues1 = query1.terms().value();
-    List<FieldValue> fieldValues2 = query2.terms().value();
-    assertEquals(2, fieldValues1.size());
-    assertEquals(1, fieldValues2.size());
+    assertEquals(3, fieldValues1.size());
+    Set<String> values = fieldValues1.stream().map(FieldValue::stringValue).collect(Collectors.toSet());
+    assertEquals(new HashSet<>(List.of("doc1value", "doc1v2value", "doc2value")), values);
+  }
 
-    assertEquals("doc1value", fieldValues1.get(0).stringValue());
-    assertEquals("doc1v2value", fieldValues1.get(1).stringValue());
-    assertEquals("doc2value", fieldValues2.get(0).stringValue());
+  @Test
+  public void testDeleteUsesIdOverride() throws Exception {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/batching.conf")
+        .withValue("indexer.idOverrideField", ConfigValueFactory.fromAnyRef("other_id"));
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", mockClient);
+
+    Document deletedDoc = Document.create("doc-original", "test_run");
+    deletedDoc.setField("other_id", "doc-override");
+    deletedDoc.setField("deleted", "true");
+
+    messenger.sendForIndexing(deletedDoc);
+    indexer.run(1);
+
+    ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(mockClient, times(1)).bulk(bulkRequestArgumentCaptor.capture());
+    BulkRequest br = bulkRequestArgumentCaptor.getValue();
+    assertEquals(1, br.operations().size());
+    // delete path should use id override just like index/update paths.
+    assertNotNull(br.operations().get(0).delete());
+    assertEquals("doc-override", br.operations().get(0).delete().id());
+  }
+
+  @Test
+  public void testDeleteUsesFileExpiredMarker() throws Exception {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/batching.conf")
+        .withValue("indexer.deletionMarkerField", ConfigValueFactory.fromAnyRef("file_expired"))
+        .withValue("indexer.deletionMarkerFieldValue", ConfigValueFactory.fromAnyRef("true"));
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", mockClient);
+
+    Document expiredDoc = Document.create("doc-expired", "test_run");
+    // deletion marker check uses getString(), so boolean true matches "true".
+    expiredDoc.setField("file_expired", true);
+
+    messenger.sendForIndexing(expiredDoc);
+    indexer.run(1);
+
+    ArgumentCaptor<BulkRequest> bulkRequestArgumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(mockClient, times(1)).bulk(bulkRequestArgumentCaptor.capture());
+    BulkRequest br = bulkRequestArgumentCaptor.getValue();
+    assertEquals(1, br.operations().size());
+    assertNotNull(br.operations().get(0).delete());
+    assertEquals("doc-expired", br.operations().get(0).delete().id());
   }
 
   @Test


### PR DESCRIPTION
There seems to be basic incremental search logic missing from TraversalParams code to make sure a document is a candidate for index update due to having a newer modification date than last published date.

If a document was never published, it should automatically be a candidate for publishing, but if it was previously published and hasn't been modified since, it shouldn't need an update.

A full update can be forced by deleting state information before an index, which should cause all document to look new. 

Expected Behavior: 
1st Ingest: 6 documents ingested, 6 documents published
2nd ingest: 6 documents (or urls) ingested, not were modified, 0 documents published
3rd ingest: 6 documents (urls) ingestsed, one was modified, 1 document published

Behavior Seen:
Documents ingested, not cutoffs, docs always published