### PR TITLE
Register ConfigInfo resource in API application

### DIFF
--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
@@ -7,6 +7,7 @@ import com.kmwllc.lucille.auth.BasicAuthenticator;
 import com.kmwllc.lucille.config.AuthConfiguration.AuthType;
 import com.kmwllc.lucille.config.LucilleAPIConfiguration;
 import com.kmwllc.lucille.core.RunnerManager;
+import com.kmwllc.lucille.endpoints.ConfigInfo;
 import com.kmwllc.lucille.endpoints.LivenessResource;
 import com.kmwllc.lucille.endpoints.LucilleResource;
 import com.kmwllc.lucille.endpoints.ReadinessResource;
@@ -124,6 +125,7 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
 
     // Register SystemStatsResource
     env.jersey().register(new SystemStatsResource());
+    env.jersey().register(new ConfigInfo(authHandler));
   }
 
   /**


### PR DESCRIPTION
## Summary

- ConfigInfo endpoints (`/v1/config-info/connector-list`, `/stage-list`, `/indexer-list`) were implemented but never registered in `APIApplication.run()`, making them unreachable
- Adds the missing one-line registration: `env.jersey().register(new ConfigInfo(authHandler))`

## Context

Discovered while building an admin dashboard that consumes these endpoints. The `ConfigInfo` class and its JAX-RS annotations are fully implemented — it just wasn't wired up.

## Test plan

- [ ] Start lucille-api with `java -Dconfig.file=conf/simple-config.conf -jar target/lucille-api-plugin.jar server conf/api.yml`
- [ ] Verify `curl http://localhost:8080/v1/config-info/connector-list` returns connector specs (previously returned 404)
- [ ] Verify `curl http://localhost:8080/v1/config-info/stage-list` returns stage specs
- [ ] Verify `curl http://localhost:8080/v1/config-info/indexer-list` returns indexer specs
- [ ] Verify existing endpoints (`/v1/systemstats`, `/v1/config`, `/v1/run`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)