### PR TITLE
LC-865: Support Redis as store for retry counters

### DIFF
--- a/application-example.conf
+++ b/application-example.conf
@@ -251,8 +251,12 @@ worker {
 
   # maximum number of times across all workers that an attempt should be made to process any given document;
   # when this property is not provided, retries will not be tracked and no limit will be imposed;
-  # this property requires that zookeeper is available at the specified zookeeper.connectString
+  # this property requires that zookeeper or redis is available (see worker.retryCounterStore)
   maxRetries: 2
+
+  # store to use for tracking retry counters; valid values are "zookeeper" (default) and "redis";
+  # "zookeeper" requires zookeeper.connectString; "redis" requires redis.host / redis.port
+  retryCounterStore: zookeeper
 
   # tell the worker process to generate a heartbeat.log that can be used to check liveness
   # the frequency of the heartbeat is controlled by log.seconds
@@ -260,8 +264,16 @@ worker {
 }
 
 zookeeper {
-  # connect string for zookeeper ensemble to use when worker.maxRetries is set
+  # connect string for zookeeper ensemble to use when worker.maxRetries is set and worker.retryCounterStore is "zookeeper"
   connectString: "localhost:2181"
+}
+
+redis {
+  # host and port for Redis when worker.maxRetries is set and worker.retryCounterStore is "redis"
+  host: "localhost"
+  port: 6379
+  # optional TTL in seconds for retry counter keys (default: 86400 / 24 hours)
+  # ttlSeconds: 86400
 }
 
 ################

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -73,6 +73,11 @@
       <version>5.1.0</version>
     </dependency>
     <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>5.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.1.0-jre</version>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RedisRetryCounter.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RedisRetryCounter.java
@@ -1,0 +1,98 @@
+package com.kmwllc.lucille.core;
+
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+/**
+ * A {@link RetryCounter} implementation that uses Redis (via Jedis) to store per-document retry
+ * counts. Counters are stored as Redis keys with an optional TTL so they are automatically cleaned
+ * up even if {@link #remove(Document)} is never called.
+ *
+ * <p>Required configuration:
+ * <ul>
+ *   <li>{@code redis.host} – Redis host (default: {@code localhost})</li>
+ *   <li>{@code redis.port} – Redis port (default: {@code 6379})</li>
+ * </ul>
+ *
+ * <p>Optional configuration:
+ * <ul>
+ *   <li>{@code redis.ttlSeconds} – TTL in seconds for each counter key (default: {@code 86400})</li>
+ * </ul>
+ */
+public class RedisRetryCounter implements RetryCounter {
+
+  private static final Logger log = LoggerFactory.getLogger(RedisRetryCounter.class);
+
+  static final int DEFAULT_TTL_SECONDS = 86400;
+  static final String KEY_PREFIX = "LucilleCounters:";
+
+  // Functional interface for the Redis operations we need, enabling easy unit testing.
+  @FunctionalInterface
+  interface RedisOperation<T> {
+    T execute(Jedis jedis);
+  }
+
+  private final JedisPool jedisPool;
+  private final int maxRetries;
+  private final long ttlSeconds;
+  private final String keyPrefix;
+
+  public RedisRetryCounter(Config config) {
+    this.maxRetries = config.hasPath("worker.maxRetries") ? config.getInt("worker.maxRetries") : 3;
+    this.ttlSeconds = config.hasPath("redis.ttlSeconds") ? config.getLong("redis.ttlSeconds") : DEFAULT_TTL_SECONDS;
+    String consumerGroupId = config.hasPath("kafka.consumerGroupId") ? config.getString("kafka.consumerGroupId") : "default";
+    this.keyPrefix = KEY_PREFIX + consumerGroupId + ":";
+
+    String host = config.hasPath("redis.host") ? config.getString("redis.host") : "localhost";
+    int port = config.hasPath("redis.port") ? config.getInt("redis.port") : 6379;
+    this.jedisPool = new JedisPool(new JedisPoolConfig(), host, port);
+  }
+
+  // Package-private constructor for testing with a pre-built pool
+  RedisRetryCounter(Config config, JedisPool jedisPool) {
+    this.maxRetries = config.hasPath("worker.maxRetries") ? config.getInt("worker.maxRetries") : 3;
+    this.ttlSeconds = config.hasPath("redis.ttlSeconds") ? config.getLong("redis.ttlSeconds") : DEFAULT_TTL_SECONDS;
+    String consumerGroupId = config.hasPath("kafka.consumerGroupId") ? config.getString("kafka.consumerGroupId") : "default";
+    this.keyPrefix = KEY_PREFIX + consumerGroupId + ":";
+    this.jedisPool = jedisPool;
+  }
+
+  @Override
+  public boolean add(Document document) {
+    String key = getKey(document);
+    long retryCount = 0;
+    try (Jedis jedis = jedisPool.getResource()) {
+      retryCount = jedis.incr(key);
+      jedis.expire(key, ttlSeconds);
+    } catch (Exception e) {
+      log.error("Couldn't access Redis retry counter for doc " + document.getId(), e);
+      // optimistically assume the document has not exceeded the max
+      return false;
+    }
+    return retryCount > maxRetries;
+  }
+
+  @Override
+  public void remove(Document document) {
+    String key = getKey(document);
+    try (Jedis jedis = jedisPool.getResource()) {
+      jedis.del(key);
+    } catch (Exception e) {
+      log.error("Couldn't delete Redis retry counter for doc " + document.getId(), e);
+    }
+  }
+
+  // Package-private for testing
+  String getKey(Document document) {
+    if (document instanceof KafkaDocument) {
+      KafkaDocument doc = (KafkaDocument) document;
+      return keyPrefix + doc.getTopic() + ":" + doc.getRunId() + ":" + doc.getKey()
+          + "___" + doc.getPartition() + "_" + doc.getOffset();
+    }
+    return keyPrefix + "NON_KAFKA:" + document.getRunId() + ":" + document.getId();
+  }
+}

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Worker.java
@@ -49,9 +49,16 @@ class Worker implements Runnable {
     this.localRunId = localRunId;
     this.pipeline = Pipeline.fromConfig(config, pipelineName, metricsPrefix);
     if (config.hasPath("worker.maxRetries")) {
-      log.info("Retries will be tracked in Zookeeper with a configured maximum of: " + config.getInt("worker.maxRetries"));
+      String store = config.hasPath("worker.retryCounterStore") ? config.getString("worker.retryCounterStore") : "zookeeper";
+      int maxRetries = config.getInt("worker.maxRetries");
+      if ("redis".equalsIgnoreCase(store)) {
+        log.info("Retries will be tracked in Redis with a configured maximum of: " + maxRetries);
+        this.counter = new RedisRetryCounter(config);
+      } else {
+        log.info("Retries will be tracked in Zookeeper with a configured maximum of: " + maxRetries);
+        this.counter = new ZKRetryCounter(config);
+      }
       this.trackRetries = true;
-      this.counter = new ZKRetryCounter(config);
     }
     this.pollInstant = new AtomicReference();
     this.pollInstant.set(Instant.now());

--- a/lucille-core/src/main/resources/validConfigProperties.conf
+++ b/lucille-core/src/main/resources/validConfigProperties.conf
@@ -28,6 +28,10 @@ zookeeper {
   requiredProperties: ["connectString"]
 }
 
+redis {
+  optionalProperties: ["host", "port", "ttlSeconds"]
+}
+
 worker {
-  optionalProperties: ["pipeline", "threads", "exitOnTimeout", "maxProcessingSecs", "maxRetries", "enableHeartbeat"]
+  optionalProperties: ["pipeline", "threads", "exitOnTimeout", "maxProcessingSecs", "maxRetries", "enableHeartbeat", "retryCounterStore"]
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RedisRetryCounterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RedisRetryCounterTest.java
@@ -1,0 +1,177 @@
+package com.kmwllc.lucille.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.typesafe.config.ConfigFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class RedisRetryCounterTest {
+
+  /**
+   * A JedisPool backed by an in-memory map so tests never need a live Redis server
+   * and avoid Mockito/Byte Buddy issues with the large Jedis class hierarchy.
+   */
+  private static class FakeJedisPool extends JedisPool {
+
+    final Map<String, Long> counters = new HashMap<>();
+    final List<String> deleted = new ArrayList<>();
+    final List<long[]> expiries = new ArrayList<>();
+    boolean throwOnNext = false;
+
+    FakeJedisPool() {
+      super(new GenericObjectPoolConfig<>(), "localhost", 6379, 1, null, 0, null);
+    }
+
+    @Override
+    public Jedis getResource() {
+      if (throwOnNext) {
+        throw new RuntimeException("Redis unavailable");
+      }
+      return new Jedis("localhost", 6379) {
+        @Override
+        public long incr(String key) {
+          long val = counters.getOrDefault(key, 0L) + 1;
+          counters.put(key, val);
+          return val;
+        }
+
+        @Override
+        public long expire(String key, long seconds) {
+          expiries.add(new long[]{seconds});
+          return 1L;
+        }
+
+        @Override
+        public long del(String... keys) {
+          for (String k : keys) {
+            counters.remove(k);
+            deleted.add(k);
+          }
+          return (long) keys.length;
+        }
+
+        @Override
+        public long del(String key) {
+          counters.remove(key);
+          deleted.add(key);
+          return 1L;
+        }
+
+        @Override
+        public void close() {
+          // no-op
+        }
+      };
+    }
+  }
+
+  /** Creates a KafkaDocument with a known runId without needing Mockito spy. */
+  private static KafkaDocument kafkaDoc(String id, String runId, String topic, int partition, long offset, String key)
+      throws DocumentException {
+    return new KafkaDocument(Document.create(id, runId), topic, partition, offset, key);
+  }
+
+  @Test
+  public void testAddExceedsMax() throws Exception {
+    FakeJedisPool pool = new FakeJedisPool();
+    RedisRetryCounter counter = new RedisRetryCounter(
+        ConfigFactory.load("RedisRetryCounterTest/config.conf"), pool);
+
+    KafkaDocument doc = kafkaDoc("kafkaDoc", "runId", "topic", 1, 2, "key");
+
+    // maxRetries defaults to 3; call add 4 times — 4th should return true
+    assertFalse(counter.add(doc));
+    assertFalse(counter.add(doc));
+    assertFalse(counter.add(doc));
+    assertTrue(counter.add(doc));
+  }
+
+  @Test
+  public void testAddWithinMax() throws Exception {
+    FakeJedisPool pool = new FakeJedisPool();
+    // retry10.conf sets maxRetries: 10
+    RedisRetryCounter counter = new RedisRetryCounter(
+        ConfigFactory.load("RedisRetryCounterTest/retry10.conf"), pool);
+
+    Document doc = Document.create("jsonDoc", "runId2");
+    for (int i = 0; i < 5; i++) {
+      assertFalse(counter.add(doc));
+    }
+  }
+
+  @Test
+  public void testAddSetsExpiry() throws Exception {
+    FakeJedisPool pool = new FakeJedisPool();
+    RedisRetryCounter counter = new RedisRetryCounter(
+        ConfigFactory.load("RedisRetryCounterTest/config.conf"), pool);
+
+    Document doc = Document.create("jsonDoc", "runId1");
+    counter.add(doc);
+
+    assertEquals(1, pool.expiries.size());
+    assertEquals(RedisRetryCounter.DEFAULT_TTL_SECONDS, pool.expiries.get(0)[0]);
+  }
+
+  @Test
+  public void testRemoveKafkaAndNonKafka() throws Exception {
+    FakeJedisPool pool = new FakeJedisPool();
+    RedisRetryCounter counter = new RedisRetryCounter(
+        ConfigFactory.load("RedisRetryCounterTest/config.conf"), pool);
+
+    KafkaDocument kafkaDoc = kafkaDoc("kafkaDoc", "runId", "topic", 1, 2, "key");
+    Document doc = Document.create("jsonDoc", "runId2");
+
+    // seed counters first
+    counter.add(kafkaDoc);
+    counter.add(doc);
+
+    counter.remove(kafkaDoc);
+    counter.remove(doc);
+
+    assertEquals(2, pool.deleted.size());
+    assertTrue(pool.deleted.get(0).contains("topic"));
+    assertTrue(pool.deleted.get(1).contains("NON_KAFKA"));
+  }
+
+  @Test
+  public void testAddThrowsReturnsOptimisticFalse() throws Exception {
+    FakeJedisPool pool = new FakeJedisPool();
+    pool.throwOnNext = true;
+
+    RedisRetryCounter counter = new RedisRetryCounter(
+        ConfigFactory.load("RedisRetryCounterTest/config.conf"), pool);
+
+    Document doc = Document.create("jsonDoc", "runId1");
+    // on error, optimistically returns false (not exceeded)
+    assertFalse(counter.add(doc));
+  }
+
+  @Test
+  public void testKeyFormatKafkaDocument() throws Exception {
+    RedisRetryCounter counter = new RedisRetryCounter(
+        ConfigFactory.load("RedisRetryCounterTest/config.conf"), new FakeJedisPool());
+
+    KafkaDocument doc = kafkaDoc("kafkaDoc", "run1", "myTopic", 3, 7, "myKey");
+    // expected: LucilleCounters:bar:myTopic:run1:myKey___3_7
+    assertEquals("LucilleCounters:bar:myTopic:run1:myKey___3_7", counter.getKey(doc));
+  }
+
+  @Test
+  public void testKeyFormatNonKafkaDocument() throws Exception {
+    RedisRetryCounter counter = new RedisRetryCounter(
+        ConfigFactory.load("RedisRetryCounterTest/config.conf"), new FakeJedisPool());
+
+    Document doc = Document.create("myDoc", "run2");
+    // expected: LucilleCounters:bar:NON_KAFKA:run2:myDoc
+    assertEquals("LucilleCounters:bar:NON_KAFKA:run2:myDoc", counter.getKey(doc));
+  }
+}

--- a/lucille-core/src/test/resources/RedisRetryCounterTest/config.conf
+++ b/lucille-core/src/test/resources/RedisRetryCounterTest/config.conf
@@ -1,0 +1,8 @@
+redis {
+  host: "localhost"
+  port: 6379
+}
+
+kafka {
+  consumerGroupId: bar
+}

--- a/lucille-core/src/test/resources/RedisRetryCounterTest/retry10.conf
+++ b/lucille-core/src/test/resources/RedisRetryCounterTest/retry10.conf
@@ -1,0 +1,12 @@
+redis {
+  host: "localhost"
+  port: 6379
+}
+
+kafka {
+  consumerGroupId: bar
+}
+
+worker {
+  maxRetries: 10
+}


### PR DESCRIPTION
This PR aims to support Redis as a store for the retry counter logic that can be enabled with the `worker.maxRetries` config parameter.

The initial commit in this PR is purely AI-generated and has not yet gone through any human review.

The intent is to use the initial commit as a starting place for further refinement.

Here is the AI-generated summary of the changes:

- RedisRetryCounter.java — new RetryCounter implementation using Jedis. Uses INCR + EXPIRE for atomic counter-with-TTL semantics, and DEL on success. Keys follow the same namespacing pattern as ZKRetryCounter (LucilleCounters:{consumerGroupId}:{topic|NON_KAFKA}:{runId}:{docKey}).
- Worker.java — reads worker.retryCounterStore (defaults to "zookeeper") and instantiates either ZKRetryCounter or RedisRetryCounter accordingly.
- validConfigProperties.conf — added redis optional properties block and worker.retryCounterStore as an optional property.
- application-example.conf — documented the new retryCounterStore option and added a redis {} config block.
- pom.xml — added Jedis 5.2.0 dependency.
- RedisRetryCounterTest.java + test configs — 7 tests covering add/remove/key-format/error-handling, using a FakeJedisPool subclass to avoid needing a live Redis instance.