### PR TITLE
LC-858: make extended BaseStorageClient clients protected

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/AzureStorageClient.java
@@ -29,8 +29,8 @@ import org.slf4j.LoggerFactory;
  */
 public class AzureStorageClient extends BaseStorageClient {
 
-  private BlobServiceClient serviceClient;
   private static final Logger log = LoggerFactory.getLogger(AzureStorageClient.class);
+  protected BlobServiceClient serviceClient;
 
   /**
    * Creates an AzureStorageClient from the given azureCloudOptions, which must contain either "connectionString" OR

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/GoogleStorageClient.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 public class GoogleStorageClient extends BaseStorageClient {
 
   private static final Logger log = LoggerFactory.getLogger(GoogleStorageClient.class);
-  private Storage storage;
+  protected Storage storage;
 
   public GoogleStorageClient(Config googleCloudOptions) {
     super(googleCloudOptions);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/S3StorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/S3StorageClient.java
@@ -31,8 +31,8 @@ import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
  */
 public class S3StorageClient extends BaseStorageClient {
 
-  private S3Client s3;
   private static final Logger log = LoggerFactory.getLogger(S3StorageClient.class);
+  protected S3Client s3;
 
   public S3StorageClient(Config s3CloudOptions) {
     super(s3CloudOptions);


### PR DESCRIPTION
We want the ability to extend and add functionality to an implementation of a storage client. In order to do this, we need to be able to access the client fields in the subclass. This updates them to be protected instead of private.