### PR TITLE
LC-843: Adding incremental backoff logic to OpenSearchUtils

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/OpenSearchUtils.java
@@ -8,13 +8,17 @@ import java.net.URI;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.util.TimeValue;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
@@ -100,11 +104,21 @@ public class OpenSearchUtils {
 
           return httpClientBuilder
               .setDefaultCredentialsProvider(credentialsProvider)
-              .setConnectionManager(connectionManager);
+              .setConnectionManager(connectionManager)
+              .setRetryStrategy(buildRetryStrategy());
         })
         .build();
 
     return new OpenSearchClient(transport);
+  }
+
+  static DefaultHttpRequestRetryStrategy buildRetryStrategy() {
+    return new DefaultHttpRequestRetryStrategy(3, TimeValue.ofSeconds(1)) {
+      @Override
+      public TimeValue getRetryInterval(HttpResponse response, int execCount, HttpContext context) {
+        return TimeValue.ofSeconds((long) Math.pow(2, execCount)); // 2s, 4s, 8s
+      }
+    };
   }
 
   public static String getOpenSearchUrl(Config config) {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/OpenSearchUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/OpenSearchUtilsTest.java
@@ -3,7 +3,6 @@ package com.kmwllc.lucille.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,10 +18,14 @@ import java.security.KeyStore;
 import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.util.TimeValue;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
@@ -187,4 +190,44 @@ public class OpenSearchUtilsTest {
     assertThrows(Exception.class, () -> OpenSearchUtils.getOpenSearchRestClient(badUrlConfig));
 
   }
+
+  @Test
+  public void testRetryOn429and503WithIncrementalBackoff() {
+    DefaultHttpRequestRetryStrategy strategy = OpenSearchUtils.buildRetryStrategy();
+
+    HttpResponse response429 = new BasicHttpResponse(429, "Too Many Requests");
+
+    // On a 429, retry is allowed up to maxRetries of 3
+    assertTrue(strategy.retryRequest(response429, 1, null));
+    assertEquals(TimeValue.ofSeconds(2), strategy.getRetryInterval(response429, 1, null));
+
+    assertTrue(strategy.retryRequest(response429, 2, null));
+    assertEquals(TimeValue.ofSeconds(4), strategy.getRetryInterval(response429, 2, null));
+
+    assertTrue(strategy.retryRequest(response429, 3, null));
+    assertEquals(TimeValue.ofSeconds(8), strategy.getRetryInterval(response429, 3, null));
+
+    // No more retrying after maxRetries is hit
+    assertFalse(strategy.retryRequest(response429, 4, null));
+
+    // Replicate for a 503 code
+    HttpResponse response503 = new BasicHttpResponse(503, "Service Unavailable");
+
+    assertTrue(strategy.retryRequest(response503, 1, null));
+    assertEquals(TimeValue.ofSeconds(2), strategy.getRetryInterval(response429, 1, null));
+
+    assertTrue(strategy.retryRequest(response503, 2, null));
+    assertEquals(TimeValue.ofSeconds(4), strategy.getRetryInterval(response429, 2, null));
+
+    assertTrue(strategy.retryRequest(response503, 3, null));
+    assertEquals(TimeValue.ofSeconds(8), strategy.getRetryInterval(response429, 3, null));
+
+    // No more retrying after maxRetries is hit
+    assertFalse(strategy.retryRequest(response503, 4, null));
+
+    // 200 should not retry
+    HttpResponse response200 = new BasicHttpResponse(200, "OK");
+    assertFalse(strategy.retryRequest(response200, 1, null));
+  }
+
 }


### PR DESCRIPTION
If an OpenSearch cluster is under heavy load we will sometimes get a error code when trying to send batches from the Lucille indexer:
`429 too many requests`

When this error is received today, the Lucille indexer just fails the current batch and sends a new batch of content. This behavior often just results in more failed batches.

This PR tells the indexer to engage in incremental backoffs when a 429 or 503 error is received using the setRetryStrategy() that comes with HttpClientBuilder.

We would like to test this using a local OpenSearch instance, as well as a customer instance for real verifiability.