### PR TITLE
LC-862: Add ability for Indexer to retry a batch

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -73,6 +73,11 @@
       <version>5.1.0</version>
     </dependency>
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.1.0-jre</version>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -371,6 +371,10 @@ public abstract class Indexer implements Runnable {
     try {
       stopWatch.reset();
       stopWatch.start();
+      // Note: the retry wraps the entire sendToIndex() call. If sendToIndex() partially succeeds
+      // (e.g. some documents indexed before a subsequent delete-by-query fails), a retry will
+      // re-execute the entire method. This is considered safe because search engine upserts are idempotent —
+      // re-indexing an already-indexed document produces the same result.
       Set<Pair<Document, String>> failedDocPairs = retry != null
           ? Retry.decorateCheckedSupplier(retry, () -> sendToIndex(batchedDocs)).get()
           : sendToIndex(batchedDocs);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -80,22 +80,24 @@ import sun.misc.Signal;
  *   <li>indexer.deleteByFieldValue (String, Optional) : Field whose value specifies which documents to delete by query. Must be set
  *   together with indexer.deleteByFieldField.</li>
  *   <li>indexer.maxRetries (Integer, Optional) : Maximum number of times to retry a failed batch before treating all documents
- *   in the batch as failures. Retries are disabled by default ({@value #DEFAULT_MAX_RETRIES}); set to a positive integer to opt in.</li>
+ *   in the batch as failures. Retries are disabled by default; set to a positive integer to opt in. A value of 0 or less
+ *   is rejected as invalid — remove the parameter entirely to disable retries.</li>
  *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
- *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only relevant when maxRetries is greater than 0.
+ *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only allowed when maxRetries is also set.
  *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
  *   <li>indexer.retryableStatusCodes (List&lt;Integer&gt;, Optional) : HTTP status codes that should trigger a retry when thrown
  *   as an {@link IndexerRetryableException}. Failures with status codes not in this list, or plain {@link IndexerException}
- *   failures, will not be retried. Defaults to {@code [429, 503]}. Only relevant when maxRetries is greater than 0.</li>
+ *   failures, will not be retried. Include the sentinel value {@code -1} to also retry failures where no HTTP status code
+ *   is available (e.g. network timeouts). When this parameter is omitted, the default {@code [429, 503, -1]} is used.
+ *   An empty list is rejected as invalid configuration. Only allowed when maxRetries is also set.</li>
  * </ul>
  */
 public abstract class Indexer implements Runnable {
 
   public static final int DEFAULT_BATCH_SIZE = 100;
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
-  public static final int DEFAULT_MAX_RETRIES = 0;
   public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
-  public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503);
+  public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503, IndexerRetryableException.UNKNOWN_STATUS_CODE);
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
   private static final Logger docLogger = LoggerFactory.getLogger("com.kmwllc.lucille.core.DocLogger");
@@ -128,7 +130,7 @@ public abstract class Indexer implements Runnable {
 
   protected final boolean bypass;
 
-  // Non-null only when indexer.maxRetries > 0; null means retries are disabled (the default).
+  // Non-null only when indexer.maxRetries is configured; null means retries are disabled (the default).
   private final Retry retry;
 
   public void terminate() {
@@ -206,20 +208,36 @@ public abstract class Indexer implements Runnable {
 
     this.fieldFilter = new FieldFilter(config.getConfig("indexer"));
 
-    int maxRetries = ConfigUtils.getOrDefault(config, "indexer.maxRetries", DEFAULT_MAX_RETRIES);
-    int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
-    if (maxRetries > 0) {
-      List<Integer> retryableStatusCodes = config.hasPath("indexer.retryableStatusCodes")
-          ? config.getIntList("indexer.retryableStatusCodes")
-          : DEFAULT_RETRYABLE_STATUS_CODES;
+    if (!config.hasPath("indexer.maxRetries")) {
+      if (config.hasPath("indexer.retryWaitDurationMs") || config.hasPath("indexer.retryableStatusCodes")) {
+        throw new IllegalArgumentException(
+            "indexer.retryWaitDurationMs and indexer.retryableStatusCodes require indexer.maxRetries to be set.");
+      }
+      this.retry = null;
+    } else {
+      int maxRetries = config.getInt("indexer.maxRetries");
+      if (maxRetries <= 0) {
+        throw new IllegalArgumentException(
+            "indexer.maxRetries must be greater than 0 when specified. Remove the parameter to disable retries.");
+      }
+      int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
+      List<Integer> retryableStatusCodes;
+      if (!config.hasPath("indexer.retryableStatusCodes")) {
+        retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES;
+      } else {
+        retryableStatusCodes = config.getIntList("indexer.retryableStatusCodes");
+        if (retryableStatusCodes.isEmpty()) {
+          throw new IllegalArgumentException(
+              "indexer.retryableStatusCodes must not be empty when specified. "
+                  + "Remove the parameter to use the default, or provide at least one status code.");
+        }
+      }
       this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
           .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
           .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
           .retryOnException(e -> {
             if (e instanceof IndexerRetryableException retryable) {
-              // Retry if the status code is in the configured list, or if no status code is known
-              return retryable.getStatusCode() == IndexerRetryableException.UNKNOWN_STATUS_CODE
-                  || retryableStatusCodes.contains(retryable.getStatusCode());
+              return retryableStatusCodes.contains(retryable.getStatusCode());
             }
             // Plain IndexerException (non-HTTP failure) — do not retry
             return false;
@@ -230,8 +248,6 @@ public abstract class Indexer implements Runnable {
               event.getNumberOfRetryAttempts(), maxRetries,
               event.getWaitInterval().toMillis(),
               event.getLastThrowable().getMessage()));
-    } else {
-      this.retry = null;
     }
 
     // Validate the "indexer" entry and the specific implementation entry (using the spec) in the Config, if present.
@@ -391,19 +407,22 @@ public abstract class Indexer implements Runnable {
           messenger.sendEvent(d, "SUCCEEDED", Event.Type.FINISH);
           docLogger.info("Sent success message for doc {}.", d.getId());
         } catch (Exception e) {
-          // TODO: The run won't be able to finish if this event isn't received; can we do something
-          // special here?
-          log.error("Error sending completion event for doc {}", d.getId(), e);
+          log.error("Error sending completion event for doc {}. RUN WILL HANG.", d.getId(), e);
         } finally {
           if (d.getRunId() != null) {
             MDC.popByKey(RUNID_FIELD);
           }
         }
       }
-    } catch (Throwable e) {
+    } catch (Throwable t) {
+      // Rethrow Errors (OutOfMemoryError, etc.) — they should never be swallowed
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      Exception e = (t instanceof Exception) ? (Exception) t : new RuntimeException(t);
       // If an Exception is thrown, there was some larger error causing nothing (or essentially nothing) to be indexed.
       // So everything is considered to have failed - we won't even look at failedDocs.
-      log.error("Error sending documents to index: " + e.getMessage(), e);
+      log.error("Error sending documents to index: {}", e.getMessage(), e);
 
       for (Document d : batchedDocs) {
         try (MDCCloseable docIdMDC = MDC.putCloseable(ID_FIELD, d.getId())) {
@@ -414,9 +433,7 @@ public abstract class Indexer implements Runnable {
           messenger.sendEvent(d, "FAILED: " + e.getMessage(), Event.Type.FAIL);
           docLogger.error("Sent failure message for doc {}. Reason: {}", d.getId(), e.getMessage());
         } catch (Exception e2) {
-          // TODO: The run won't be able to finish if this event isn't received; can we do something
-          // special here?
-          log.error("Couldn't send failure event for doc {}", d.getId(), e2);
+          log.error("Couldn't send failure event for doc {}. RUN WILL HANG.", d.getId(), e2);
         } finally {
           if (d.getRunId() != null) {
             MDC.popByKey(RUNID_FIELD);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -17,6 +17,9 @@ import com.kmwllc.lucille.util.FieldFilter;
 import com.kmwllc.lucille.util.LogUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.StopWatch;
@@ -73,12 +76,19 @@ import sun.misc.Signal;
  *   together with indexer.deleteByFieldValue.</li>
  *   <li>indexer.deleteByFieldValue (String, Optional) : Field whose value specifies which documents to delete by query. Must be set
  *   together with indexer.deleteByFieldField.</li>
+ *   <li>indexer.maxRetries (Integer, Optional) : Maximum number of times to retry a failed batch before treating all documents
+ *   in the batch as failures. Retries are disabled by default ({@value #DEFAULT_MAX_RETRIES}); set to a positive integer to opt in.</li>
+ *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
+ *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only relevant when maxRetries is greater than 0.
+ *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
  * </ul>
  */
 public abstract class Indexer implements Runnable {
 
   public static final int DEFAULT_BATCH_SIZE = 100;
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
+  public static final int DEFAULT_MAX_RETRIES = 0;
+  public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
   private static final Logger docLogger = LoggerFactory.getLogger("com.kmwllc.lucille.core.DocLogger");
@@ -110,6 +120,9 @@ public abstract class Indexer implements Runnable {
   private final String localRunId;
 
   protected final boolean bypass;
+
+  // Non-null only when indexer.maxRetries > 0; null means retries are disabled (the default).
+  private final Retry retry;
 
   public void terminate() {
     running = false;
@@ -185,6 +198,22 @@ public abstract class Indexer implements Runnable {
     this.localRunId = localRunId;
 
     this.fieldFilter = new FieldFilter(config.getConfig("indexer"));
+
+    int maxRetries = ConfigUtils.getOrDefault(config, "indexer.maxRetries", DEFAULT_MAX_RETRIES);
+    int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
+    if (maxRetries > 0) {
+      this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
+          .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
+          .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
+          .build());
+      this.retry.getEventPublisher().onRetry(event ->
+          log.warn("Retrying batch send (attempt {}/{}), waiting {}ms: {}",
+              event.getNumberOfRetryAttempts(), maxRetries,
+              event.getWaitInterval().toMillis(),
+              event.getLastThrowable().getMessage()));
+    } else {
+      this.retry = null;
+    }
 
     // Validate the "indexer" entry and the specific implementation entry (using the spec) in the Config, if present.
     validateIndexerConfigs(config);
@@ -307,7 +336,9 @@ public abstract class Indexer implements Runnable {
     try {
       stopWatch.reset();
       stopWatch.start();
-      Set<Pair<Document, String>> failedDocPairs = sendToIndex(batchedDocs);
+      Set<Pair<Document, String>> failedDocPairs = retry != null
+          ? Retry.decorateCheckedSupplier(retry, () -> sendToIndex(batchedDocs)).get()
+          : sendToIndex(batchedDocs);
       stopWatch.stop();
       histogram.update(stopWatch.getNanoTime() / batchedDocs.size());
       meter.mark(batchedDocs.size());
@@ -350,7 +381,7 @@ public abstract class Indexer implements Runnable {
           }
         }
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       // If an Exception is thrown, there was some larger error causing nothing (or essentially nothing) to be indexed.
       // So everything is considered to have failed - we won't even look at failedDocs.
       log.error("Error sending documents to index: " + e.getMessage(), e);
@@ -457,7 +488,7 @@ public abstract class Indexer implements Runnable {
     SpecBuilder.withoutDefaults()
         .optionalString("type", "class", "idOverrideField", "indexOverrideField", "deletionMarkerField", "deletionMarkerFieldValue",
             "deleteByFieldField", "deleteByFieldValue", "versionType", "routingField")
-        .optionalNumber("batchSize", "batchTimeout", "logRate")
+        .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs")
         .optionalBoolean("sendEnabled")
         .optionalList("whitelist", new TypeReference<List<String>>(){})
         .optionalList("blacklist", new TypeReference<List<String>>(){}).build()

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -85,6 +85,13 @@ import sun.misc.Signal;
  *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
  *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only allowed when maxRetries is also set.
  *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
+ *   <li>indexer.retryMaxWaitDurationMs (Long, Optional) : Maximum wait duration in milliseconds between retries.
+ *   Caps the exponential backoff so it does not grow unbounded. Only allowed when maxRetries is also set.
+ *   Defaults to {@value #DEFAULT_RETRY_MAX_WAIT_DURATION_MS}.</li>
+ *   <li>indexer.retryRandomizationFactor (Double, Optional) : Randomization factor applied to the wait duration
+ *   to add jitter and prevent thundering-herd effects. A value of 0.5 means the actual wait will be between
+ *   50% and 150% of the computed backoff. Set to 0.0 to disable jitter. Only allowed when maxRetries is also set.
+ *   Defaults to {@value #DEFAULT_RETRY_RANDOMIZATION_FACTOR}.</li>
  *   <li>indexer.retryableStatusCodes (List&lt;Integer&gt;, Optional) : HTTP status codes that should trigger a retry when thrown
  *   as an {@link IndexerRetryableException}. Failures with status codes not in this list, or plain {@link IndexerException}
  *   failures, will not be retried. Include the sentinel value {@code -1} to also retry failures where no HTTP status code
@@ -97,6 +104,8 @@ public abstract class Indexer implements Runnable {
   public static final int DEFAULT_BATCH_SIZE = 100;
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
   public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
+  public static final long DEFAULT_RETRY_MAX_WAIT_DURATION_MS = 30000;
+  public static final double DEFAULT_RETRY_RANDOMIZATION_FACTOR = 0.5;
   public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503, IndexerRetryableException.UNKNOWN_STATUS_CODE);
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
@@ -209,9 +218,11 @@ public abstract class Indexer implements Runnable {
     this.fieldFilter = new FieldFilter(config.getConfig("indexer"));
 
     if (!config.hasPath("indexer.maxRetries")) {
-      if (config.hasPath("indexer.retryWaitDurationMs") || config.hasPath("indexer.retryableStatusCodes")) {
+      if (config.hasPath("indexer.retryWaitDurationMs") || config.hasPath("indexer.retryableStatusCodes")
+          || config.hasPath("indexer.retryMaxWaitDurationMs") || config.hasPath("indexer.retryRandomizationFactor")) {
         throw new IllegalArgumentException(
-            "indexer.retryWaitDurationMs and indexer.retryableStatusCodes require indexer.maxRetries to be set.");
+            "indexer.retryWaitDurationMs, indexer.retryMaxWaitDurationMs, indexer.retryRandomizationFactor, "
+                + "and indexer.retryableStatusCodes require indexer.maxRetries to be set.");
       }
       this.retry = null;
     } else {
@@ -221,6 +232,10 @@ public abstract class Indexer implements Runnable {
             "indexer.maxRetries must be greater than 0 when specified. Remove the parameter to disable retries.");
       }
       int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
+      long retryMaxWaitDurationMs = config.hasPath("indexer.retryMaxWaitDurationMs")
+          ? config.getLong("indexer.retryMaxWaitDurationMs") : DEFAULT_RETRY_MAX_WAIT_DURATION_MS;
+      double retryRandomizationFactor = config.hasPath("indexer.retryRandomizationFactor")
+          ? config.getDouble("indexer.retryRandomizationFactor") : DEFAULT_RETRY_RANDOMIZATION_FACTOR;
       List<Integer> retryableStatusCodes;
       if (!config.hasPath("indexer.retryableStatusCodes")) {
         retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES;
@@ -234,7 +249,9 @@ public abstract class Indexer implements Runnable {
       }
       this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
           .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
-          .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
+          .intervalFunction(IntervalFunction.ofExponentialRandomBackoff(
+              retryInitialWaitDurationMs, IntervalFunction.DEFAULT_MULTIPLIER,
+              retryRandomizationFactor, retryMaxWaitDurationMs))
           .retryOnException(e -> {
             if (e instanceof IndexerRetryableException retryable) {
               return retryableStatusCodes.contains(retryable.getStatusCode());
@@ -528,7 +545,8 @@ public abstract class Indexer implements Runnable {
     SpecBuilder.withoutDefaults()
         .optionalString("type", "class", "idOverrideField", "indexOverrideField", "deletionMarkerField", "deletionMarkerFieldValue",
             "deleteByFieldField", "deleteByFieldValue", "versionType", "routingField")
-        .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs")
+        .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs",
+            "retryMaxWaitDurationMs", "retryRandomizationFactor")
         .optionalBoolean("sendEnabled")
         .optionalList("whitelist", new TypeReference<List<String>>(){})
         .optionalList("blacklist", new TypeReference<List<String>>(){})

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -20,6 +20,9 @@ import com.typesafe.config.ConfigFactory;
 import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.StopWatch;
@@ -81,6 +84,9 @@ import sun.misc.Signal;
  *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
  *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only relevant when maxRetries is greater than 0.
  *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
+ *   <li>indexer.retryableStatusCodes (List&lt;Integer&gt;, Optional) : HTTP status codes that should trigger a retry when thrown
+ *   as an {@link IndexerRetryableException}. Failures with status codes not in this list, or plain {@link IndexerException}
+ *   failures, will not be retried. Defaults to {@code [429, 503]}. Only relevant when maxRetries is greater than 0.</li>
  * </ul>
  */
 public abstract class Indexer implements Runnable {
@@ -89,6 +95,7 @@ public abstract class Indexer implements Runnable {
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
   public static final int DEFAULT_MAX_RETRIES = 0;
   public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
+  public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503);
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
   private static final Logger docLogger = LoggerFactory.getLogger("com.kmwllc.lucille.core.DocLogger");
@@ -202,9 +209,21 @@ public abstract class Indexer implements Runnable {
     int maxRetries = ConfigUtils.getOrDefault(config, "indexer.maxRetries", DEFAULT_MAX_RETRIES);
     int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
     if (maxRetries > 0) {
+      List<Integer> retryableStatusCodes = config.hasPath("indexer.retryableStatusCodes")
+          ? config.getIntList("indexer.retryableStatusCodes")
+          : DEFAULT_RETRYABLE_STATUS_CODES;
       this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
           .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
           .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
+          .retryOnException(e -> {
+            if (e instanceof IndexerRetryableException retryable) {
+              // Retry if the status code is in the configured list, or if no status code is known
+              return retryable.getStatusCode() == IndexerRetryableException.UNKNOWN_STATUS_CODE
+                  || retryableStatusCodes.contains(retryable.getStatusCode());
+            }
+            // Plain IndexerException (non-HTTP failure) — do not retry
+            return false;
+          })
           .build());
       this.retry.getEventPublisher().onRetry(event ->
           log.warn("Retrying batch send (attempt {}/{}), waiting {}ms: {}",
@@ -491,7 +510,8 @@ public abstract class Indexer implements Runnable {
         .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs")
         .optionalBoolean("sendEnabled")
         .optionalList("whitelist", new TypeReference<List<String>>(){})
-        .optionalList("blacklist", new TypeReference<List<String>>(){}).build()
+        .optionalList("blacklist", new TypeReference<List<String>>(){})
+        .optionalList("retryableStatusCodes", new TypeReference<List<Integer>>(){}).build()
         .validate(indexerConfig, "Indexer");
 
     // Validate the specific implementation in the config (solr, elasticsearch, csv, ...) if it is present / needed.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
@@ -1,0 +1,52 @@
+package com.kmwllc.lucille.core;
+
+/**
+ * Thrown by an {@link Indexer} implementation when a batch send fails with an HTTP-level error
+ * that may be transient and worth retrying. Carries the HTTP status code so that the base
+ * {@link Indexer} can decide whether to retry based on the configured
+ * {@code indexer.retryableStatusCodes} list.
+ *
+ * <p>Use {@link IndexerException} instead when the failure is not HTTP-based or should never
+ * be retried regardless of configuration.
+ */
+public class IndexerRetryableException extends IndexerException {
+
+  /** Sentinel value used when no HTTP status code is available (e.g. a pure network failure). */
+  public static final int UNKNOWN_STATUS_CODE = -1;
+
+  private final int statusCode;
+
+  /**
+   * Creates an exception with a known HTTP status code.
+   *
+   * @param statusCode the HTTP status code returned by the backend
+   * @param message    a description of the failure
+   * @param cause      the underlying exception
+   */
+  public IndexerRetryableException(int statusCode, String message, Throwable cause) {
+    super(message, cause);
+    this.statusCode = statusCode;
+  }
+
+  /**
+   * Creates an exception for a non-HTTP failure (e.g. a network timeout) where no status code
+   * is available. Uses {@value #UNKNOWN_STATUS_CODE} as the status code.
+   *
+   * @param message a description of the failure
+   * @param cause   the underlying exception
+   */
+  public IndexerRetryableException(String message, Throwable cause) {
+    super(message, cause);
+    this.statusCode = UNKNOWN_STATUS_CODE;
+  }
+
+  /**
+   * Returns the HTTP status code associated with this failure, or {@value #UNKNOWN_STATUS_CODE}
+   * if no status code is available.
+   *
+   * @return the HTTP status code, or {@value #UNKNOWN_STATUS_CODE}
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+}

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
@@ -6,6 +6,11 @@ package com.kmwllc.lucille.core;
  * {@link Indexer} can decide whether to retry based on the configured
  * {@code indexer.retryableStatusCodes} list.
  *
+ * <p>When no HTTP status code is available (e.g. a pure network failure), the sentinel value
+ * {@link #UNKNOWN_STATUS_CODE} ({@value #UNKNOWN_STATUS_CODE}) is used. The Indexer retries
+ * unknown-status-code failures only when the user omits {@code indexer.retryableStatusCodes}
+ * (using the default) or explicitly includes {@value #UNKNOWN_STATUS_CODE} in the list.
+ *
  * <p>Use {@link IndexerException} instead when the failure is not HTTP-based or should never
  * be retried regardless of configuration.
  */

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -196,7 +196,15 @@ public class OpenSearchIndexer extends Indexer {
       );
     }
 
-    BulkResponse response = client.bulk(br.build());
+    BulkResponse response;
+    try {
+      response = client.bulk(br.build());
+    } catch (org.opensearch.client.opensearch._types.OpenSearchException e) {
+      throw new IndexerRetryableException(e.status(), "OpenSearch returned HTTP " + e.status(), e);
+    } catch (IOException e) {
+      throw new IndexerRetryableException("Transport failure communicating with OpenSearch", e);
+    }
+
     if (response.errors()) {
       for (BulkResponseItem item : response.items()) {
         if (item.error() != null) {
@@ -276,7 +284,15 @@ public class OpenSearchIndexer extends Indexer {
           .index(entry.getKey())
           .query(q -> q.bool(boolQuery.build()))
           .build();
-      DeleteByQueryResponse response = client.deleteByQuery(deleteByQueryRequest);
+
+      DeleteByQueryResponse response;
+      try {
+        response = client.deleteByQuery(deleteByQueryRequest);
+      } catch (org.opensearch.client.opensearch._types.OpenSearchException e) {
+        throw new IndexerRetryableException(e.status(), "OpenSearch returned HTTP " + e.status(), e);
+      } catch (IOException e) {
+        throw new IndexerRetryableException("Transport failure communicating with OpenSearch", e);
+      }
 
       if (!response.failures().isEmpty()) {
         for (BulkIndexByScrollFailure failure : response.failures()) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -3,6 +3,7 @@ package com.kmwllc.lucille.indexer;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Indexer;
 import com.kmwllc.lucille.core.IndexerException;
+import com.kmwllc.lucille.core.IndexerRetryableException;
 import com.kmwllc.lucille.core.KafkaDocument;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.SpecBuilder;
@@ -286,7 +287,7 @@ public class OpenSearchIndexer extends Indexer {
     }
   }
 
-  private Set<Pair<Document, String>> uploadDocuments(Collection<Document> documentsToUpload) throws IOException, IndexerException {
+  private Set<Pair<Document, String>> uploadDocuments(Collection<Document> documentsToUpload) throws IndexerException {
     if (documentsToUpload.isEmpty()) {
       return Set.of();
     }
@@ -355,7 +356,16 @@ public class OpenSearchIndexer extends Indexer {
 
     Set<Pair<Document, String>> failedDocs = new HashSet<>();
 
-    BulkResponse response = client.bulk(br.build());
+    BulkResponse response;
+    try {
+      response = client.bulk(br.build());
+    } catch (org.opensearch.client.opensearch._types.OpenSearchException e) {
+      // HTTP-level error with a known status code — wrap so the base Indexer can apply retry policy
+      throw new IndexerRetryableException(e.status(), "OpenSearch returned HTTP " + e.status(), e);
+    } catch (IOException e) {
+      // Transport-level failure (connection refused, timeout, etc.) — no status code available
+      throw new IndexerRetryableException("Transport failure communicating with OpenSearch", e);
+    }
 
     if (response != null) {
       for (BulkResponseItem item : response.items()) {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1146,6 +1146,88 @@ public class OpenSearchIndexerTest {
     indexer.closeConnection();
   }
 
+  /**
+   * Tests that the indexer retries a failed batch and succeeds on a subsequent attempt.
+   * The mock client throws on the first bulk call and succeeds on the second.
+   * With maxRetries=3 and retryWaitDurationMs=0, the indexer should retry and ultimately
+   * send FINISH events for all documents.
+   */
+  @Test
+  public void testRetrySucceedsOnSecondAttempt() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    BulkResponse successResponse = Mockito.mock(BulkResponse.class);
+    Mockito.when(successResponse.errors()).thenReturn(false);
+    Mockito.when(successResponse.items()).thenReturn(new ArrayList<>());
+
+    // Throw on the first call, succeed on the second
+    Mockito.when(retryClient.bulk(any(BulkRequest.class)))
+        .thenThrow(new IOException("Simulated transient failure"))
+        .thenReturn(successResponse);
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    indexer.run(2);
+
+    // bulk() should have been called twice: once failing, once succeeding
+    verify(retryClient, times(2)).bulk(any(BulkRequest.class));
+
+    // Both documents should have received FINISH events
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(2, events.size());
+    assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FINISH));
+  }
+
+  /**
+   * Tests that the indexer exhausts all retries when every attempt fails, and that all
+   * documents in the batch receive FAIL events after the final attempt.
+   * With maxRetries=3, bulk() should be called 4 times total (1 initial + 3 retries).
+   */
+  @Test
+  public void testRetryExhaustedAllDocumentsFail() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    // Always throw — every attempt fails
+    Mockito.when(retryClient.bulk(any(BulkRequest.class)))
+        .thenThrow(new IOException("Persistent failure"));
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+    Document doc3 = Document.create("doc3", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    indexer.run(3);
+
+    // bulk() should have been called 4 times: 1 initial + 3 retries
+    verify(retryClient, times(4)).bulk(any(BulkRequest.class));
+
+    // All documents should have received FAIL events
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(3, events.size());
+    assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
+  }
+
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 
     public static final Spec SPEC = OpenSearchIndexer.SPEC;

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -10,12 +10,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kmwllc.lucille.core.IndexerRetryableException;
+import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
@@ -1228,6 +1234,85 @@ public class OpenSearchIndexerTest {
     assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
   }
 
+  /**
+   * Tests that no retry is attempted when the server returns an HTTP status code that is not
+   * in the configured retryableStatusCodes list.
+   *
+   * The indexer is configured with retryableStatusCodes: [429] and maxRetries: 3.
+   * The mock throws an IndexerRetryableException with status 503 (not in the list).
+   * bulk() should be called exactly once — no retries — and all documents should receive FAIL events.
+   */
+  @Test
+  public void testNoRetryForNonRetryableStatusCode() throws Exception {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retryWith429Only.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+
+    // Use a subclass that throws IndexerRetryableException with status 503 (not in retryableStatusCodes)
+    OpenSearchIndexer indexer = new Status503OpenSearchIndexer(config, messenger, mockClient, "testing");
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    indexer.run(2);
+
+    // bulk() on the mock client should never be called — the subclass overrides sendToIndex entirely
+    verify(mockClient, times(0)).bulk(any(BulkRequest.class));
+
+    // All documents should have received FAIL events with no retries
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(2, events.size());
+    assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
+  }
+
+  @Test
+  public void testRetryAgainstLiveServer() throws Exception {
+    AtomicInteger requestCount = new AtomicInteger(0);
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+
+    // Minimal valid OpenSearch bulk API response for a single successful index operation
+    String bulkSuccessBody = "{\"took\":1,\"errors\":false,\"items\":"
+        + "[{\"index\":{\"_index\":\"lucille-default\",\"_id\":\"doc1\","
+        + "\"result\":\"created\",\"status\":201}}]}";
+    byte[] bulkSuccessBytes = bulkSuccessBody.getBytes(StandardCharsets.UTF_8);
+
+    server.createContext("/", exchange -> {
+      int count = requestCount.incrementAndGet();
+      if (count == 1) {
+        // First request: return 429 to trigger a retry
+        exchange.sendResponseHeaders(429, -1);
+        exchange.close();
+      } else {
+        // Second request: return a valid bulk success response
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bulkSuccessBytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+          os.write(bulkSuccessBytes);
+        }
+        exchange.close();
+      }
+    });
+    server.start();
+
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf").
+        withValue("opensearch.url", ConfigValueFactory.fromAnyRef("http://localhost:" + server.getAddress().getPort()));
+    TestMessenger messenger = new TestMessenger();
+    Document doc = Document.create("doc1");
+
+    try {
+      OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, false, "testing", "run1");
+      messenger.sendForIndexing(doc);
+      indexer.run(1);
+    } finally {
+      server.stop(0);
+    }
+    assertEquals(1, messenger.getDocsSentForIndexing().size()); // only 1 doc was sent for indexing
+    assertEquals(2, requestCount.get()); // server should have received 2 requests: initial request and retry
+    assertEquals(1, messenger.getSentEvents().size()); // only 1 accounting event should have been sent
+    assertEquals(Event.Type.FINISH, messenger.getSentEvents().get(0).getType()); // document should have succeeded
+  }
+
+
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 
     public static final Spec SPEC = OpenSearchIndexer.SPEC;
@@ -1240,6 +1325,27 @@ public class OpenSearchIndexerTest {
     @Override
     public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
+    }
+  }
+
+  /**
+   * An OpenSearchIndexer subclass that always throws an {@link IndexerRetryableException}
+   * with HTTP status 503, used to verify that status codes not in the configured
+   * retryableStatusCodes list do not trigger a retry.
+   */
+  public static class Status503OpenSearchIndexer extends OpenSearchIndexer {
+
+    public static final Spec SPEC = OpenSearchIndexer.SPEC;
+
+    public Status503OpenSearchIndexer(Config config, IndexerMessenger messenger,
+        OpenSearchClient client, String metricsPrefix) {
+      super(config, messenger, metricsPrefix, client);
+    }
+
+    @Override
+    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
+      throw new IndexerRetryableException(
+          503, "Simulated 503 Service Unavailable", new IOException("backend unavailable"));
     }
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1155,7 +1155,7 @@ public class OpenSearchIndexerTest {
   /**
    * Tests that the indexer retries a failed batch and succeeds on a subsequent attempt.
    * The mock client throws on the first bulk call and succeeds on the second.
-   * With maxRetries=3 and retryWaitDurationMs=0, the indexer should retry and ultimately
+   * With maxRetries=3 and retryWaitDurationMs=1, the indexer should retry and ultimately
    * send FINISH events for all documents.
    */
   @Test
@@ -1312,6 +1312,93 @@ public class OpenSearchIndexerTest {
     assertEquals(Event.Type.FINISH, messenger.getSentEvents().get(0).getType()); // document should have succeeded
   }
 
+  /**
+   * Tests that unknown-status-code failures (e.g. network timeouts) are NOT retried when the user
+   * explicitly specifies retryableStatusCodes without including -1.
+   * Config uses retryableStatusCodes: [429] — no -1, so IOException-based failures should not retry.
+   */
+  @Test
+  public void testNoRetryForUnknownStatusCodeWhenNotInList() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    // IOException becomes IndexerRetryableException with UNKNOWN_STATUS_CODE
+    Mockito.when(retryClient.bulk(any(BulkRequest.class)))
+        .thenThrow(new IOException("Connection refused"));
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retryWith429Only.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    indexer.run(1);
+
+    // bulk() should have been called only once — no retries for unknown status code
+    verify(retryClient, times(1)).bulk(any(BulkRequest.class));
+
+    // Document should have received a FAIL event
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(1, events.size());
+    assertEquals(Event.Type.FAIL, events.get(0).getType());
+  }
+
+  /**
+   * Tests that an empty retryableStatusCodes list is rejected as invalid configuration.
+   */
+  @Test
+  public void testEmptyRetryableStatusCodesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf")
+        .withValue("indexer.retryableStatusCodes", ConfigValueFactory.fromIterable(List.of()));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that maxRetries of 0 is rejected as invalid.
+   */
+  @Test
+  public void testMaxRetriesZeroRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf")
+        .withValue("indexer.maxRetries", ConfigValueFactory.fromAnyRef(0));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that retryWaitDurationMs without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryWaitDurationWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryWaitDurationMs", ConfigValueFactory.fromAnyRef(500));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that retryableStatusCodes without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryableStatusCodesWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryableStatusCodes", ConfigValueFactory.fromIterable(List.of(429)));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
 
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 
@@ -1349,3 +1436,4 @@ public class OpenSearchIndexerTest {
     }
   }
 }
+

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1399,6 +1399,68 @@ public class OpenSearchIndexerTest {
         new OpenSearchIndexer(config, messenger, "testing", mockClient));
   }
 
+  /**
+   * Tests that retryMaxWaitDurationMs without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryMaxWaitDurationWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryMaxWaitDurationMs", ConfigValueFactory.fromAnyRef(5000));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that retryRandomizationFactor without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryRandomizationFactorWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryRandomizationFactor", ConfigValueFactory.fromAnyRef(0.3));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that the indexer accepts a retry configuration with all parameters set to their defaults.
+   */
+  @Test
+  public void testRetryConfigWithAllParametersAccepted() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.maxRetries", ConfigValueFactory.fromAnyRef(3))
+        .withValue("indexer.retryWaitDurationMs", ConfigValueFactory.fromAnyRef(1000))
+        .withValue("indexer.retryMaxWaitDurationMs", ConfigValueFactory.fromAnyRef(30000))
+        .withValue("indexer.retryRandomizationFactor", ConfigValueFactory.fromAnyRef(0.5))
+        .withValue("indexer.retryableStatusCodes", ConfigValueFactory.fromIterable(List.of(429, 503)));
+
+    // Should not throw — all parameters are valid
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", mockClient);
+    assertTrue(indexer.validateConnection());
+  }
+
+  /**
+   * Tests that the indexer accepts a retry configuration with non-default custom values
+   * for max wait duration and randomization factor.
+   */
+  @Test
+  public void testRetryConfigWithCustomMaxWaitAndRandomization() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.maxRetries", ConfigValueFactory.fromAnyRef(5))
+        .withValue("indexer.retryWaitDurationMs", ConfigValueFactory.fromAnyRef(500))
+        .withValue("indexer.retryMaxWaitDurationMs", ConfigValueFactory.fromAnyRef(10000))
+        .withValue("indexer.retryRandomizationFactor", ConfigValueFactory.fromAnyRef(0.0));
+
+    // Should not throw — custom values are valid
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", mockClient);
+    assertTrue(indexer.validateConnection());
+  }
+
 
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/retry.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/retry.conf
@@ -1,0 +1,14 @@
+indexer {
+  type: "OpenSearch"
+  batchSize: 5
+  batchTimeout: 1000
+  logRate: 1000
+  sendEnabled: false
+  maxRetries: 3
+  retryWaitDurationMs: 1
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+}

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/retryWith429Only.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/retryWith429Only.conf
@@ -1,0 +1,15 @@
+indexer {
+  type: "OpenSearch"
+  batchSize: 5
+  batchTimeout: 1000
+  logRate: 1000
+  sendEnabled: false
+  maxRetries: 3
+  retryWaitDurationMs: 1
+  retryableStatusCodes: [429]
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+}


### PR DESCRIPTION
- Indexer base class now wraps the abstract sendToIndex call in a retry handler implemented via a new dependency, resilience4j
- Indexer accepts new optional params maxRetries, retryWaitDurationMs, retryableStatusCodes; default behavior when these params are not set is no retries
- For a retry to occur, the Indexer subclass must throw IndexerRetryableException from sendToIndex() and the exception must contain one of the status codes configured as retryable
- OpenSearchIndexer is updated in this PR to throw IndexerRetryableException where appropriate; ElasticsearchIndexer and SolrIndexer have NOT been updated and this work should be tracked in separate tickets
- Test coverage includes testRetryAgainstLiveServer() which starts an embedded HttpServer, important for validating that retry logic is actually working, since mocking can give a false sense of security in this context  

