### PR TITLE
LC-517: HTTPS on Lucille API

### DIFF
--- a/lucille-plugins/lucille-api/README.md
+++ b/lucille-plugins/lucille-api/README.md
@@ -112,7 +112,7 @@ auth:
 
 ### Local HTTPS Configuration
 
-Add an `applicationConnectors` block to the `server:` section of your `api.yml`:
+Add an `applicationConnectors` block to the `server:` section of your DropWizard yml config file:
 
 ```yaml
 server:
@@ -123,6 +123,7 @@ server:
       keyStorePassword: KEYSTORE_PASSWORD
       keyStoreType: JKS
 ```
+We provide an example of this for you at conf/https_api.yml.
 
 #### Local development (self-signed cert)
 

--- a/lucille-plugins/lucille-api/README.md
+++ b/lucille-plugins/lucille-api/README.md
@@ -25,7 +25,7 @@ The API can be run locally or in a Docker container:
 
 ### Run Lucille with the Config
 1. `curl -X POST http://localhost:8080/v1/run -H "Content-Type: application/json" -d '{"configId":"CONFIG_ID"}'`
-2. You can do `curl -s http://localhost:8080/v1/run` to check the status of your runs
+2. You can do `curl http://localhost:8080/v1/run` to check the status of your runs
 
 ## Available Endpoints
 
@@ -51,21 +51,21 @@ All requests are served from `localhost:8080` (or `localhost:8443` if HTTPS is e
 
 ```bash
 # Health
-curl -s http://localhost:8080/v1/livez
+curl http://localhost:8080/v1/livez
 
 # Register a config (returns {"configId": "<uuid>"})
-curl -s -X POST http://localhost:8080/v1/config \
+curl -X POST http://localhost:8080/v1/config \
   -H "Content-Type: application/json" \
   -d @conf/simple-config.json
 
 # Kick off a run with that configId
-curl -s -X POST http://localhost:8080/v1/run \
+curl -X POST http://localhost:8080/v1/run \
   -H "Content-Type: application/json" \
   -d '{"configId":"<uuid>"}'
 
 # Check run status
-curl -s http://localhost:8080/v1/run
-curl -s http://localhost:8080/v1/run/<runId>
+curl http://localhost:8080/v1/run
+curl http://localhost:8080/v1/run/<runId>
 ```
 
 If auth is enabled, add `-u <anyuser>:<password>` (the username is not validated, only the password). If HTTPS is enabled with a self-signed cert, also add `-k`:

--- a/lucille-plugins/lucille-api/README.md
+++ b/lucille-plugins/lucille-api/README.md
@@ -107,7 +107,7 @@ Note: Only the password is validated, so any non-empty username works.
 auth:
   type: basicAuth
   enabled: true
-  password: YourPassword
+  password: KEYSTORE_PASSWORD
 ```
 
 ### Local HTTPS Configuration
@@ -119,8 +119,8 @@ server:
   applicationConnectors:
     - type: https
       port: 8443
-      keyStorePath: <PATH_TO_JKS>
-      keyStorePassword: <YOUR_PASSWORD>
+      keyStorePath: PATH_TO_JKS
+      keyStorePassword: KEYSTORE_PASSWORD
       keyStoreType: JKS
 ```
 
@@ -130,7 +130,7 @@ For local development you can generate a self-signed keystore. Run this from the
 
 ```bash
 keytool -genkeypair -alias dw-server -keyalg RSA -keysize 2048 \
-  -storetype JKS -keystore conf/keystore.jks -storepass YourPassword \
+  -storetype JKS -keystore PATH_TO_JKS -storepass KEYSTORE_PASSWORD \
   -validity 365 -dname "CN=localhost, OU=Dev, O=Local, L=., ST=., C=US" \
   -ext san=dns:localhost,ip:127.0.0.1
 ```
@@ -140,8 +140,8 @@ The `-ext san=...` is necessary, or else Jetty's SNI host check rejects requests
 ```yaml
     - type: https
       port: 8443
-      keyStorePath: conf/keystore.jks
-      keyStorePassword: YourPassword
+      keyStorePath: PATH_TO_JKS
+      keyStorePassword: KEYSTORE_PASSWORD
       disableSniHostCheck: true
 ```
 

--- a/lucille-plugins/lucille-api/README.md
+++ b/lucille-plugins/lucille-api/README.md
@@ -10,7 +10,7 @@ The API can be run locally or in a Docker container:
 ### Local Run
 
 1. Replace the placeholders with your config file names or export them as environment variables. See [Configuration](#configuration) for more information
-2. `java -Dconfig.file=${LUCILLE_CONF} -jar target/lucille-api-X.X.X-SNAPSHOT.jar server ${DROPWIZARD_CONF}`
+2. `java -jar target/lucille-api-plugin.jar server ${DROPWIZARD_CONF}`
 
 ### Dockerized Run
 
@@ -18,19 +18,61 @@ The API can be run locally or in a Docker container:
 2. Replace the placeholders with your config file names or export them as environment variables. See [Configuration](#configuration) for more information
 3. Run the image: `docker run --env LUCILLE_CONF=${LUCILLE_CONF} --env DROPWIZARD_CONF=${DROPWIZARD_CONF} -p 8080:8080 lucille-api`
 
+### Upload Lucille Config
+1. This should be a JSON file
+2. `curl -X POST http://localhost:8080/v1/config -H "Content-Type: application/json" -d @${LUCILLE_CONF}`
+3. This will respond with a configId for your config
+
+### Run Lucille with the Config
+1. `curl -X POST http://localhost:8080/v1/run -H "Content-Type: application/json" -d '{"configId":"CONFIG_ID"}'`
+2. You can do `curl -s http://localhost:8080/v1/run` to check the status of your runs
+
 ## Available Endpoints
 
-In both the local or dockerized deployment, all requests should be sent to localhost:8080. Currently, none of the endpoints expect
-any query parameters or payloads.
+All requests are served from `localhost:8080` (or `localhost:8443` if HTTPS is enabled — see [Setting up HTTPS](#setting-up-https-with-dropwizard)). When auth is enabled, every endpoint except the Dropwizard admin port requires Basic Auth credentials.
 
-The available endpoints are as follows:
+| Method | Path | Description | Body |
+|--------|------|-------------|------|
+| GET    | `/v1/livez`                          | Liveness probe — returns 200 if the process is running | — |
+| GET    | `/v1/readyz`                         | Readiness probe — returns 200 once the app is ready to serve | — |
+| GET    | `/v1/systemstats`                    | CPU, memory, and JVM resource usage | — |
+| GET    | `/v1/systemstats/metrics`            | Detailed metrics breakdown | — |
+| GET    | `/v1/config-info/connector-list`     | Lists the available connector classes | — |
+| GET    | `/v1/config-info/stage-list`         | Lists the available stage classes | — |
+| GET    | `/v1/config-info/indexer-list`       | Lists the available indexer classes | — |
+| POST   | `/v1/config`                         | Register a new Lucille config. Responds with a generated `configId` to use in `POST /v1/run` | Full Lucille config as JSON (see [Upload Lucille Config](#upload-lucille-config)) |
+| GET    | `/v1/config`                         | List all registered configs, keyed by `configId` | — |
+| GET    | `/v1/config/{configId}`              | Get a specific registered config | — |
+| POST   | `/v1/run`                            | Start a Lucille run using a previously registered config | `{"configId": "<uuid>"}` |
+| GET    | `/v1/run`                            | List all runs and their statuses | — |
+| GET    | `/v1/run/{runId}`                    | Get details of a specific run | — |
 
- |        | GET                                        | POST                                               | DELETE          |
- |--------|--------------------------------------------|----------------------------------------------------|-----------------|
- | /v1/lucille| Gets the status of the current lucille run | Kicks off a new lucille run, if one is not running | Not Implemented |
- | /v1/livez  | liveness health check endpoint             | Not Implemented                                    | Not Implemented |
- | /v1/readyz | readiness health check endpoint            | Not Implemented                                    | Not Implemented |
- | /v1/systemstats | system resource usage endpoint             | Not Implemented                                    | Not Implemented |
+### Examples
+
+```bash
+# Health
+curl -s http://localhost:8080/v1/livez
+
+# Register a config (returns {"configId": "<uuid>"})
+curl -s -X POST http://localhost:8080/v1/config \
+  -H "Content-Type: application/json" \
+  -d @conf/simple-config.json
+
+# Kick off a run with that configId
+curl -s -X POST http://localhost:8080/v1/run \
+  -H "Content-Type: application/json" \
+  -d '{"configId":"<uuid>"}'
+
+# Check run status
+curl -s http://localhost:8080/v1/run
+curl -s http://localhost:8080/v1/run/<runId>
+```
+
+If auth is enabled, add `-u <anyuser>:<password>` (the username is not validated, only the password). If HTTPS is enabled with a self-signed cert, also add `-k`:
+
+```bash
+curl -k -u user:password https://localhost:8443/v1/run
+```
 
 ## Configuration
 
@@ -49,20 +91,68 @@ Details on how can be found [here](https://www.dropwizard.io/en/stable/manual/co
 
 ### Auth Configuration
 
-Authentication is configured under the `auth` JSONProperty.
+Authentication is configured under the `auth` block. When `enabled: true`, every endpoint in the table above (except the Dropwizard admin port, which is separate) requires Basic Auth credentials.
 
 | Property |            Description                |
 |----------|-------------------------------------- |
-|  type    | currently only basicAuth is supported |
-| password |   supported for basic authentication  |
+| type     | currently only `basicAuth` is supported |
+| enabled  | `true` to require auth, `false` to disable |
+| password | the password Basic Auth requests must match |
+
+Note: Only the password is validated, so any non-empty username works.
 
 #### Example
 
 ```yaml
 auth:
   type: basicAuth
+  enabled: true
   password: password
 ```
+
+### Local HTTPS Configuration
+
+Add an `applicationConnectors` block to the `server:` section of your `api.yml`:
+
+```yaml
+server:
+  applicationConnectors:
+    - type: https
+      port: 8443
+      keyStorePath: <PATH_TO_JKS>
+      keyStorePassword: <YOUR_PASSWORD>
+      keyStoreType: JKS
+```
+
+#### Local development (self-signed cert)
+
+For local development you can generate a self-signed keystore. Run this from the `lucille-plugins/lucille-api/` directory so the file lands at `conf/keystore.jks` (matching the `keyStorePath` in `api.yml`):
+
+```bash
+keytool -genkeypair -alias dw-server -keyalg RSA -keysize 2048 \
+  -storetype JKS -keystore conf/keystore.jks -storepass YourPassword \
+  -validity 365 -dname "CN=localhost, OU=Dev, O=Local, L=., ST=., C=US" \
+  -ext san=dns:localhost,ip:127.0.0.1
+```
+
+The `-ext san=...` is necessary, or else Jetty's SNI host check rejects requests to `localhost` with `400 Invalid SNI`. As an alternative to embedding SANs, you can disable the SNI check on the connector:
+
+```yaml
+    - type: https
+      port: 8443
+      keyStorePath: conf/keystore.jks
+      keyStorePassword: YourPassword
+      disableSniHostCheck: true
+```
+
+Hit endpoints with `-k` (skip cert verification, since the cert isn't in any trust store) and `-u <anyuser>:<password>` if auth is on:
+
+```bash
+curl -k -u user:password https://localhost:8443/v1/config -H "Content-Type: application/json" -d @${LUCILLE_CONF}
+```
+
+#### Production HTTPS
+For a real deployment you want a CA-issued cert, the strict defaults turned back on, and secrets out of the YAML file.
 
 ## Logging and Integration Testing with Dropwizard
 

--- a/lucille-plugins/lucille-api/README.md
+++ b/lucille-plugins/lucille-api/README.md
@@ -107,7 +107,7 @@ Note: Only the password is validated, so any non-empty username works.
 auth:
   type: basicAuth
   enabled: true
-  password: password
+  password: YourPassword
 ```
 
 ### Local HTTPS Configuration

--- a/lucille-plugins/lucille-api/conf/api.yml
+++ b/lucille-plugins/lucille-api/conf/api.yml
@@ -1,4 +1,4 @@
-# This is the DropWizard configuration file. For now we are not configuring anything, but we may want
+# This is the DropWizard configuration file. For now, we are not configuring anything, but we may want
 # to in prod. https://www.dropwizard.io/en/stable/manual/configuration.html#man-configuration
 server:
   type: default
@@ -16,8 +16,3 @@ swagger:
   version: 0.0.1
   contact: info@kmwllc.com
   license: Apache 2.0
-  securityDefinitions:
-    basicAuth:
-      type: "basic"
-  security:
-    - basicAuth: []

--- a/lucille-plugins/lucille-api/conf/api.yml
+++ b/lucille-plugins/lucille-api/conf/api.yml
@@ -2,15 +2,6 @@
 # to in prod. https://www.dropwizard.io/en/stable/manual/configuration.html#man-configuration
 server:
   type: default
-  applicationConnectors:
-        - type: https
-          port: 8443
-          keyStorePath: conf/keystore.jks
-          keyStorePassword: password
-          keyStoreType: JKS
-          validateCerts: false
-          validatePeers: false
-          disableSniHostCheck: true
   requestLog:
     type: external
 logging:

--- a/lucille-plugins/lucille-api/conf/api.yml
+++ b/lucille-plugins/lucille-api/conf/api.yml
@@ -2,13 +2,22 @@
 # to in prod. https://www.dropwizard.io/en/stable/manual/configuration.html#man-configuration
 server:
   type: default
+  applicationConnectors:
+        - type: https
+          port: 8443
+          keyStorePath: conf/keystore.jks
+          keyStorePassword: password
+          keyStoreType: JKS
+          validateCerts: false
+          validatePeers: false
+          disableSniHostCheck: true
   requestLog:
     type: external
 logging:
   type: external
 auth:
   type: "basicAuth"
-  enabled: false
+  enabled: true
   password: "password"
 swagger:
   resourcePackage: "com.kmwllc.lucille.endpoints"
@@ -21,4 +30,4 @@ swagger:
     basicAuth:
       type: "basic"
   security:
-    - basicAuth: []      
+    - basicAuth: []

--- a/lucille-plugins/lucille-api/conf/api.yml
+++ b/lucille-plugins/lucille-api/conf/api.yml
@@ -8,8 +8,7 @@ logging:
   type: external
 auth:
   type: "basicAuth"
-  enabled: true
-  password: "password"
+  enabled: false
 swagger:
   resourcePackage: "com.kmwllc.lucille.endpoints"
   title: Lucille API

--- a/lucille-plugins/lucille-api/conf/https_api.yml
+++ b/lucille-plugins/lucille-api/conf/https_api.yml
@@ -1,5 +1,6 @@
-# This is the DropWizard configuration file. For now we are not configuring anything, but we may want
-# to in prod. https://www.dropwizard.io/en/stable/manual/configuration.html#man-configuration
+# This is the DropWizard configuration file. We are configuring HTTPS and basicAuth.
+# Refer to lucille-api/README.md for information on using HTTPS. More configuration options can be found at:
+# https://www.dropwizard.io/en/stable/manual/configuration.html#man-configuration
 server:
   type: default
   applicationConnectors:

--- a/lucille-plugins/lucille-api/conf/https_api.yml
+++ b/lucille-plugins/lucille-api/conf/https_api.yml
@@ -1,0 +1,32 @@
+# This is the DropWizard configuration file. For now we are not configuring anything, but we may want
+# to in prod. https://www.dropwizard.io/en/stable/manual/configuration.html#man-configuration
+server:
+  type: default
+  applicationConnectors:
+        - type: https
+          port: 8443
+          keyStorePath: conf/keystore.jks
+          keyStorePassword: password
+          keyStoreType: JKS
+          validateCerts: false
+          validatePeers: false
+  requestLog:
+    type: external
+logging:
+  type: external
+auth:
+  type: "basicAuth"
+  enabled: true
+  password: "password"
+swagger:
+  resourcePackage: "com.kmwllc.lucille.endpoints"
+  title: Lucille API
+  description: Lucille API
+  version: 0.0.1
+  contact: info@kmwllc.com
+  license: Apache 2.0
+  securityDefinitions:
+    basicAuth:
+      type: "basic"
+  security:
+    - basicAuth: []


### PR DESCRIPTION
This PR overhauls the README for the `lucille-api` folder and changes the example `api.yml` file to have HTTPS and basic auth on by default.