### PR TITLE
Fix ClassGraph OOM in ConfigInfo by narrowing scan scope

### DIFF
--- a/lucille-plugins/lucille-api/README.md
+++ b/lucille-plugins/lucille-api/README.md
@@ -47,6 +47,19 @@ Dropwizard can be configured via the `conf/api.yml` file. Details about availabl
 If configuration beyond what Dropwizard supplies is required, the functionality can be extended via the LucilleAPIConfiguration class.
 Details on how can be found [here](https://www.dropwizard.io/en/stable/manual/configuration.html#man-configuration).
 
+### Scanning Custom Components
+
+The `/v1/config-info/*` endpoints discover Connector, Stage, and Indexer implementations by scanning the classpath under
+`com.kmwllc.lucille`. To expose custom implementations that live in other packages, supply a comma-separated list via the
+`scan.extra.packages` system property at startup:
+
+```bash
+java -Dscan.extra.packages=com.example.lucille.custom,org.acme.lucille \
+     -jar target/lucille-api-X.X.X-SNAPSHOT.jar server ${DROPWIZARD_CONF}
+```
+
+Whitespace around entries is trimmed. The built-in `com.kmwllc.lucille` package is always scanned and does not need to be listed.
+
 ### Auth Configuration
 
 Authentication is configured under the `auth` JSONProperty.

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/endpoints/ConfigInfo.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/endpoints/ConfigInfo.java
@@ -176,7 +176,7 @@ public class ConfigInfo {
       throws NoSuchFieldException, IllegalAccessException {
     ArrayNode array = mapper.createArrayNode();
     // Use ClassGraph to scan the classpath
-    try (ScanResult scanResult = new ClassGraph().enableAllInfo().scan()) {
+    try (ScanResult scanResult = new ClassGraph().enableClassInfo().acceptPackages("com.kmwllc.lucille").scan()) {
       // Find every class that is a subclass of the provided class name
       ClassInfoList classes = scanResult.getSubclasses(baseClassName);
       // Load whatever matches were found as class objects

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/endpoints/ConfigInfo.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/endpoints/ConfigInfo.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.*;
+import java.util.stream.Stream;
 import java.io.InputStream;
 import java.io.IOException;
 import org.jsoup.Jsoup;
@@ -39,6 +40,12 @@ import org.jsoup.select.Elements;
 @Tag(name = "Config")
 @Produces(MediaType.APPLICATION_JSON)
 public class ConfigInfo {
+
+  // System property for additional packages to scan (comma-separated) for custom
+  // Connector/Stage/Indexer subclasses that live outside com.kmwllc.lucille.
+  public static final String EXTRA_PACKAGES_PROPERTY = "scan.extra.packages";
+
+  private static final String DEFAULT_PACKAGE = "com.kmwllc.lucille";
 
   private static final ObjectMapper mapper = new ObjectMapper();
   private final AuthHandler authHandler;
@@ -171,12 +178,28 @@ public class ConfigInfo {
     }
   }
 
+  // Resolves the package list ClassGraph should scan: the built-in com.kmwllc.lucille
+  // package plus any extras supplied via the "scan.extra.packages" system property
+  // (comma-separated, whitespace-tolerant). Visible for testing.
+  public static String[] resolveScanPackages(String extraPackages) {
+    if (extraPackages == null) {
+      return new String[]{DEFAULT_PACKAGE};
+    }
+    return Stream.concat(
+        Stream.of(DEFAULT_PACKAGE),
+        Arrays.stream(extraPackages.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+    ).toArray(String[]::new);
+  }
+
   // Builds an array of specs for the subclasses of a base class
   private ArrayNode buildSpecArrayForSubclasses(String baseClassName, Map<String, ComponentDoc> docs)
       throws NoSuchFieldException, IllegalAccessException {
     ArrayNode array = mapper.createArrayNode();
+    String[] packages = resolveScanPackages(System.getProperty(EXTRA_PACKAGES_PROPERTY));
     // Use ClassGraph to scan the classpath
-    try (ScanResult scanResult = new ClassGraph().enableClassInfo().acceptPackages("com.kmwllc.lucille").scan()) {
+    try (ScanResult scanResult = new ClassGraph().enableClassInfo().acceptPackages(packages).scan()) {
       // Find every class that is a subclass of the provided class name
       ClassInfoList classes = scanResult.getSubclasses(baseClassName);
       // Load whatever matches were found as class objects

--- a/lucille-plugins/lucille-api/src/test/java/endpoints/ConfigInfoTest.java
+++ b/lucille-plugins/lucille-api/src/test/java/endpoints/ConfigInfoTest.java
@@ -108,4 +108,51 @@ public class ConfigInfoTest {
     assertNotNull(percentTrue);
     assertTrue(percentTrue.has("description") && !percentTrue.get("description").asText().isEmpty());
   }
+
+  @Test
+  public void testResolveScanPackages_nullReturnsDefaultOnly() {
+    String[] result = ConfigInfo.resolveScanPackages(null);
+    assertArrayEquals(new String[]{"com.kmwllc.lucille"}, result);
+  }
+
+  @Test
+  public void testResolveScanPackages_emptyReturnsDefaultOnly() {
+    assertArrayEquals(new String[]{"com.kmwllc.lucille"}, ConfigInfo.resolveScanPackages(""));
+    assertArrayEquals(new String[]{"com.kmwllc.lucille"}, ConfigInfo.resolveScanPackages("   "));
+    assertArrayEquals(new String[]{"com.kmwllc.lucille"}, ConfigInfo.resolveScanPackages(",, ,"));
+  }
+
+  @Test
+  public void testResolveScanPackages_singleExtra() {
+    assertArrayEquals(
+        new String[]{"com.kmwllc.lucille", "com.example.custom"},
+        ConfigInfo.resolveScanPackages("com.example.custom"));
+  }
+
+  @Test
+  public void testResolveScanPackages_multipleExtrasWithWhitespace() {
+    assertArrayEquals(
+        new String[]{"com.kmwllc.lucille", "com.example.a", "com.example.b", "com.example.c"},
+        ConfigInfo.resolveScanPackages("com.example.a, com.example.b ,com.example.c"));
+  }
+
+  @Test
+  public void testResolveScanPackages_systemPropertyIsHonored() throws Exception {
+    String prior = System.getProperty(ConfigInfo.EXTRA_PACKAGES_PROPERTY);
+    System.setProperty(ConfigInfo.EXTRA_PACKAGES_PROPERTY, "com.example.never.matches");
+    try {
+      ConfigInfo isolated = new ConfigInfo(new AuthHandler(false));
+      Response resp = isolated.getStages(Optional.empty());
+      assertEquals(200, resp.getStatus());
+      ArrayNode arr = mapper.valueToTree(resp.getEntity());
+      // Adding a non-matching extra package must not break the default scan.
+      assertTrue(arr.size() > 0);
+    } finally {
+      if (prior == null) {
+        System.clearProperty(ConfigInfo.EXTRA_PACKAGES_PROPERTY);
+      } else {
+        System.setProperty(ConfigInfo.EXTRA_PACKAGES_PROPERTY, prior);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- `ConfigInfo.buildSpecArrayForSubclasses` was using `new ClassGraph().enableAllInfo().scan()`, which scans every annotation, method, and field across **all JARs** on the classpath
- This caused an `OutOfMemoryError: Java heap space` in `ConfigInfoTest.testStages_basicShape` on CI (observed in PR #466's run)
- `getSubclasses()` only needs class hierarchy info — `enableClassInfo()` is sufficient
- Limiting the scan to `com.kmwllc.lucille` packages further reduces memory and scan time

**Before:**
```java
new ClassGraph().enableAllInfo().scan()
```
**After:**
```java
new ClassGraph().enableClassInfo().acceptPackages("com.kmwllc.lucille").scan()
```

> Note: happy for this to be closed and absorbed into other ongoing work if you prefer — just flagging the root cause of the intermittent CI OOM.

## Test plan
- [ ] `ConfigInfoTest` passes in CI without OOM
- [ ] Connector, stage, and indexer lists still return correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)