### PR TITLE
LC-836 Switch to using npm package manager instead of snap

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -39,7 +39,7 @@ jobs:
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
+        run: npm install sass
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Used for installing dart-sass in the hugo workflow