### PR TITLE
LC-836: update script so banner link works properly

### DIFF
--- a/.github/scripts/versionsworkflow.sh
+++ b/.github/scripts/versionsworkflow.sh
@@ -94,7 +94,7 @@ done <<< "$tags"
 # reads top-to-bottom from newest to oldest.
 {
   printf 'version = "%s (latest)"\n' "$latest_tag"
-  printf 'url_latest_version = "/docs/"\n'
+  printf 'url_latest_version = "%s/"\n' "$url"
   printf '\n'
 
   # Add the latest version first, it points to the main /docs/ path

--- a/doc/site/assets/scss/_variables_project.scss
+++ b/doc/site/assets/scss/_variables_project.scss
@@ -5,11 +5,11 @@ Add styles or override variables from the theme here.
 */
 
 // Sets the background color of the navbar
-$td-navbar-bg-color: #6bb8ff;
+$td-navbar-bg-color: #77bcfc;
 
 .td-version-selector .btn {
-    background-color: #6bb8ff;
-    color: white;
+    background-color: #77bcfc;
+    color: black;
     font-weight: bold;
   }
 

--- a/doc/site/layouts/partials/version-banner.html
+++ b/doc/site/layouts/partials/version-banner.html
@@ -32,7 +32,7 @@
   }
 </style>
 <div class="version-banner">
-  <h3>You are viewing documentation for an old version of Lucille.</h3>
+  <h3>You are viewing documentation for an older version of Lucille.</h3>
   <p>
     This is a static snapshot.
     <br>


### PR DESCRIPTION
url_latest_version is only used in doc/site/layouts/partials/version-banner.html as the href for the "latest version" link in the archived-version banner, so this change will only impact the banner link which is what we want