### PR TITLE
LC-861: Config option to setSkipped in SetStaticValues.java

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * <ul>
  *   <li>staticValues (Map&lt;String, Object&gt;) : A mapping from the field to the value.</li>
  *   <li>updateMode (UpdateMode) : The update mode to use when updating the fields.</li>
- *   <li>skipDoc (boolean) : Sets the document to be skipped by the rest of the pipeline. Can be used in place of the {@link SkipDocument}
+ *   <li>skipDocument (boolean) : Sets the document to be skipped by the rest of the pipeline. Can be used in place of the {@link SkipDocument}
  *   stage when we want to both skip and delete documents, and don't want to add another stage with duplicate conditions.</li>
  * </ul>
  */
@@ -28,25 +28,25 @@ public class SetStaticValues extends Stage {
 
   public static final Spec SPEC = SpecBuilder.stage()
       .optionalString("updateMode")
-      .optionalBoolean("skipDoc")
+      .optionalBoolean("skipDocument")
       .requiredParent("staticValues", new TypeReference<Map<String, Object>>() {}).build();
 
   private final Map<String, Object> staticValues;
   private final UpdateMode updateMode;
-  private final boolean skipDoc;
+  private final boolean skipDocument;
 
   public SetStaticValues(Config config) {
     super(config);
 
     this.staticValues = config.getConfig("staticValues").root().unwrapped();
     this.updateMode = UpdateMode.fromConfig(config);
-    this.skipDoc = ConfigUtils.getOrDefault(config, "skipDoc", false);
+    this.skipDocument = ConfigUtils.getOrDefault(config, "skipDocument", false);
   }
 
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     staticValues.forEach((fieldName, staticValue) -> doc.update(fieldName, updateMode, staticValue));
-    if (skipDoc) {
+    if (skipDocument) {
       doc.setSkipped(true);
     }
     return null;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * <ul>
  *   <li>staticValues (Map&lt;String, Object&gt;) : A mapping from the field to the value.</li>
  *   <li>updateMode (UpdateMode) : The update mode to use when updating the fields.</li>
- *   <li>skip (Boolean) : Sets the document to be skipped by the rest of the pipeline. Can be used in place of the {@link SkipDocument}
+ *   <li>skipDoc (boolean) : Sets the document to be skipped by the rest of the pipeline. Can be used in place of the {@link SkipDocument}
  *   stage when we want to both skip and delete documents, and don't want to add another stage with duplicate conditions.</li>
  * </ul>
  */
@@ -28,25 +28,25 @@ public class SetStaticValues extends Stage {
 
   public static final Spec SPEC = SpecBuilder.stage()
       .optionalString("updateMode")
-      .optionalBoolean("skip")
+      .optionalBoolean("skipDoc")
       .requiredParent("staticValues", new TypeReference<Map<String, Object>>() {}).build();
 
   private final Map<String, Object> staticValues;
   private final UpdateMode updateMode;
-  private final Boolean skip;
+  private final boolean skipDoc;
 
   public SetStaticValues(Config config) {
     super(config);
 
     this.staticValues = config.getConfig("staticValues").root().unwrapped();
     this.updateMode = UpdateMode.fromConfig(config);
-    this.skip = ConfigUtils.getOrDefault(config, "skip", false);
+    this.skipDoc = ConfigUtils.getOrDefault(config, "skipDoc", false);
   }
 
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     staticValues.forEach((fieldName, staticValue) -> doc.update(fieldName, updateMode, staticValue));
-    if (skip) {
+    if (skipDoc) {
       doc.setSkipped(true);
     }
     return null;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
@@ -20,7 +20,8 @@ import java.util.Map;
  * <ul>
  *   <li>staticValues (Map&lt;String, Object&gt;) : A mapping from the field to the value.</li>
  *   <li>updateMode (UpdateMode) : The update mode to use when updating the fields.</li>
- *   <li>skip (Boolean) : Sets the document to be skipped by the rest of the pipeline.</li>
+ *   <li>skip (Boolean) : Sets the document to be skipped by the rest of the pipeline. Can be used in place of the {@link SkipDocument}
+ *   stage when we want to both skip and delete documents, and don't want to add another stage with duplicate conditions.</li>
  * </ul>
  */
 public class SetStaticValues extends Stage {
@@ -45,7 +46,9 @@ public class SetStaticValues extends Stage {
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     staticValues.forEach((fieldName, staticValue) -> doc.update(fieldName, updateMode, staticValue));
-    doc.setSkipped(skip);
+    if (skip) {
+      doc.setSkipped(true);
+    }
     return null;
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.stage;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.kmwllc.lucille.core.ConfigUtils;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Stage;
@@ -19,6 +20,7 @@ import java.util.Map;
  * <ul>
  *   <li>staticValues (Map&lt;String, Object&gt;) : A mapping from the field to the value.</li>
  *   <li>updateMode (UpdateMode) : The update mode to use when updating the fields.</li>
+ *   <li>skip (Boolean) : Sets the document to be skipped by the rest of the pipeline.</li>
  * </ul>
  */
 public class SetStaticValues extends Stage {
@@ -37,7 +39,7 @@ public class SetStaticValues extends Stage {
 
     this.staticValues = config.getConfig("staticValues").root().unwrapped();
     this.updateMode = UpdateMode.fromConfig(config);
-    this.skip = config.hasPath("skip") ? config.getBoolean("skip") : false;
+    this.skip = ConfigUtils.getOrDefault(config, "skip", false);
   }
 
   @Override

--- a/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/stage/SetStaticValues.java
@@ -25,21 +25,25 @@ public class SetStaticValues extends Stage {
 
   public static final Spec SPEC = SpecBuilder.stage()
       .optionalString("updateMode")
+      .optionalBoolean("skip")
       .requiredParent("staticValues", new TypeReference<Map<String, Object>>() {}).build();
 
   private final Map<String, Object> staticValues;
   private final UpdateMode updateMode;
+  private final Boolean skip;
 
   public SetStaticValues(Config config) {
     super(config);
 
-    staticValues = config.getConfig("staticValues").root().unwrapped();
-    updateMode = UpdateMode.fromConfig(config);
+    this.staticValues = config.getConfig("staticValues").root().unwrapped();
+    this.updateMode = UpdateMode.fromConfig(config);
+    this.skip = config.hasPath("skip") ? config.getBoolean("skip") : false;
   }
 
   @Override
   public Iterator<Document> processDocument(Document doc) throws StageException {
     staticValues.forEach((fieldName, staticValue) -> doc.update(fieldName, updateMode, staticValue));
+    doc.setSkipped(skip);
     return null;
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
@@ -57,6 +57,6 @@ public class SetStaticValuesTest {
   @Test
   public void testGetLegalProperties() throws StageException {
     Stage stage = factory.get("SetStaticValuesTest/config.conf");
-    assertEquals(Set.of("updateMode", "name", "conditions", "class", "conditionPolicy", "staticValues", "skip"), stage.getLegalProperties());
+    assertEquals(Set.of("updateMode", "name", "conditions", "class", "conditionPolicy", "staticValues", "skipDoc"), stage.getLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SetStaticValuesTest {
 
@@ -37,8 +38,18 @@ public class SetStaticValuesTest {
   }
 
   @Test
+  public void testSkip() throws Exception {
+    Stage stage = factory.get("SetStaticValuesTest/skipConfig.conf");
+
+    Document doc = Document.create("doc");
+    stage.processDocument(doc);
+
+    assertTrue(doc.getBoolean(".skipped"));
+  }
+
+  @Test
   public void testGetLegalProperties() throws StageException {
     Stage stage = factory.get("SetStaticValuesTest/config.conf");
-    assertEquals(Set.of("updateMode", "name", "conditions", "class", "conditionPolicy", "staticValues"), stage.getLegalProperties());
+    assertEquals(Set.of("updateMode", "name", "conditions", "class", "conditionPolicy", "staticValues", "skip"), stage.getLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SetStaticValuesTest {
@@ -34,7 +35,9 @@ public class SetStaticValuesTest {
     // updateMode is set to "skip" in the config
     assertEquals("Directory", doc.getString("myString"));
     assertEquals(2, doc.getInt("myInt").intValue());
-    assertEquals(false, doc.getBoolean("myBool"));
+    assertFalse(doc.getBoolean("myBool"));
+    // ensure document is not skipped because we didn't configure that
+    assertFalse(doc.isSkipped());
   }
 
   @Test
@@ -48,7 +51,7 @@ public class SetStaticValuesTest {
     assertEquals(1, doc.getInt("myInt").intValue());
     assertEquals(true, doc.getBoolean("myBool"));
 
-    assertTrue(doc.getBoolean(".skipped"));
+    assertTrue(doc.isSkipped());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
@@ -44,6 +44,10 @@ public class SetStaticValuesTest {
     Document doc = Document.create("doc");
     stage.processDocument(doc);
 
+    assertEquals("File", doc.getString("myString"));
+    assertEquals(1, doc.getInt("myInt").intValue());
+    assertEquals(true, doc.getBoolean("myBool"));
+
     assertTrue(doc.getBoolean(".skipped"));
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
@@ -57,6 +57,6 @@ public class SetStaticValuesTest {
   @Test
   public void testGetLegalProperties() throws StageException {
     Stage stage = factory.get("SetStaticValuesTest/config.conf");
-    assertEquals(Set.of("updateMode", "name", "conditions", "class", "conditionPolicy", "staticValues", "skipDoc"), stage.getLegalProperties());
+    assertEquals(Set.of("updateMode", "name", "conditions", "class", "conditionPolicy", "staticValues", "skipDocument"), stage.getLegalProperties());
   }
 }

--- a/lucille-core/src/test/resources/SetStaticValuesTest/skipConfig.conf
+++ b/lucille-core/src/test/resources/SetStaticValuesTest/skipConfig.conf
@@ -1,0 +1,11 @@
+{
+  class = "com.kmwllc.lucille.stage.SetStaticValues"
+  staticValues {
+    myString = "File"
+    myInt = 1
+    myBool = true
+  }
+  updateMode = "skip"
+  skip = true
+}
+

--- a/lucille-core/src/test/resources/SetStaticValuesTest/skipConfig.conf
+++ b/lucille-core/src/test/resources/SetStaticValuesTest/skipConfig.conf
@@ -6,6 +6,6 @@
     myBool = true
   }
   updateMode = "skip"
-  skipDoc = true
+  skipDocument = true
 }
 

--- a/lucille-core/src/test/resources/SetStaticValuesTest/skipConfig.conf
+++ b/lucille-core/src/test/resources/SetStaticValuesTest/skipConfig.conf
@@ -6,6 +6,6 @@
     myBool = true
   }
   updateMode = "skip"
-  skip = true
+  skipDoc = true
 }
 


### PR DESCRIPTION
Allows us to automatically mark a document for to be skipped by our pipeline as a config option in SetStaticValues. We want to do this because SetStaticValues is often used to mark docs to be deleted, so we don't need / want those to be processed by other stages. Originally we would have to use the SkipDocument stage after SetStaticValues using the same conditions for both 