### PR TITLE
LC-848: Logging for indexers where deletionMarkerField isn't supported

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -56,7 +56,7 @@ public class CSVIndexer extends Indexer {
       throw new IllegalArgumentException(
           "Cannot create CSVIndexer. Config setting 'indexer.indexOverrideField' is not supported by CSVIndexer.");
     }
-    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null) {
       log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
     

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -56,8 +56,8 @@ public class CSVIndexer extends Indexer {
       throw new IllegalArgumentException(
           "Cannot create CSVIndexer. Config setting 'indexer.indexOverrideField' is not supported by CSVIndexer.");
     }
-    if (this.deletionMarkerField != null) {
-      log.warn("indexer.deletionMarkerField is set but is not supported by CSVIndexer; documents marked for deletion will be written as regular rows.");
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
     
     this.writer = writer;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -56,6 +56,10 @@ public class CSVIndexer extends Indexer {
       throw new IllegalArgumentException(
           "Cannot create CSVIndexer. Config setting 'indexer.indexOverrideField' is not supported by CSVIndexer.");
     }
+    if (this.deletionMarkerField != null) {
+      log.warn("indexer.deletionMarkerField is set but is not supported by CSVIndexer; documents marked for deletion will be written as regular rows.");
+    }
+    
     this.writer = writer;
     this.columns = config.getStringList("csv.columns");
     this.includeHeader = config.hasPath("csv.includeHeader") ? config.getBoolean("csv.includeHeader") : true;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -79,7 +79,7 @@ public class ElasticsearchIndexer extends Indexer {
       throw new IllegalArgumentException(
           "Cannot create ElasticsearchIndexer. Config setting 'indexer.indexOverrideField' is not supported by ElasticsearchIndexer.");
     }
-    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null) {
       log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -79,6 +79,10 @@ public class ElasticsearchIndexer extends Indexer {
       throw new IllegalArgumentException(
           "Cannot create ElasticsearchIndexer. Config setting 'indexer.indexOverrideField' is not supported by ElasticsearchIndexer.");
     }
+    if (this.deletionMarkerField != null) {
+      log.warn("indexer.deletionMarkerField is set but is not supported by ElasticsearchIndexer; documents marked for deletion will be indexed as regular documents.");
+    }
+
     this.client = client;
     this.index = ElasticsearchUtils.getElasticsearchIndex(config);
     this.update = config.hasPath("elasticsearch.update") ? config.getBoolean("elasticsearch.update") : false;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -80,7 +80,7 @@ public class ElasticsearchIndexer extends Indexer {
           "Cannot create ElasticsearchIndexer. Config setting 'indexer.indexOverrideField' is not supported by ElasticsearchIndexer.");
     }
     if (this.deletionMarkerField != null || this.deleteByFieldField != null) {
-      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
+      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be indexed as regular docs");
     }
 
     this.client = client;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -79,8 +79,8 @@ public class ElasticsearchIndexer extends Indexer {
       throw new IllegalArgumentException(
           "Cannot create ElasticsearchIndexer. Config setting 'indexer.indexOverrideField' is not supported by ElasticsearchIndexer.");
     }
-    if (this.deletionMarkerField != null) {
-      log.warn("indexer.deletionMarkerField is set but is not supported by ElasticsearchIndexer; documents marked for deletion will be indexed as regular documents.");
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
 
     this.client = client;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -25,7 +25,7 @@ public class NopIndexer extends Indexer {
   public NopIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix, String localRunId) {
     super(config, messenger, bypass, metricsPrefix, localRunId);
 
-    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null) {
       log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -24,10 +24,6 @@ public class NopIndexer extends Indexer {
 
   public NopIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix, String localRunId) {
     super(config, messenger, bypass, metricsPrefix, localRunId);
-
-    if (this.deletionMarkerField != null || this.deleteByFieldField != null) {
-      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
-    }
   }
 
   public NopIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -9,6 +9,8 @@ import com.typesafe.config.Config;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The NopIndexer performs no operations and does not send documents to any index. It is intended to be used for testing or
@@ -18,8 +20,14 @@ public class NopIndexer extends Indexer {
 
   public static final Spec SPEC = SpecBuilder.indexer().build();
 
+  private static final Logger log = LoggerFactory.getLogger(NopIndexer.class);
+
   public NopIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix, String localRunId) {
     super(config, messenger, bypass, metricsPrefix, localRunId);
+
+    if (this.deletionMarkerField != null) {
+      log.warn("indexer.deletionMarkerField is set but is not supported by NopIndexer.");
+    }
   }
 
   public NopIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -25,8 +25,8 @@ public class NopIndexer extends Indexer {
   public NopIndexer(Config config, IndexerMessenger messenger, boolean bypass, String metricsPrefix, String localRunId) {
     super(config, messenger, bypass, metricsPrefix, localRunId);
 
-    if (this.deletionMarkerField != null) {
-      log.warn("indexer.deletionMarkerField is set but is not supported by NopIndexer.");
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
   }
 

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -59,8 +59,8 @@ public class WeaviateIndexer extends Indexer {
       String metricsPrefix, String localRunId) {
     super(config, messenger, false, metricsPrefix, localRunId);
 
-    if (this.deletionMarkerField != null) {
-      log.warn("indexer.deletionMarkerField is set but is not supported by NopIndexer.");
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
 
     this.weaviateClassName = config.hasPath("weaviate.className") ? config.getString("weaviate.className") : "Document";

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -60,7 +60,7 @@ public class WeaviateIndexer extends Indexer {
     super(config, messenger, false, metricsPrefix, localRunId);
 
     if (this.deletionMarkerField != null || this.deleteByFieldField != null) {
-      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
+      log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be indexed as regular docs");
     }
 
     this.weaviateClassName = config.hasPath("weaviate.className") ? config.getString("weaviate.className") : "Document";

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -59,7 +59,7 @@ public class WeaviateIndexer extends Indexer {
       String metricsPrefix, String localRunId) {
     super(config, messenger, false, metricsPrefix, localRunId);
 
-    if (this.deletionMarkerField != null || this.deleteByFieldField != null || this.deleteByFieldValue != null) {
+    if (this.deletionMarkerField != null || this.deleteByFieldField != null) {
       log.warn("Deletion is not supported for this indexer. Documents marked for deletion will be written as regular rows.");
     }
 

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -59,6 +59,10 @@ public class WeaviateIndexer extends Indexer {
       String metricsPrefix, String localRunId) {
     super(config, messenger, false, metricsPrefix, localRunId);
 
+    if (this.deletionMarkerField != null) {
+      log.warn("indexer.deletionMarkerField is set but is not supported by NopIndexer.");
+    }
+
     this.weaviateClassName = config.hasPath("weaviate.className") ? config.getString("weaviate.className") : "Document";
     this.idDestinationName = config.hasPath("weaviate.idDestinationName") ? config.getString("weaviate.idDestinationName") :
         "id_original";


### PR DESCRIPTION
A user can specify deletionMarkerField in their indexer config and it will not trigger a validation error.
However, the only Indexer implementations that respect this field are SolrIndexer, OpenSearchIndexer, and PineconeIndexer.
If the user is using ElasticsearchIndexer or others, the setting will have no effect. The user will never receive feedback that it isn’t being considered.

This PR adds logging for those indexers where the setting has no effect
