### PR TITLE
LC-866: update reserved fields names

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Document.java
@@ -50,9 +50,9 @@ public interface Document {
 
   String ID_FIELD = "id";
   String RUNID_FIELD = "run_id";
-  String CHILDREN_FIELD = ".children";
-  String DROP_FIELD = ".dropped";
-  String SKIP_FIELD = ".skipped";
+  String CHILDREN_FIELD = "___children";
+  String DROP_FIELD = "___dropped";
+  String SKIP_FIELD = "___skipped";
   Set<String> RESERVED_FIELDS = new HashSet<>(List.of(ID_FIELD, RUNID_FIELD, CHILDREN_FIELD, DROP_FIELD, SKIP_FIELD));
 
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/jdbc/DatabaseConnectorTest.java
@@ -452,7 +452,7 @@ public class DatabaseConnectorTest {
     assertEquals(3, docs.size());
 
     // TODO: better verification / edge cases.. also formalize the "children" docs.
-    String expected = "{\"id\":\"1\",\"name\":\"Matt\",\".children\":[{\"id\":\"0\",\"meal_id\":1,\"animal_id\":1,\"name\":\"breakfast\"},{\"id\":\"1\",\"meal_id\":2,\"animal_id\":1,\"name\":\"lunch\"},{\"id\":\"2\",\"meal_id\":3,\"animal_id\":1,\"name\":\"dinner\"}],\"run_id\":\"testRunId\"}";
+    String expected = "{\"id\":\"1\",\"name\":\"Matt\",\"___children\":[{\"id\":\"0\",\"meal_id\":1,\"animal_id\":1,\"name\":\"breakfast\"},{\"id\":\"1\",\"meal_id\":2,\"animal_id\":1,\"name\":\"lunch\"},{\"id\":\"2\",\"meal_id\":3,\"animal_id\":1,\"name\":\"dinner\"}],\"run_id\":\"testRunId\"}";
     assertEquals(expected, docs.get(0).toString());
 
     connector.close();
@@ -487,7 +487,7 @@ public class DatabaseConnectorTest {
 
     List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(3, docs.size());
-    String expected = "{\"id\":\"Matt\",\"name\":\"Matt\",\"type\":\"Human\",\".children\":[{\"id\":\"0\",\"network_id\":3,\"name\":\"Matt\",\"friends_with\":\"Bob\"},{\"id\":\"1\",\"network_id\":4,\"name\":\"Matt\",\"friends_with\":\"Sonny\"},{\"id\":\"2\",\"network_id\":5,\"name\":\"Matt\",\"friends_with\":\"Blaze\"}],\"run_id\":\"testRunId\"}";
+    String expected = "{\"id\":\"Matt\",\"name\":\"Matt\",\"type\":\"Human\",\"___children\":[{\"id\":\"0\",\"network_id\":3,\"name\":\"Matt\",\"friends_with\":\"Bob\"},{\"id\":\"1\",\"network_id\":4,\"name\":\"Matt\",\"friends_with\":\"Sonny\"},{\"id\":\"2\",\"network_id\":5,\"name\":\"Matt\",\"friends_with\":\"Blaze\"}],\"run_id\":\"testRunId\"}";
     assertEquals(expected, docs.get(1).toString());
 
     connector.close();
@@ -552,7 +552,7 @@ public class DatabaseConnectorTest {
     List<Document> docs = messenger.getDocsSentForProcessing();
     assertEquals(1, docs.size());
     // birthday is idField
-    String expected = "{\"id\":\"2024-07-30\",\"name\":\"Sonny\",\"type\":\"Cat\",\"birthday\":\"2024-07-30T00:00:00Z\",\".children\":[{\"id\":\"0\",\"adoption_id\":1,\"name\":\"Sonny\",\"adopted_on\":\"2024-07-30T00:00:00Z\"},{\"id\":\"1\",\"adoption_id\":2,\"name\":\"Blaze\",\"adopted_on\":\"2024-07-30T00:00:00Z\"}],\"run_id\":\"testRunId\"}";
+    String expected = "{\"id\":\"2024-07-30\",\"name\":\"Sonny\",\"type\":\"Cat\",\"birthday\":\"2024-07-30T00:00:00Z\",\"___children\":[{\"id\":\"0\",\"adoption_id\":1,\"name\":\"Sonny\",\"adopted_on\":\"2024-07-30T00:00:00Z\"},{\"id\":\"1\",\"adoption_id\":2,\"name\":\"Blaze\",\"adopted_on\":\"2024-07-30T00:00:00Z\"}],\"run_id\":\"testRunId\"}";
     assertEquals(expected, docs.get(0).toString());
 
     String expectedDateStr = "2024-07-30";

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/DocumentTest.java
@@ -779,7 +779,7 @@ public abstract class DocumentTest {
     String beforeString = parent.toString();
     List<Document> children = parent.getChildren();
     String afterString = parent.toString();
-    // getChildren() should not create a .children field if it didn't already exist,
+    // getChildren() should not create a ___children field if it didn't already exist,
     // so the json-stringified form of the document should not change after calling getChildren()
     assertEquals(beforeString, afterString);
     assertEquals(0, children.size());

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONataTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONataTest.java
@@ -230,4 +230,22 @@ public class ApplyJSONataTest {
     assertEquals("doc1", doc.getId());
     assertNull(doc.getJson("destination"));
   }
+
+  @Test
+  public void testApplyReservedFields() throws StageException {
+    Stage stage = factory.get("ApplyJSONataTest/reservedFields.conf");
+    // Expression: $[0].enabled ? $[0].enabled : false
+    Document child0 = Document.create("child0");
+    child0.setField("enabled", true);
+    Document child1 = Document.create("child1");
+    child1.setField("enabled", false);
+    Document doc = Document.create("doc1");
+    doc.addChild(child0);
+    doc.addChild(child1);
+
+    stage.processDocument(doc);
+
+    assertEquals(true, child0.getBoolean("enabled"));
+    assertEquals(true, doc.getBoolean("isEnabled"));
+  }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONataTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSONataTest.java
@@ -233,6 +233,9 @@ public class ApplyJSONataTest {
 
   @Test
   public void testApplyReservedFields() throws StageException {
+    // We have updated the reserved fields to use underscores instead (ex. ___chlidren vs .children), because if not handled correctly,
+    //  it would break this use case where we want to use the ___children field with nested funtionality.
+
     Stage stage = factory.get("ApplyJSONataTest/reservedFields.conf");
     // Expression: $[0].enabled ? $[0].enabled : false
     Document child0 = Document.create("child0");

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/CopyFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/CopyFieldsTest.java
@@ -131,6 +131,27 @@ public class CopyFieldsTest {
   }
 
   @Test
+  public void testCopyFieldsReserved() throws StageException {
+    // We have updated the reserved fields to use underscores instead (ex. ___chlidren vs .children), because if not handled correctly,
+    //  it would break this use case where we want to use the ___children field with nested funtionality.
+
+    Stage stage = factory.get("CopyFieldsTest/reservedFields.conf");
+    Document child0 = Document.create("child0");
+    child0.setField("enabled", true);
+    Document child1 = Document.create("child1");
+    child1.setField("enabled", false);
+    Document doc = Document.create("doc1");
+    doc.addChild(child0);
+    doc.addChild(child1);
+
+    stage.processDocument(doc);
+
+    assertEquals(2, doc.getJsonList("nodes").size());
+    assertEquals(doc.getChildren().get(0).getId(), doc.getJsonList("nodes").get(0).get("id").textValue());
+    assertEquals(doc.getChildren().get(1).getId(), doc.getJsonList("nodes").get(1).get("id").textValue());
+  }
+
+  @Test
   public void testGetLegalProperties() throws StageException {
     Stage stage = factory.get("CopyFieldsTest/replace.conf");
     assertEquals(

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SkipDocumentTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SkipDocumentTest.java
@@ -18,8 +18,8 @@ public class SkipDocumentTest {
     Stage stage = factory.get("SkipDocumentTest/config.conf");
 
     Document doc = Document.create("doc");
-    // setting a field called .skipped should throw an exception as a reserved field
-    assertThrows(IllegalArgumentException.class, () -> doc.setField(".skipped", "test"));
+    // setting a field called ___skipped should throw an exception as a reserved field
+    assertThrows(IllegalArgumentException.class, () -> doc.setField("___skipped", "test"));
 
     assertFalse(doc.isSkipped());
     stage.processDocument(doc);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/FieldFilterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/FieldFilterTest.java
@@ -157,7 +157,7 @@ public class FieldFilterTest {
 
   @Test
   public void testGetFilteredDocumentChildrenRemovedWhenBlacklisted() throws Exception {
-    FieldFilter filter = new FieldFilter(ConfigFactory.parseMap(Map.of("blacklist", List.of(".children"))));
+    FieldFilter filter = new FieldFilter(ConfigFactory.parseMap(Map.of("blacklist", List.of("___children"))));
     Document doc = Document.create("id1");
     doc.addChild(Document.create("child1"));
 

--- a/lucille-core/src/test/resources/ApplyJSONataTest/reservedFields.conf
+++ b/lucille-core/src/test/resources/ApplyJSONataTest/reservedFields.conf
@@ -1,0 +1,6 @@
+{
+  class: com.kmwllc.lucille.stage.ApplyJSONata,
+  source: "___children",
+  destination: "isEnabled",
+  expression: "$[0].enabled ? $[0].enabled : false"
+}

--- a/lucille-core/src/test/resources/CopyFieldsTest/reservedFIelds.conf
+++ b/lucille-core/src/test/resources/CopyFieldsTest/reservedFIelds.conf
@@ -1,0 +1,7 @@
+{
+  class: "com.kmwllc.lucille.stage.CopyFields"
+  fieldMapping: {
+    "___children":"nodes"
+  }
+  isNested: true
+}


### PR DESCRIPTION
The reserved fields names used to start with a period. This could cause some confusion when dealing with nested json. We are replacing the names to begin with three underscores. This is a breaking change.