### PR TITLE
LC-862 Indexer Retry with per-item handling 

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -73,6 +73,11 @@
       <version>5.1.0</version>
     </dependency>
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.1.0-jre</version>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -371,6 +371,10 @@ public abstract class Indexer implements Runnable {
     try {
       stopWatch.reset();
       stopWatch.start();
+      // Note: the retry wraps the entire sendToIndex() call. If sendToIndex() partially succeeds
+      // (e.g. some documents indexed before a subsequent delete-by-query fails), a retry will
+      // re-execute the entire method. This is considered safe because search engine upserts are idempotent —
+      // re-indexing an already-indexed document produces the same result.
       Set<Pair<Document, String>> failedDocPairs = retry != null
           ? Retry.decorateCheckedSupplier(retry, () -> sendToIndex(batchedDocs)).get()
           : sendToIndex(batchedDocs);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.lang3.tuple.Pair;
@@ -141,6 +142,8 @@ public abstract class Indexer implements Runnable {
 
   // Non-null only when indexer.maxRetries is configured; null means retries are disabled (the default).
   private final Retry retry;
+  // Empty when retries are disabled; otherwise the set of HTTP status codes (and -1 for no-status) that trigger a retry.
+  private final List<Integer> retryableStatusCodes;
 
   public void terminate() {
     running = false;
@@ -225,6 +228,7 @@ public abstract class Indexer implements Runnable {
                 + "and indexer.retryableStatusCodes require indexer.maxRetries to be set.");
       }
       this.retry = null;
+      this.retryableStatusCodes = List.of();
     } else {
       int maxRetries = config.getInt("indexer.maxRetries");
       if (maxRetries <= 0) {
@@ -236,12 +240,11 @@ public abstract class Indexer implements Runnable {
           ? config.getLong("indexer.retryMaxWaitDurationMs") : DEFAULT_RETRY_MAX_WAIT_DURATION_MS;
       double retryRandomizationFactor = config.hasPath("indexer.retryRandomizationFactor")
           ? config.getDouble("indexer.retryRandomizationFactor") : DEFAULT_RETRY_RANDOMIZATION_FACTOR;
-      List<Integer> retryableStatusCodes;
       if (!config.hasPath("indexer.retryableStatusCodes")) {
-        retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES;
+        this.retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES;
       } else {
-        retryableStatusCodes = config.getIntList("indexer.retryableStatusCodes");
-        if (retryableStatusCodes.isEmpty()) {
+        this.retryableStatusCodes = config.getIntList("indexer.retryableStatusCodes");
+        if (this.retryableStatusCodes.isEmpty()) {
           throw new IllegalArgumentException(
               "indexer.retryableStatusCodes must not be empty when specified. "
                   + "Remove the parameter to use the default, or provide at least one status code.");
@@ -292,12 +295,15 @@ public abstract class Indexer implements Runnable {
    * each document individually.
    *
    * @param documents The documents to send to the destination.
-   * @return A set of Pairs, containing the Documents that were not successfully indexed, along with a String of information about why it failed.
-   * Returns an empty set if no documents fail, or if this information is not supported by the Indexer implementation. Does not return null.
-   * @throws Exception In the event of a considerable error causing indexing to fail. (Does not throw
-   * Exceptions just because some Documents were not successfully indexed.)
+   * @return A set of Pairs containing Documents that were not successfully indexed, along with an
+   *     Exception describing the failure. Use {@link IndexerRetryableException} to signal that the
+   *     failure may be transient; the base class will trigger a retry of the entire batch for any
+   *     returned exception whose status code is in the configured retryable set. Use
+   *     {@link IndexerException} for permanent per-document failures. Returns an empty set if all
+   *     documents succeeded or if per-document failure tracking is not supported. Does not return null.
+   * @throws Exception for errors that prevent the entire batch from being attempted.
    */
-  protected abstract Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception;
+  protected abstract Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws Exception;
 
   /** Close the client or connection to the destination search engine. */
   public abstract void closeConnection();
@@ -392,9 +398,41 @@ public abstract class Indexer implements Runnable {
       // (e.g. some documents indexed before a subsequent delete-by-query fails), a retry will
       // re-execute the entire method. This is considered safe because search engine upserts are idempotent —
       // re-indexing an already-indexed document produces the same result.
-      Set<Pair<Document, String>> failedDocPairs = retry != null
-          ? Retry.decorateCheckedSupplier(retry, () -> sendToIndex(batchedDocs)).get()
-          : sendToIndex(batchedDocs);
+      AtomicReference<Set<Pair<Document, Exception>>> lastResult = new AtomicReference<>();
+      Set<Pair<Document, Exception>> failedDocPairs;
+      try {
+        failedDocPairs = retry != null
+            ? Retry.decorateCheckedSupplier(retry, () -> {
+                Set<Pair<Document, Exception>> result = sendToIndex(batchedDocs);
+                // Capture the result before potentially throwing, so it is available if retries
+                // are exhausted — preserving per-document detail for the FAIL event path below.
+                lastResult.set(result);
+                // Throw the first retryable item-level failure so Resilience4j can apply the retry
+                // policy. Only throw if the status code is actually in the retryable set — non-retryable
+                // item failures (e.g. mapping conflicts) must stay in the return set so they reach the
+                // per-document FAIL event path below rather than collapsing into a batch-level exception.
+                for (Pair<Document, Exception> pair : result) {
+                  if (pair.getRight() instanceof IndexerRetryableException e
+                      && retryableStatusCodes.contains(e.getStatusCode())) {
+                    throw e;
+                  }
+                }
+                return result;
+              }).get()
+            : sendToIndex(batchedDocs);
+      } catch (IndexerRetryableException e) {
+        // Retries exhausted due to item-level errors. If the last sendToIndex call returned
+        // per-document detail, use it so individual FAIL events carry specific reasons rather
+        // than a generic batch-level message. If lastResult is empty the exception came from a
+        // throw inside sendToIndex itself (e.g. transport failure) — re-throw so the outer
+        // catch (Throwable) handles it as a batch-level failure as before.
+        Set<Pair<Document, Exception>> last = lastResult.get();
+        if (last != null && !last.isEmpty()) {
+          failedDocPairs = last;
+        } else {
+          throw e;
+        }
+      }
       stopWatch.stop();
       histogram.update(stopWatch.getNanoTime() / batchedDocs.size());
       meter.mark(batchedDocs.size());
@@ -404,10 +442,10 @@ public abstract class Indexer implements Runnable {
       }
 
       // Mark all the documents in failedDoc as failed
-      for (Pair<Document, String> pair : failedDocPairs) {
+      for (Pair<Document, Exception> pair : failedDocPairs) {
         try (MDCCloseable docIdMDC = MDC.putCloseable(ID_FIELD, pair.getLeft().getId())) {
-          messenger.sendEvent(pair.getLeft(), "FAILED: " + pair.getRight(), Event.Type.FAIL);
-          docLogger.error("Sent failure message for doc {}. Reason: {}", pair.getLeft().getId(), pair.getRight());
+          messenger.sendEvent(pair.getLeft(), "FAILED: " + pair.getRight().getMessage(), Event.Type.FAIL);
+          docLogger.error("Sent failure message for doc {}. Reason: {}", pair.getLeft().getId(), pair.getRight().getMessage());
         } catch (Exception e) {
           log.error("Couldn't send failure event for doc {}", pair.getLeft().getId(), e);
         }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -80,22 +80,24 @@ import sun.misc.Signal;
  *   <li>indexer.deleteByFieldValue (String, Optional) : Field whose value specifies which documents to delete by query. Must be set
  *   together with indexer.deleteByFieldField.</li>
  *   <li>indexer.maxRetries (Integer, Optional) : Maximum number of times to retry a failed batch before treating all documents
- *   in the batch as failures. Retries are disabled by default ({@value #DEFAULT_MAX_RETRIES}); set to a positive integer to opt in.</li>
+ *   in the batch as failures. Retries are disabled by default; set to a positive integer to opt in. A value of 0 or less
+ *   is rejected as invalid — remove the parameter entirely to disable retries.</li>
  *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
- *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only relevant when maxRetries is greater than 0.
+ *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only allowed when maxRetries is also set.
  *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
  *   <li>indexer.retryableStatusCodes (List&lt;Integer&gt;, Optional) : HTTP status codes that should trigger a retry when thrown
  *   as an {@link IndexerRetryableException}. Failures with status codes not in this list, or plain {@link IndexerException}
- *   failures, will not be retried. Defaults to {@code [429, 503]}. Only relevant when maxRetries is greater than 0.</li>
+ *   failures, will not be retried. Include the sentinel value {@code -1} to also retry failures where no HTTP status code
+ *   is available (e.g. network timeouts). When this parameter is omitted, the default {@code [429, 503, -1]} is used.
+ *   An empty list is rejected as invalid configuration. Only allowed when maxRetries is also set.</li>
  * </ul>
  */
 public abstract class Indexer implements Runnable {
 
   public static final int DEFAULT_BATCH_SIZE = 100;
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
-  public static final int DEFAULT_MAX_RETRIES = 0;
   public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
-  public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503);
+  public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503, IndexerRetryableException.UNKNOWN_STATUS_CODE);
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
   private static final Logger docLogger = LoggerFactory.getLogger("com.kmwllc.lucille.core.DocLogger");
@@ -128,7 +130,7 @@ public abstract class Indexer implements Runnable {
 
   protected final boolean bypass;
 
-  // Non-null only when indexer.maxRetries > 0; null means retries are disabled (the default).
+  // Non-null only when indexer.maxRetries is configured; null means retries are disabled (the default).
   private final Retry retry;
 
   public void terminate() {
@@ -206,20 +208,36 @@ public abstract class Indexer implements Runnable {
 
     this.fieldFilter = new FieldFilter(config.getConfig("indexer"));
 
-    int maxRetries = ConfigUtils.getOrDefault(config, "indexer.maxRetries", DEFAULT_MAX_RETRIES);
-    int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
-    if (maxRetries > 0) {
-      List<Integer> retryableStatusCodes = config.hasPath("indexer.retryableStatusCodes")
-          ? config.getIntList("indexer.retryableStatusCodes")
-          : DEFAULT_RETRYABLE_STATUS_CODES;
+    if (!config.hasPath("indexer.maxRetries")) {
+      if (config.hasPath("indexer.retryWaitDurationMs") || config.hasPath("indexer.retryableStatusCodes")) {
+        throw new IllegalArgumentException(
+            "indexer.retryWaitDurationMs and indexer.retryableStatusCodes require indexer.maxRetries to be set.");
+      }
+      this.retry = null;
+    } else {
+      int maxRetries = config.getInt("indexer.maxRetries");
+      if (maxRetries <= 0) {
+        throw new IllegalArgumentException(
+            "indexer.maxRetries must be greater than 0 when specified. Remove the parameter to disable retries.");
+      }
+      int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
+      List<Integer> retryableStatusCodes;
+      if (!config.hasPath("indexer.retryableStatusCodes")) {
+        retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES;
+      } else {
+        retryableStatusCodes = config.getIntList("indexer.retryableStatusCodes");
+        if (retryableStatusCodes.isEmpty()) {
+          throw new IllegalArgumentException(
+              "indexer.retryableStatusCodes must not be empty when specified. "
+                  + "Remove the parameter to use the default, or provide at least one status code.");
+        }
+      }
       this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
           .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
           .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
           .retryOnException(e -> {
             if (e instanceof IndexerRetryableException retryable) {
-              // Retry if the status code is in the configured list, or if no status code is known
-              return retryable.getStatusCode() == IndexerRetryableException.UNKNOWN_STATUS_CODE
-                  || retryableStatusCodes.contains(retryable.getStatusCode());
+              return retryableStatusCodes.contains(retryable.getStatusCode());
             }
             // Plain IndexerException (non-HTTP failure) — do not retry
             return false;
@@ -230,8 +248,6 @@ public abstract class Indexer implements Runnable {
               event.getNumberOfRetryAttempts(), maxRetries,
               event.getWaitInterval().toMillis(),
               event.getLastThrowable().getMessage()));
-    } else {
-      this.retry = null;
     }
 
     // Validate the "indexer" entry and the specific implementation entry (using the spec) in the Config, if present.
@@ -391,19 +407,22 @@ public abstract class Indexer implements Runnable {
           messenger.sendEvent(d, "SUCCEEDED", Event.Type.FINISH);
           docLogger.info("Sent success message for doc {}.", d.getId());
         } catch (Exception e) {
-          // TODO: The run won't be able to finish if this event isn't received; can we do something
-          // special here?
-          log.error("Error sending completion event for doc {}", d.getId(), e);
+          log.error("Error sending completion event for doc {}. RUN WILL HANG.", d.getId(), e);
         } finally {
           if (d.getRunId() != null) {
             MDC.popByKey(RUNID_FIELD);
           }
         }
       }
-    } catch (Throwable e) {
+    } catch (Throwable t) {
+      // Rethrow Errors (OutOfMemoryError, etc.) — they should never be swallowed
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      Exception e = (t instanceof Exception) ? (Exception) t : new RuntimeException(t);
       // If an Exception is thrown, there was some larger error causing nothing (or essentially nothing) to be indexed.
       // So everything is considered to have failed - we won't even look at failedDocs.
-      log.error("Error sending documents to index: " + e.getMessage(), e);
+      log.error("Error sending documents to index: {}", e.getMessage(), e);
 
       for (Document d : batchedDocs) {
         try (MDCCloseable docIdMDC = MDC.putCloseable(ID_FIELD, d.getId())) {
@@ -414,9 +433,7 @@ public abstract class Indexer implements Runnable {
           messenger.sendEvent(d, "FAILED: " + e.getMessage(), Event.Type.FAIL);
           docLogger.error("Sent failure message for doc {}. Reason: {}", d.getId(), e.getMessage());
         } catch (Exception e2) {
-          // TODO: The run won't be able to finish if this event isn't received; can we do something
-          // special here?
-          log.error("Couldn't send failure event for doc {}", d.getId(), e2);
+          log.error("Couldn't send failure event for doc {}. RUN WILL HANG.", d.getId(), e2);
         } finally {
           if (d.getRunId() != null) {
             MDC.popByKey(RUNID_FIELD);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -420,12 +420,7 @@ public abstract class Indexer implements Runnable {
 
       // Mark all the documents in failedDoc as failed
       for (Pair<Document, Exception> pair : failedDocPairs) {
-        try (MDCCloseable docIdMDC = MDC.putCloseable(ID_FIELD, pair.getLeft().getId())) {
-          messenger.sendEvent(pair.getLeft(), "FAILED: " + pair.getRight().getMessage(), Event.Type.FAIL);
-          docLogger.error("Sent failure message for doc {}. Reason: {}", pair.getLeft().getId(), pair.getRight().getMessage());
-        } catch (Exception e) {
-          log.error("Couldn't send failure event for doc {}", pair.getLeft().getId(), e);
-        }
+        sendFailEvent(pair.getLeft(), pair.getRight().getMessage());
       }
 
       Set<Document> failedDocs = failedDocPairs.stream().map(Pair::getLeft).collect(Collectors.toSet());
@@ -461,20 +456,7 @@ public abstract class Indexer implements Runnable {
       log.error("Error sending documents to index: {}", e.getMessage(), e);
 
       for (Document d : batchedDocs) {
-        try (MDCCloseable docIdMDC = MDC.putCloseable(ID_FIELD, d.getId())) {
-          if (d.getRunId() != null) {
-            MDC.pushByKey(RUNID_FIELD, d.getRunId());
-          }
-
-          messenger.sendEvent(d, "FAILED: " + e.getMessage(), Event.Type.FAIL);
-          docLogger.error("Sent failure message for doc {}. Reason: {}", d.getId(), e.getMessage());
-        } catch (Exception e2) {
-          log.error("Couldn't send failure event for doc {}. RUN WILL HANG.", d.getId(), e2);
-        } finally {
-          if (d.getRunId() != null) {
-            MDC.popByKey(RUNID_FIELD);
-          }
-        }
+        sendFailEvent(d, e.getMessage());
       }
     } finally {
       // We always mark batches as completed, regardless of whether the whole batch failed, some docs failed, etc.
@@ -482,6 +464,26 @@ public abstract class Indexer implements Runnable {
         messenger.batchComplete(batchedDocs);
       } catch (Exception e) {
         log.error("Error marking batch complete.", e);
+      }
+    }
+  }
+
+  /**
+   * Sends a FAIL event for the given document with the specified reason, setting up MDC context
+   * for structured logging.
+   */
+  private void sendFailEvent(Document d, String reason) {
+    try (MDCCloseable docIdMDC = MDC.putCloseable(ID_FIELD, d.getId())) {
+      if (d.getRunId() != null) {
+        MDC.pushByKey(RUNID_FIELD, d.getRunId());
+      }
+      messenger.sendEvent(d, "FAILED: " + reason, Event.Type.FAIL);
+      docLogger.error("Sent failure message for doc {}. Reason: {}", d.getId(), reason);
+    } catch (Exception e) {
+      log.error("Couldn't send failure event for doc {}. RUN WILL HANG.", d.getId(), e);
+    } finally {
+      if (d.getRunId() != null) {
+        MDC.popByKey(RUNID_FIELD);
       }
     }
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -17,6 +17,9 @@ import com.kmwllc.lucille.util.FieldFilter;
 import com.kmwllc.lucille.util.LogUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.StopWatch;
@@ -73,12 +76,19 @@ import sun.misc.Signal;
  *   together with indexer.deleteByFieldValue.</li>
  *   <li>indexer.deleteByFieldValue (String, Optional) : Field whose value specifies which documents to delete by query. Must be set
  *   together with indexer.deleteByFieldField.</li>
+ *   <li>indexer.maxRetries (Integer, Optional) : Maximum number of times to retry a failed batch before treating all documents
+ *   in the batch as failures. Retries are disabled by default ({@value #DEFAULT_MAX_RETRIES}); set to a positive integer to opt in.</li>
+ *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
+ *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only relevant when maxRetries is greater than 0.
+ *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
  * </ul>
  */
 public abstract class Indexer implements Runnable {
 
   public static final int DEFAULT_BATCH_SIZE = 100;
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
+  public static final int DEFAULT_MAX_RETRIES = 0;
+  public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
   private static final Logger docLogger = LoggerFactory.getLogger("com.kmwllc.lucille.core.DocLogger");
@@ -110,6 +120,9 @@ public abstract class Indexer implements Runnable {
   private final String localRunId;
 
   protected final boolean bypass;
+
+  // Non-null only when indexer.maxRetries > 0; null means retries are disabled (the default).
+  private final Retry retry;
 
   public void terminate() {
     running = false;
@@ -185,6 +198,22 @@ public abstract class Indexer implements Runnable {
     this.localRunId = localRunId;
 
     this.fieldFilter = new FieldFilter(config.getConfig("indexer"));
+
+    int maxRetries = ConfigUtils.getOrDefault(config, "indexer.maxRetries", DEFAULT_MAX_RETRIES);
+    int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
+    if (maxRetries > 0) {
+      this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
+          .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
+          .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
+          .build());
+      this.retry.getEventPublisher().onRetry(event ->
+          log.warn("Retrying batch send (attempt {}/{}), waiting {}ms: {}",
+              event.getNumberOfRetryAttempts(), maxRetries,
+              event.getWaitInterval().toMillis(),
+              event.getLastThrowable().getMessage()));
+    } else {
+      this.retry = null;
+    }
 
     // Validate the "indexer" entry and the specific implementation entry (using the spec) in the Config, if present.
     validateIndexerConfigs(config);
@@ -307,7 +336,9 @@ public abstract class Indexer implements Runnable {
     try {
       stopWatch.reset();
       stopWatch.start();
-      Set<Pair<Document, String>> failedDocPairs = sendToIndex(batchedDocs);
+      Set<Pair<Document, String>> failedDocPairs = retry != null
+          ? Retry.decorateCheckedSupplier(retry, () -> sendToIndex(batchedDocs)).get()
+          : sendToIndex(batchedDocs);
       stopWatch.stop();
       histogram.update(stopWatch.getNanoTime() / batchedDocs.size());
       meter.mark(batchedDocs.size());
@@ -350,7 +381,7 @@ public abstract class Indexer implements Runnable {
           }
         }
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       // If an Exception is thrown, there was some larger error causing nothing (or essentially nothing) to be indexed.
       // So everything is considered to have failed - we won't even look at failedDocs.
       log.error("Error sending documents to index: " + e.getMessage(), e);
@@ -457,7 +488,7 @@ public abstract class Indexer implements Runnable {
     SpecBuilder.withoutDefaults()
         .optionalString("type", "class", "idOverrideField", "indexOverrideField", "deletionMarkerField", "deletionMarkerFieldValue",
             "deleteByFieldField", "deleteByFieldValue", "versionType", "routingField")
-        .optionalNumber("batchSize", "batchTimeout", "logRate")
+        .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs")
         .optionalBoolean("sendEnabled")
         .optionalList("whitelist", new TypeReference<List<String>>(){})
         .optionalList("blacklist", new TypeReference<List<String>>(){}).build()

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -85,6 +85,13 @@ import sun.misc.Signal;
  *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
  *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only allowed when maxRetries is also set.
  *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
+ *   <li>indexer.retryMaxWaitDurationMs (Long, Optional) : Maximum wait duration in milliseconds between retries.
+ *   Caps the exponential backoff so it does not grow unbounded. Only allowed when maxRetries is also set.
+ *   Defaults to {@value #DEFAULT_RETRY_MAX_WAIT_DURATION_MS}.</li>
+ *   <li>indexer.retryRandomizationFactor (Double, Optional) : Randomization factor applied to the wait duration
+ *   to add jitter and prevent thundering-herd effects. A value of 0.5 means the actual wait will be between
+ *   50% and 150% of the computed backoff. Set to 0.0 to disable jitter. Only allowed when maxRetries is also set.
+ *   Defaults to {@value #DEFAULT_RETRY_RANDOMIZATION_FACTOR}.</li>
  *   <li>indexer.retryableStatusCodes (List&lt;Integer&gt;, Optional) : HTTP status codes that should trigger a retry when thrown
  *   as an {@link IndexerRetryableException}. Failures with status codes not in this list, or plain {@link IndexerException}
  *   failures, will not be retried. Include the sentinel value {@code -1} to also retry failures where no HTTP status code
@@ -97,6 +104,8 @@ public abstract class Indexer implements Runnable {
   public static final int DEFAULT_BATCH_SIZE = 100;
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
   public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
+  public static final long DEFAULT_RETRY_MAX_WAIT_DURATION_MS = 30000;
+  public static final double DEFAULT_RETRY_RANDOMIZATION_FACTOR = 0.5;
   public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503, IndexerRetryableException.UNKNOWN_STATUS_CODE);
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
@@ -209,9 +218,11 @@ public abstract class Indexer implements Runnable {
     this.fieldFilter = new FieldFilter(config.getConfig("indexer"));
 
     if (!config.hasPath("indexer.maxRetries")) {
-      if (config.hasPath("indexer.retryWaitDurationMs") || config.hasPath("indexer.retryableStatusCodes")) {
+      if (config.hasPath("indexer.retryWaitDurationMs") || config.hasPath("indexer.retryableStatusCodes")
+          || config.hasPath("indexer.retryMaxWaitDurationMs") || config.hasPath("indexer.retryRandomizationFactor")) {
         throw new IllegalArgumentException(
-            "indexer.retryWaitDurationMs and indexer.retryableStatusCodes require indexer.maxRetries to be set.");
+            "indexer.retryWaitDurationMs, indexer.retryMaxWaitDurationMs, indexer.retryRandomizationFactor, "
+                + "and indexer.retryableStatusCodes require indexer.maxRetries to be set.");
       }
       this.retry = null;
     } else {
@@ -221,6 +232,10 @@ public abstract class Indexer implements Runnable {
             "indexer.maxRetries must be greater than 0 when specified. Remove the parameter to disable retries.");
       }
       int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
+      long retryMaxWaitDurationMs = config.hasPath("indexer.retryMaxWaitDurationMs")
+          ? config.getLong("indexer.retryMaxWaitDurationMs") : DEFAULT_RETRY_MAX_WAIT_DURATION_MS;
+      double retryRandomizationFactor = config.hasPath("indexer.retryRandomizationFactor")
+          ? config.getDouble("indexer.retryRandomizationFactor") : DEFAULT_RETRY_RANDOMIZATION_FACTOR;
       List<Integer> retryableStatusCodes;
       if (!config.hasPath("indexer.retryableStatusCodes")) {
         retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES;
@@ -234,7 +249,9 @@ public abstract class Indexer implements Runnable {
       }
       this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
           .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
-          .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
+          .intervalFunction(IntervalFunction.ofExponentialRandomBackoff(
+              retryInitialWaitDurationMs, IntervalFunction.DEFAULT_MULTIPLIER,
+              retryRandomizationFactor, retryMaxWaitDurationMs))
           .retryOnException(e -> {
             if (e instanceof IndexerRetryableException retryable) {
               return retryableStatusCodes.contains(retryable.getStatusCode());
@@ -528,7 +545,8 @@ public abstract class Indexer implements Runnable {
     SpecBuilder.withoutDefaults()
         .optionalString("type", "class", "idOverrideField", "indexOverrideField", "deletionMarkerField", "deletionMarkerFieldValue",
             "deleteByFieldField", "deleteByFieldValue", "versionType", "routingField")
-        .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs")
+        .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs",
+            "retryMaxWaitDurationMs", "retryRandomizationFactor")
         .optionalBoolean("sendEnabled")
         .optionalList("whitelist", new TypeReference<List<String>>(){})
         .optionalList("blacklist", new TypeReference<List<String>>(){})

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -20,6 +20,9 @@ import com.typesafe.config.ConfigFactory;
 import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.StopWatch;
@@ -81,6 +84,9 @@ import sun.misc.Signal;
  *   <li>indexer.retryWaitDurationMs (Integer, Optional) : Initial wait duration in milliseconds before the first retry.
  *   Subsequent retries use exponential backoff, doubling the wait on each attempt. Only relevant when maxRetries is greater than 0.
  *   Defaults to {@value #DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS}.</li>
+ *   <li>indexer.retryableStatusCodes (List&lt;Integer&gt;, Optional) : HTTP status codes that should trigger a retry when thrown
+ *   as an {@link IndexerRetryableException}. Failures with status codes not in this list, or plain {@link IndexerException}
+ *   failures, will not be retried. Defaults to {@code [429, 503]}. Only relevant when maxRetries is greater than 0.</li>
  * </ul>
  */
 public abstract class Indexer implements Runnable {
@@ -89,6 +95,7 @@ public abstract class Indexer implements Runnable {
   public static final int DEFAULT_BATCH_TIMEOUT = 100;
   public static final int DEFAULT_MAX_RETRIES = 0;
   public static final int DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS = 1000;
+  public static final List<Integer> DEFAULT_RETRYABLE_STATUS_CODES = List.of(429, 503);
 
   private static final Logger log = LoggerFactory.getLogger(Indexer.class);
   private static final Logger docLogger = LoggerFactory.getLogger("com.kmwllc.lucille.core.DocLogger");
@@ -202,9 +209,21 @@ public abstract class Indexer implements Runnable {
     int maxRetries = ConfigUtils.getOrDefault(config, "indexer.maxRetries", DEFAULT_MAX_RETRIES);
     int retryInitialWaitDurationMs = ConfigUtils.getOrDefault(config, "indexer.retryWaitDurationMs", DEFAULT_RETRY_INITIAL_WAIT_DURATION_MS);
     if (maxRetries > 0) {
+      List<Integer> retryableStatusCodes = config.hasPath("indexer.retryableStatusCodes")
+          ? config.getIntList("indexer.retryableStatusCodes")
+          : DEFAULT_RETRYABLE_STATUS_CODES;
       this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
           .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
           .intervalFunction(IntervalFunction.ofExponentialBackoff(retryInitialWaitDurationMs))
+          .retryOnException(e -> {
+            if (e instanceof IndexerRetryableException retryable) {
+              // Retry if the status code is in the configured list, or if no status code is known
+              return retryable.getStatusCode() == IndexerRetryableException.UNKNOWN_STATUS_CODE
+                  || retryableStatusCodes.contains(retryable.getStatusCode());
+            }
+            // Plain IndexerException (non-HTTP failure) — do not retry
+            return false;
+          })
           .build());
       this.retry.getEventPublisher().onRetry(event ->
           log.warn("Retrying batch send (attempt {}/{}), waiting {}ms: {}",
@@ -491,7 +510,8 @@ public abstract class Indexer implements Runnable {
         .optionalNumber("batchSize", "batchTimeout", "logRate", "maxRetries", "retryWaitDurationMs")
         .optionalBoolean("sendEnabled")
         .optionalList("whitelist", new TypeReference<List<String>>(){})
-        .optionalList("blacklist", new TypeReference<List<String>>(){}).build()
+        .optionalList("blacklist", new TypeReference<List<String>>(){})
+        .optionalList("retryableStatusCodes", new TypeReference<List<Integer>>(){}).build()
         .validate(indexerConfig, "Indexer");
 
     // Validate the specific implementation in the config (solr, elasticsearch, csv, ...) if it is present / needed.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Indexer.java
@@ -24,17 +24,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
 import org.slf4j.MDC;
 import org.slf4j.MDC.MDCCloseable;
 import sun.misc.Signal;
@@ -250,11 +246,19 @@ public abstract class Indexer implements Runnable {
                   + "Remove the parameter to use the default, or provide at least one status code.");
         }
       }
-      this.retry = Retry.of("indexer-batch-retry", RetryConfig.custom()
+      this.retry = Retry.of("indexer-batch-retry", RetryConfig.<Set<Pair<Document, Exception>>>custom()
           .maxAttempts(maxRetries + 1) // maxAttempts includes the initial attempt
           .intervalFunction(IntervalFunction.ofExponentialRandomBackoff(
               retryInitialWaitDurationMs, IntervalFunction.DEFAULT_MULTIPLIER,
               retryRandomizationFactor, retryMaxWaitDurationMs))
+          .retryOnResult(result -> {
+            // Retry the batch if any per-document failure has a retryable status code.
+            @SuppressWarnings("unchecked")
+            Set<Pair<Document, Exception>> pairs = (Set<Pair<Document, Exception>>) result;
+            return pairs.stream().anyMatch(p ->
+                p.getRight() instanceof IndexerRetryableException e
+                    && retryableStatusCodes.contains(e.getStatusCode()));
+          })
           .retryOnException(e -> {
             if (e instanceof IndexerRetryableException retryable) {
               return retryableStatusCodes.contains(retryable.getStatusCode());
@@ -263,11 +267,13 @@ public abstract class Indexer implements Runnable {
             return false;
           })
           .build());
-      this.retry.getEventPublisher().onRetry(event ->
-          log.warn("Retrying batch send (attempt {}/{}), waiting {}ms: {}",
-              event.getNumberOfRetryAttempts(), maxRetries,
-              event.getWaitInterval().toMillis(),
-              event.getLastThrowable().getMessage()));
+      this.retry.getEventPublisher().onRetry(event -> {
+        Throwable lastThrowable = event.getLastThrowable();
+        log.warn("Retrying batch send (attempt {}/{}), waiting {}ms: {}",
+            event.getNumberOfRetryAttempts(), maxRetries,
+            event.getWaitInterval().toMillis(),
+            lastThrowable != null ? lastThrowable.getMessage() : "per-document retryable failures");
+      });
     }
 
     // Validate the "indexer" entry and the specific implementation entry (using the spec) in the Config, if present.
@@ -398,41 +404,12 @@ public abstract class Indexer implements Runnable {
       // (e.g. some documents indexed before a subsequent delete-by-query fails), a retry will
       // re-execute the entire method. This is considered safe because search engine upserts are idempotent —
       // re-indexing an already-indexed document produces the same result.
-      AtomicReference<Set<Pair<Document, Exception>>> lastResult = new AtomicReference<>();
-      Set<Pair<Document, Exception>> failedDocPairs;
-      try {
-        failedDocPairs = retry != null
-            ? Retry.decorateCheckedSupplier(retry, () -> {
-                Set<Pair<Document, Exception>> result = sendToIndex(batchedDocs);
-                // Capture the result before potentially throwing, so it is available if retries
-                // are exhausted — preserving per-document detail for the FAIL event path below.
-                lastResult.set(result);
-                // Throw the first retryable item-level failure so Resilience4j can apply the retry
-                // policy. Only throw if the status code is actually in the retryable set — non-retryable
-                // item failures (e.g. mapping conflicts) must stay in the return set so they reach the
-                // per-document FAIL event path below rather than collapsing into a batch-level exception.
-                for (Pair<Document, Exception> pair : result) {
-                  if (pair.getRight() instanceof IndexerRetryableException e
-                      && retryableStatusCodes.contains(e.getStatusCode())) {
-                    throw e;
-                  }
-                }
-                return result;
-              }).get()
-            : sendToIndex(batchedDocs);
-      } catch (IndexerRetryableException e) {
-        // Retries exhausted due to item-level errors. If the last sendToIndex call returned
-        // per-document detail, use it so individual FAIL events carry specific reasons rather
-        // than a generic batch-level message. If lastResult is empty the exception came from a
-        // throw inside sendToIndex itself (e.g. transport failure) — re-throw so the outer
-        // catch (Throwable) handles it as a batch-level failure as before.
-        Set<Pair<Document, Exception>> last = lastResult.get();
-        if (last != null && !last.isEmpty()) {
-          failedDocPairs = last;
-        } else {
-          throw e;
-        }
-      }
+      // When retries are configured, retryOnResult triggers a retry if any per-document failure has a
+      // retryable status code. When retries are exhausted, the last result is returned directly —
+      // preserving per-document detail for the FAIL event path below.
+      Set<Pair<Document, Exception>> failedDocPairs = retry != null
+          ? Retry.decorateCheckedSupplier(retry, () -> sendToIndex(batchedDocs)).get()
+          : sendToIndex(batchedDocs);
       stopWatch.stop();
       histogram.update(stopWatch.getNanoTime() / batchedDocs.size());
       meter.mark(batchedDocs.size());

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
@@ -1,0 +1,52 @@
+package com.kmwllc.lucille.core;
+
+/**
+ * Thrown by an {@link Indexer} implementation when a batch send fails with an HTTP-level error
+ * that may be transient and worth retrying. Carries the HTTP status code so that the base
+ * {@link Indexer} can decide whether to retry based on the configured
+ * {@code indexer.retryableStatusCodes} list.
+ *
+ * <p>Use {@link IndexerException} instead when the failure is not HTTP-based or should never
+ * be retried regardless of configuration.
+ */
+public class IndexerRetryableException extends IndexerException {
+
+  /** Sentinel value used when no HTTP status code is available (e.g. a pure network failure). */
+  public static final int UNKNOWN_STATUS_CODE = -1;
+
+  private final int statusCode;
+
+  /**
+   * Creates an exception with a known HTTP status code.
+   *
+   * @param statusCode the HTTP status code returned by the backend
+   * @param message    a description of the failure
+   * @param cause      the underlying exception
+   */
+  public IndexerRetryableException(int statusCode, String message, Throwable cause) {
+    super(message, cause);
+    this.statusCode = statusCode;
+  }
+
+  /**
+   * Creates an exception for a non-HTTP failure (e.g. a network timeout) where no status code
+   * is available. Uses {@value #UNKNOWN_STATUS_CODE} as the status code.
+   *
+   * @param message a description of the failure
+   * @param cause   the underlying exception
+   */
+  public IndexerRetryableException(String message, Throwable cause) {
+    super(message, cause);
+    this.statusCode = UNKNOWN_STATUS_CODE;
+  }
+
+  /**
+   * Returns the HTTP status code associated with this failure, or {@value #UNKNOWN_STATUS_CODE}
+   * if no status code is available.
+   *
+   * @return the HTTP status code, or {@value #UNKNOWN_STATUS_CODE}
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+}

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/IndexerRetryableException.java
@@ -6,6 +6,11 @@ package com.kmwllc.lucille.core;
  * {@link Indexer} can decide whether to retry based on the configured
  * {@code indexer.retryableStatusCodes} list.
  *
+ * <p>When no HTTP status code is available (e.g. a pure network failure), the sentinel value
+ * {@link #UNKNOWN_STATUS_CODE} ({@value #UNKNOWN_STATUS_CODE}) is used. The Indexer retries
+ * unknown-status-code failures only when the user omits {@code indexer.retryableStatusCodes}
+ * (using the default) or explicitly includes {@value #UNKNOWN_STATUS_CODE} in the list.
+ *
  * <p>Use {@link IndexerException} instead when the failure is not HTTP-based or should never
  * be retried regardless of configuration.
  */

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/CSVIndexer.java
@@ -121,7 +121,7 @@ public class CSVIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws Exception {
     for (Document doc : documents) {
       writer.writeNext(getLine(doc), true);
     }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/ElasticsearchIndexer.java
@@ -128,7 +128,7 @@ public class ElasticsearchIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (bypass) {
       return Set.of();
@@ -207,7 +207,7 @@ public class ElasticsearchIndexer extends Indexer {
       }
     }
 
-    Set<Pair<Document, String>> failedDocs = new HashSet<>();
+    Set<Pair<Document, Exception>> failedDocs = new HashSet<>();
 
     BulkResponse response = client.bulk(br.build());
     if (response != null) {
@@ -217,7 +217,7 @@ public class ElasticsearchIndexer extends Indexer {
           // If not, we don't know what the error is, and opt to throw an actual IndexerException instead.
           if (documentsUploaded.containsKey(item.id())) {
             Document failedDoc = documentsUploaded.get(item.id());
-            failedDocs.add(Pair.of(failedDoc, item.error().reason()));
+            failedDocs.add(Pair.of(failedDoc, new IndexerException(item.error().reason())));
           } else {
             throw new IndexerException(item.error().reason());
           }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/NopIndexer.java
@@ -35,7 +35,7 @@ public class NopIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws Exception {
     // no-op
     return Set.of();
   }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -131,7 +131,7 @@ public class OpenSearchIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws Exception {
     // skip indexing if there is no indexer client
     if (bypass) {
       return Set.of();
@@ -174,7 +174,7 @@ public class OpenSearchIndexer extends Indexer {
       }
     }
 
-    Set<Pair<Document, String>> failedDocs = uploadDocuments(documentsToUpload.values());
+    Set<Pair<Document, Exception>> failedDocs = uploadDocuments(documentsToUpload.values());
     deleteById(new ArrayList<>(idsToDelete));
     deleteByQuery(termsToDeleteByQuery);
 
@@ -303,7 +303,7 @@ public class OpenSearchIndexer extends Indexer {
     }
   }
 
-  private Set<Pair<Document, String>> uploadDocuments(Collection<Document> documentsToUpload) throws IndexerException {
+  private Set<Pair<Document, Exception>> uploadDocuments(Collection<Document> documentsToUpload) throws IndexerException {
     if (documentsToUpload.isEmpty()) {
       return Set.of();
     }
@@ -370,7 +370,7 @@ public class OpenSearchIndexer extends Indexer {
       }
     }
 
-    Set<Pair<Document, String>> failedDocs = new HashSet<>();
+    Set<Pair<Document, Exception>> failedDocs = new HashSet<>();
 
     BulkResponse response;
     try {
@@ -390,7 +390,12 @@ public class OpenSearchIndexer extends Indexer {
           // If not, we don't know what the error is, and opt to throw an actual IndexerException instead.
           if (uploadedDocuments.containsKey(item.id())) {
             Document failedDoc = uploadedDocuments.get(item.id());
-            failedDocs.add(Pair.of(failedDoc, item.error().reason()));
+            // item.status() is always an HTTP status code. The OpenSearch bulk API defines the per-item
+            // status field as the HTTP status of that individual operation (e.g. 200, 201, 400, 409, 429,
+            // 503). This is consistent across all OpenSearch client libraries and confirmed by the
+            // OpenSearch REST API documentation and source — there are no documented non-HTTP values.
+            failedDocs.add(Pair.of(failedDoc, new IndexerRetryableException(item.status(),
+                "OpenSearch bulk item error (status " + item.status() + "): " + item.error().reason(), null)));
           } else {
             throw new IndexerException(item.error().reason());
           }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -196,7 +196,15 @@ public class OpenSearchIndexer extends Indexer {
       );
     }
 
-    BulkResponse response = client.bulk(br.build());
+    BulkResponse response;
+    try {
+      response = client.bulk(br.build());
+    } catch (org.opensearch.client.opensearch._types.OpenSearchException e) {
+      throw new IndexerRetryableException(e.status(), "OpenSearch returned HTTP " + e.status(), e);
+    } catch (IOException e) {
+      throw new IndexerRetryableException("Transport failure communicating with OpenSearch", e);
+    }
+
     if (response.errors()) {
       for (BulkResponseItem item : response.items()) {
         if (item.error() != null) {
@@ -276,7 +284,15 @@ public class OpenSearchIndexer extends Indexer {
           .index(entry.getKey())
           .query(q -> q.bool(boolQuery.build()))
           .build();
-      DeleteByQueryResponse response = client.deleteByQuery(deleteByQueryRequest);
+
+      DeleteByQueryResponse response;
+      try {
+        response = client.deleteByQuery(deleteByQueryRequest);
+      } catch (org.opensearch.client.opensearch._types.OpenSearchException e) {
+        throw new IndexerRetryableException(e.status(), "OpenSearch returned HTTP " + e.status(), e);
+      } catch (IOException e) {
+        throw new IndexerRetryableException("Transport failure communicating with OpenSearch", e);
+      }
 
       if (!response.failures().isEmpty()) {
         for (BulkIndexByScrollFailure failure : response.failures()) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/OpenSearchIndexer.java
@@ -3,6 +3,7 @@ package com.kmwllc.lucille.indexer;
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Indexer;
 import com.kmwllc.lucille.core.IndexerException;
+import com.kmwllc.lucille.core.IndexerRetryableException;
 import com.kmwllc.lucille.core.KafkaDocument;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.SpecBuilder;
@@ -286,7 +287,7 @@ public class OpenSearchIndexer extends Indexer {
     }
   }
 
-  private Set<Pair<Document, String>> uploadDocuments(Collection<Document> documentsToUpload) throws IOException, IndexerException {
+  private Set<Pair<Document, String>> uploadDocuments(Collection<Document> documentsToUpload) throws IndexerException {
     if (documentsToUpload.isEmpty()) {
       return Set.of();
     }
@@ -355,7 +356,16 @@ public class OpenSearchIndexer extends Indexer {
 
     Set<Pair<Document, String>> failedDocs = new HashSet<>();
 
-    BulkResponse response = client.bulk(br.build());
+    BulkResponse response;
+    try {
+      response = client.bulk(br.build());
+    } catch (org.opensearch.client.opensearch._types.OpenSearchException e) {
+      // HTTP-level error with a known status code — wrap so the base Indexer can apply retry policy
+      throw new IndexerRetryableException(e.status(), "OpenSearch returned HTTP " + e.status(), e);
+    } catch (IOException e) {
+      // Transport-level failure (connection refused, timeout, etc.) — no status code available
+      throw new IndexerRetryableException("Transport failure communicating with OpenSearch", e);
+    }
 
     if (response != null) {
       for (BulkResponseItem item : response.items()) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/indexer/SolrIndexer.java
@@ -146,7 +146,7 @@ public class SolrIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
+  protected Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws Exception {
     if (bypass) {
       log.debug("sendToSolr bypassed for documents: " + documents);
       return Set.of();
@@ -216,7 +216,7 @@ public class SolrIndexer extends Indexer {
       }
     }
 
-    Set<Pair<Document, String>> failedDocs = new HashSet<>();
+    Set<Pair<Document, Exception>> failedDocs = new HashSet<>();
 
     for (String collection : solrDocRequestsByCollection.keySet()) {
       List<SolrInputDocument> collectionDocs = solrDocRequestsByCollection.get(collection).getAddUpdateDocs();
@@ -229,7 +229,7 @@ public class SolrIndexer extends Indexer {
           String docId = d.getFieldValue(Document.ID_FIELD).toString();
 
           if (docsUploaded.containsKey(docId)) {
-            failedDocs.add(Pair.of(docsUploaded.get(docId), e.getMessage()));
+            failedDocs.add(Pair.of(docsUploaded.get(docId), e));
           } else {
             throw e;
           }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/ElasticsearchIndexerTest.java
@@ -204,7 +204,7 @@ public class ElasticsearchIndexerTest {
     doc3.setField("other_id", "something_else");
 
     ElasticsearchIndexer indexer = new ElasticsearchIndexer(config, messenger, "testing", mockClient2);
-    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
+    Set<Pair<Document, Exception>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
     assertEquals(2, failedDocs.size());
     assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc)));
     assertFalse(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc2)));
@@ -850,7 +850,7 @@ public class ElasticsearchIndexerTest {
     }
 
     @Override
-    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, Exception>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -233,7 +233,7 @@ public class OpenSearchIndexerTest {
     doc3.setField("other_id", "something_else");
 
     OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", mockClient2);
-    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
+    Set<Pair<Document, Exception>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
     assertEquals(2, failedDocs.size());
     assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc)));
     assertFalse(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc2)));
@@ -1265,6 +1265,160 @@ public class OpenSearchIndexerTest {
     assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
   }
 
+  /**
+   * Tests that the indexer retries when the bulk call returns without throwing but the response
+   * contains an item-level error with a retryable status code (429). On the second attempt the
+   * response is clean, so the document should receive a FINISH event and bulk() should be called
+   * twice.
+   */
+  @Test
+  public void testRetryOnRetryableItemLevelError() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    // First response: item carries a 429 error — should trigger a retry
+    BulkResponseItem errorItem = Mockito.mock(BulkResponseItem.class);
+    ErrorCause errorCause = new ErrorCause.Builder()
+        .reason("too many requests").type("es_rejected_execution_exception").build();
+    Mockito.when(errorItem.error()).thenReturn(errorCause);
+    Mockito.when(errorItem.status()).thenReturn(429);
+    Mockito.when(errorItem.id()).thenReturn("doc1");
+
+    BulkResponse errorResponse = Mockito.mock(BulkResponse.class);
+    Mockito.when(errorResponse.items()).thenReturn(List.of(errorItem));
+
+    // Second response: clean, no errors
+    BulkResponseItem successItem = Mockito.mock(BulkResponseItem.class);
+    Mockito.when(successItem.error()).thenReturn(null);
+    Mockito.when(successItem.id()).thenReturn("doc1");
+
+    BulkResponse successResponse = Mockito.mock(BulkResponse.class);
+    Mockito.when(successResponse.items()).thenReturn(List.of(successItem));
+
+    Mockito.when(retryClient.bulk(any(BulkRequest.class)))
+        .thenReturn(errorResponse)
+        .thenReturn(successResponse);
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    indexer.run(1);
+
+    // bulk() should be called twice: first returns a 429 item error, second succeeds
+    verify(retryClient, times(2)).bulk(any(BulkRequest.class));
+
+    // Document should have received a FINISH event after the successful retry
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(1, events.size());
+    assertEquals(Event.Type.FINISH, events.get(0).getType());
+  }
+
+  /**
+   * Tests that no retry is attempted when the bulk call returns without throwing but the response
+   * contains an item-level error with a non-retryable status code (400). bulk() should be called
+   * exactly once and the document should receive a FAIL event carrying the item-level error reason.
+   */
+  @Test
+  public void testNoRetryForNonRetryableItemLevelError() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    // Response: item has a 400 error (e.g. mapping conflict) — not in the retryable list
+    BulkResponseItem errorItem = Mockito.mock(BulkResponseItem.class);
+    ErrorCause errorCause = new ErrorCause.Builder()
+        .reason("mapper parsing exception").type("mapper_parsing_exception").build();
+    Mockito.when(errorItem.error()).thenReturn(errorCause);
+    Mockito.when(errorItem.status()).thenReturn(400);
+    Mockito.when(errorItem.id()).thenReturn("doc1");
+
+    BulkResponse errorResponse = Mockito.mock(BulkResponse.class);
+    Mockito.when(errorResponse.items()).thenReturn(List.of(errorItem));
+
+    Mockito.when(retryClient.bulk(any(BulkRequest.class))).thenReturn(errorResponse);
+
+    TestMessenger messenger = new TestMessenger();
+    // maxRetries: 3, retryableStatusCodes: [429] — 400 is not in the list
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retryWith429Only.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    indexer.run(1);
+
+    // bulk() should be called exactly once — 400 is not retryable
+    verify(retryClient, times(1)).bulk(any(BulkRequest.class));
+
+    // Document should receive a FAIL event containing the item-level error reason
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(1, events.size());
+    assertEquals(Event.Type.FAIL, events.get(0).getType());
+    assertTrue(events.get(0).getMessage().contains("mapper parsing exception"));
+  }
+
+  /**
+   * Tests that when retries are exhausted due to persistent item-level retryable errors,
+   * each document receives a per-document FAIL event with the specific item-level reason
+   * rather than a generic batch-level message.
+   * With maxRetries=3, bulk() should be called 4 times (1 initial + 3 retries), and every
+   * document should receive a FAIL event containing the item-level error reason.
+   */
+  @Test
+  public void testRetryExhaustedItemLevelErrorsProducePerDocFail() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    // Every response: both items carry a 429 error — retries will be exhausted
+    BulkResponseItem errorItem1 = Mockito.mock(BulkResponseItem.class);
+    BulkResponseItem errorItem2 = Mockito.mock(BulkResponseItem.class);
+    ErrorCause errorCause = new ErrorCause.Builder()
+        .reason("too many requests").type("es_rejected_execution_exception").build();
+    Mockito.when(errorItem1.error()).thenReturn(errorCause);
+    Mockito.when(errorItem1.status()).thenReturn(429);
+    Mockito.when(errorItem1.id()).thenReturn("doc1");
+    Mockito.when(errorItem2.error()).thenReturn(errorCause);
+    Mockito.when(errorItem2.status()).thenReturn(429);
+    Mockito.when(errorItem2.id()).thenReturn("doc2");
+
+    BulkResponse errorResponse = Mockito.mock(BulkResponse.class);
+    Mockito.when(errorResponse.items()).thenReturn(List.of(errorItem1, errorItem2));
+
+    Mockito.when(retryClient.bulk(any(BulkRequest.class))).thenReturn(errorResponse);
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    indexer.run(2);
+
+    // bulk() should be called 4 times: 1 initial + 3 retries
+    verify(retryClient, times(4)).bulk(any(BulkRequest.class));
+
+    // Each document should receive a per-document FAIL event with the item-level reason
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(2, events.size());
+    assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
+    assertTrue(events.stream().allMatch(e -> e.getMessage().contains("too many requests")));
+  }
+
   @Test
   public void testRetryAgainstLiveServer() throws Exception {
     AtomicInteger requestCount = new AtomicInteger(0);
@@ -1472,7 +1626,7 @@ public class OpenSearchIndexerTest {
     }
 
     @Override
-    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, Exception>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }
@@ -1492,7 +1646,7 @@ public class OpenSearchIndexerTest {
     }
 
     @Override
-    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, Exception>> sendToIndex(List<Document> docs) throws Exception {
       throw new IndexerRetryableException(
           503, "Simulated 503 Service Unavailable", new IOException("backend unavailable"));
     }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1146,6 +1146,88 @@ public class OpenSearchIndexerTest {
     indexer.closeConnection();
   }
 
+  /**
+   * Tests that the indexer retries a failed batch and succeeds on a subsequent attempt.
+   * The mock client throws on the first bulk call and succeeds on the second.
+   * With maxRetries=3 and retryWaitDurationMs=0, the indexer should retry and ultimately
+   * send FINISH events for all documents.
+   */
+  @Test
+  public void testRetrySucceedsOnSecondAttempt() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    BulkResponse successResponse = Mockito.mock(BulkResponse.class);
+    Mockito.when(successResponse.errors()).thenReturn(false);
+    Mockito.when(successResponse.items()).thenReturn(new ArrayList<>());
+
+    // Throw on the first call, succeed on the second
+    Mockito.when(retryClient.bulk(any(BulkRequest.class)))
+        .thenThrow(new IOException("Simulated transient failure"))
+        .thenReturn(successResponse);
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    indexer.run(2);
+
+    // bulk() should have been called twice: once failing, once succeeding
+    verify(retryClient, times(2)).bulk(any(BulkRequest.class));
+
+    // Both documents should have received FINISH events
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(2, events.size());
+    assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FINISH));
+  }
+
+  /**
+   * Tests that the indexer exhausts all retries when every attempt fails, and that all
+   * documents in the batch receive FAIL events after the final attempt.
+   * With maxRetries=3, bulk() should be called 4 times total (1 initial + 3 retries).
+   */
+  @Test
+  public void testRetryExhaustedAllDocumentsFail() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    // Always throw — every attempt fails
+    Mockito.when(retryClient.bulk(any(BulkRequest.class)))
+        .thenThrow(new IOException("Persistent failure"));
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+    Document doc3 = Document.create("doc3", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    messenger.sendForIndexing(doc3);
+    indexer.run(3);
+
+    // bulk() should have been called 4 times: 1 initial + 3 retries
+    verify(retryClient, times(4)).bulk(any(BulkRequest.class));
+
+    // All documents should have received FAIL events
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(3, events.size());
+    assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
+  }
+
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 
     public static final Spec SPEC = OpenSearchIndexer.SPEC;

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -10,12 +10,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kmwllc.lucille.core.IndexerRetryableException;
+import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
@@ -1228,6 +1234,85 @@ public class OpenSearchIndexerTest {
     assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
   }
 
+  /**
+   * Tests that no retry is attempted when the server returns an HTTP status code that is not
+   * in the configured retryableStatusCodes list.
+   *
+   * The indexer is configured with retryableStatusCodes: [429] and maxRetries: 3.
+   * The mock throws an IndexerRetryableException with status 503 (not in the list).
+   * bulk() should be called exactly once — no retries — and all documents should receive FAIL events.
+   */
+  @Test
+  public void testNoRetryForNonRetryableStatusCode() throws Exception {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retryWith429Only.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+    Document doc2 = Document.create("doc2", "test_run");
+
+    // Use a subclass that throws IndexerRetryableException with status 503 (not in retryableStatusCodes)
+    OpenSearchIndexer indexer = new Status503OpenSearchIndexer(config, messenger, mockClient, "testing");
+    messenger.sendForIndexing(doc1);
+    messenger.sendForIndexing(doc2);
+    indexer.run(2);
+
+    // bulk() on the mock client should never be called — the subclass overrides sendToIndex entirely
+    verify(mockClient, times(0)).bulk(any(BulkRequest.class));
+
+    // All documents should have received FAIL events with no retries
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(2, events.size());
+    assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
+  }
+
+  @Test
+  public void testRetryAgainstLiveServer() throws Exception {
+    AtomicInteger requestCount = new AtomicInteger(0);
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+
+    // Minimal valid OpenSearch bulk API response for a single successful index operation
+    String bulkSuccessBody = "{\"took\":1,\"errors\":false,\"items\":"
+        + "[{\"index\":{\"_index\":\"lucille-default\",\"_id\":\"doc1\","
+        + "\"result\":\"created\",\"status\":201}}]}";
+    byte[] bulkSuccessBytes = bulkSuccessBody.getBytes(StandardCharsets.UTF_8);
+
+    server.createContext("/", exchange -> {
+      int count = requestCount.incrementAndGet();
+      if (count == 1) {
+        // First request: return 429 to trigger a retry
+        exchange.sendResponseHeaders(429, -1);
+        exchange.close();
+      } else {
+        // Second request: return a valid bulk success response
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bulkSuccessBytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+          os.write(bulkSuccessBytes);
+        }
+        exchange.close();
+      }
+    });
+    server.start();
+
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf").
+        withValue("opensearch.url", ConfigValueFactory.fromAnyRef("http://localhost:" + server.getAddress().getPort()));
+    TestMessenger messenger = new TestMessenger();
+    Document doc = Document.create("doc1");
+
+    try {
+      OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, false, "testing", "run1");
+      messenger.sendForIndexing(doc);
+      indexer.run(1);
+    } finally {
+      server.stop(0);
+    }
+    assertEquals(1, messenger.getDocsSentForIndexing().size()); // only 1 doc was sent for indexing
+    assertEquals(2, requestCount.get()); // server should have received 2 requests: initial request and retry
+    assertEquals(1, messenger.getSentEvents().size()); // only 1 accounting event should have been sent
+    assertEquals(Event.Type.FINISH, messenger.getSentEvents().get(0).getType()); // document should have succeeded
+  }
+
+
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 
     public static final Spec SPEC = OpenSearchIndexer.SPEC;
@@ -1240,6 +1325,27 @@ public class OpenSearchIndexerTest {
     @Override
     public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
+    }
+  }
+
+  /**
+   * An OpenSearchIndexer subclass that always throws an {@link IndexerRetryableException}
+   * with HTTP status 503, used to verify that status codes not in the configured
+   * retryableStatusCodes list do not trigger a retry.
+   */
+  public static class Status503OpenSearchIndexer extends OpenSearchIndexer {
+
+    public static final Spec SPEC = OpenSearchIndexer.SPEC;
+
+    public Status503OpenSearchIndexer(Config config, IndexerMessenger messenger,
+        OpenSearchClient client, String metricsPrefix) {
+      super(config, messenger, metricsPrefix, client);
+    }
+
+    @Override
+    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
+      throw new IndexerRetryableException(
+          503, "Simulated 503 Service Unavailable", new IOException("backend unavailable"));
     }
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1381,15 +1381,17 @@ public class OpenSearchIndexerTest {
     Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
     Mockito.when(mockBooleanResponse.value()).thenReturn(true);
 
-    // Every response: both items carry a 429 error — retries will be exhausted
+    // Every response: both items carry a 429 error with distinct reasons — retries will be exhausted
     BulkResponseItem errorItem1 = Mockito.mock(BulkResponseItem.class);
     BulkResponseItem errorItem2 = Mockito.mock(BulkResponseItem.class);
-    ErrorCause errorCause = new ErrorCause.Builder()
-        .reason("too many requests").type("es_rejected_execution_exception").build();
-    Mockito.when(errorItem1.error()).thenReturn(errorCause);
+    ErrorCause errorCause1 = new ErrorCause.Builder()
+        .reason("too many requests on shard 1").type("es_rejected_execution_exception").build();
+    ErrorCause errorCause2 = new ErrorCause.Builder()
+        .reason("too many requests on shard 2").type("es_rejected_execution_exception").build();
+    Mockito.when(errorItem1.error()).thenReturn(errorCause1);
     Mockito.when(errorItem1.status()).thenReturn(429);
     Mockito.when(errorItem1.id()).thenReturn("doc1");
-    Mockito.when(errorItem2.error()).thenReturn(errorCause);
+    Mockito.when(errorItem2.error()).thenReturn(errorCause2);
     Mockito.when(errorItem2.status()).thenReturn(429);
     Mockito.when(errorItem2.id()).thenReturn("doc2");
 
@@ -1412,11 +1414,15 @@ public class OpenSearchIndexerTest {
     // bulk() should be called 4 times: 1 initial + 3 retries
     verify(retryClient, times(4)).bulk(any(BulkRequest.class));
 
-    // Each document should receive a per-document FAIL event with the item-level reason
+    // Each document should receive a per-document FAIL event with its specific item-level reason
     List<Event> events = messenger.getSentEvents();
     assertEquals(2, events.size());
     assertTrue(events.stream().allMatch(e -> e.getType() == Event.Type.FAIL));
-    assertTrue(events.stream().allMatch(e -> e.getMessage().contains("too many requests")));
+
+    Event doc1Event = events.stream().filter(e -> "doc1".equals(e.getDocumentId())).findFirst().orElseThrow();
+    Event doc2Event = events.stream().filter(e -> "doc2".equals(e.getDocumentId())).findFirst().orElseThrow();
+    assertTrue(doc1Event.getMessage().contains("too many requests on shard 1"));
+    assertTrue(doc2Event.getMessage().contains("too many requests on shard 2"));
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1155,7 +1155,7 @@ public class OpenSearchIndexerTest {
   /**
    * Tests that the indexer retries a failed batch and succeeds on a subsequent attempt.
    * The mock client throws on the first bulk call and succeeds on the second.
-   * With maxRetries=3 and retryWaitDurationMs=0, the indexer should retry and ultimately
+   * With maxRetries=3 and retryWaitDurationMs=1, the indexer should retry and ultimately
    * send FINISH events for all documents.
    */
   @Test
@@ -1312,6 +1312,93 @@ public class OpenSearchIndexerTest {
     assertEquals(Event.Type.FINISH, messenger.getSentEvents().get(0).getType()); // document should have succeeded
   }
 
+  /**
+   * Tests that unknown-status-code failures (e.g. network timeouts) are NOT retried when the user
+   * explicitly specifies retryableStatusCodes without including -1.
+   * Config uses retryableStatusCodes: [429] — no -1, so IOException-based failures should not retry.
+   */
+  @Test
+  public void testNoRetryForUnknownStatusCodeWhenNotInList() throws Exception {
+    OpenSearchClient retryClient = Mockito.mock(OpenSearchClient.class);
+
+    BooleanResponse mockBooleanResponse = Mockito.mock(BooleanResponse.class);
+    Mockito.when(retryClient.ping()).thenReturn(mockBooleanResponse);
+    Mockito.when(mockBooleanResponse.value()).thenReturn(true);
+
+    // IOException becomes IndexerRetryableException with UNKNOWN_STATUS_CODE
+    Mockito.when(retryClient.bulk(any(BulkRequest.class)))
+        .thenThrow(new IOException("Connection refused"));
+
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retryWith429Only.conf");
+
+    Document doc1 = Document.create("doc1", "test_run");
+
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", retryClient);
+    messenger.sendForIndexing(doc1);
+    indexer.run(1);
+
+    // bulk() should have been called only once — no retries for unknown status code
+    verify(retryClient, times(1)).bulk(any(BulkRequest.class));
+
+    // Document should have received a FAIL event
+    List<Event> events = messenger.getSentEvents();
+    assertEquals(1, events.size());
+    assertEquals(Event.Type.FAIL, events.get(0).getType());
+  }
+
+  /**
+   * Tests that an empty retryableStatusCodes list is rejected as invalid configuration.
+   */
+  @Test
+  public void testEmptyRetryableStatusCodesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf")
+        .withValue("indexer.retryableStatusCodes", ConfigValueFactory.fromIterable(List.of()));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that maxRetries of 0 is rejected as invalid.
+   */
+  @Test
+  public void testMaxRetriesZeroRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/retry.conf")
+        .withValue("indexer.maxRetries", ConfigValueFactory.fromAnyRef(0));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that retryWaitDurationMs without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryWaitDurationWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryWaitDurationMs", ConfigValueFactory.fromAnyRef(500));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that retryableStatusCodes without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryableStatusCodesWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryableStatusCodes", ConfigValueFactory.fromIterable(List.of(429)));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
 
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 
@@ -1349,3 +1436,4 @@ public class OpenSearchIndexerTest {
     }
   }
 }
+

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/OpenSearchIndexerTest.java
@@ -1399,6 +1399,68 @@ public class OpenSearchIndexerTest {
         new OpenSearchIndexer(config, messenger, "testing", mockClient));
   }
 
+  /**
+   * Tests that retryMaxWaitDurationMs without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryMaxWaitDurationWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryMaxWaitDurationMs", ConfigValueFactory.fromAnyRef(5000));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that retryRandomizationFactor without maxRetries is rejected.
+   */
+  @Test
+  public void testRetryRandomizationFactorWithoutMaxRetriesRejected() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.retryRandomizationFactor", ConfigValueFactory.fromAnyRef(0.3));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        new OpenSearchIndexer(config, messenger, "testing", mockClient));
+  }
+
+  /**
+   * Tests that the indexer accepts a retry configuration with all parameters set to their defaults.
+   */
+  @Test
+  public void testRetryConfigWithAllParametersAccepted() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.maxRetries", ConfigValueFactory.fromAnyRef(3))
+        .withValue("indexer.retryWaitDurationMs", ConfigValueFactory.fromAnyRef(1000))
+        .withValue("indexer.retryMaxWaitDurationMs", ConfigValueFactory.fromAnyRef(30000))
+        .withValue("indexer.retryRandomizationFactor", ConfigValueFactory.fromAnyRef(0.5))
+        .withValue("indexer.retryableStatusCodes", ConfigValueFactory.fromIterable(List.of(429, 503)));
+
+    // Should not throw — all parameters are valid
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", mockClient);
+    assertTrue(indexer.validateConnection());
+  }
+
+  /**
+   * Tests that the indexer accepts a retry configuration with non-default custom values
+   * for max wait duration and randomization factor.
+   */
+  @Test
+  public void testRetryConfigWithCustomMaxWaitAndRandomization() {
+    TestMessenger messenger = new TestMessenger();
+    Config config = ConfigFactory.load("OpenSearchIndexerTest/config.conf")
+        .withValue("indexer.maxRetries", ConfigValueFactory.fromAnyRef(5))
+        .withValue("indexer.retryWaitDurationMs", ConfigValueFactory.fromAnyRef(500))
+        .withValue("indexer.retryMaxWaitDurationMs", ConfigValueFactory.fromAnyRef(10000))
+        .withValue("indexer.retryRandomizationFactor", ConfigValueFactory.fromAnyRef(0.0));
+
+    // Should not throw — custom values are valid
+    OpenSearchIndexer indexer = new OpenSearchIndexer(config, messenger, "testing", mockClient);
+    assertTrue(indexer.validateConnection());
+  }
+
 
   public static class ErroringOpenSearchIndexer extends OpenSearchIndexer {
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/indexer/SolrIndexerTest.java
@@ -751,7 +751,7 @@ public class SolrIndexerTest {
 
     SolrIndexer indexer = new SolrIndexer(config, messenger, "", solrClient);
 
-    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
+    Set<Pair<Document, Exception>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3));
     assertEquals(2, failedDocs.size());
     assertTrue(failedDocs.stream().anyMatch(p -> p.getLeft().equals(doc)));
 
@@ -1037,7 +1037,7 @@ public class SolrIndexerTest {
     }
 
     @Override
-    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, Exception>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to Solr are correctly handled");
     }
   }

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/retry.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/retry.conf
@@ -1,0 +1,14 @@
+indexer {
+  type: "OpenSearch"
+  batchSize: 5
+  batchTimeout: 1000
+  logRate: 1000
+  sendEnabled: false
+  maxRetries: 3
+  retryWaitDurationMs: 1
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+}

--- a/lucille-core/src/test/resources/OpenSearchIndexerTest/retryWith429Only.conf
+++ b/lucille-core/src/test/resources/OpenSearchIndexerTest/retryWith429Only.conf
@@ -1,0 +1,15 @@
+indexer {
+  type: "OpenSearch"
+  batchSize: 5
+  batchTimeout: 1000
+  logRate: 1000
+  sendEnabled: false
+  maxRetries: 3
+  retryWaitDurationMs: 1
+  retryableStatusCodes: [429]
+}
+
+opensearch {
+  url: "http://localhost:9200"
+  index: "lucille-default"
+}

--- a/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
+++ b/lucille-plugins/lucille-pinecone/src/main/java/com/kmwllc/lucille/pinecone/indexer/PineconeIndexer.java
@@ -116,7 +116,7 @@ public class PineconeIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws IndexerException {
+  protected Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws IndexerException {
     // retrieve documents to delete & upload, mapping id to document
     Map<String, Document> deleteMap = new LinkedHashMap<>();
     Map<String, Document> uploadMap = new LinkedHashMap<>();

--- a/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
+++ b/lucille-plugins/lucille-weaviate/src/main/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexer.java
@@ -119,8 +119,8 @@ public class WeaviateIndexer extends Indexer {
   }
 
   @Override
-  protected Set<Pair<Document, String>> sendToIndex(List<Document> documents) throws Exception {
-    Set<Pair<Document, String>> failedDocs = new HashSet<>();
+  protected Set<Pair<Document, Exception>> sendToIndex(List<Document> documents) throws Exception {
+    Set<Pair<Document, Exception>> failedDocs = new HashSet<>();
 
     try (ObjectsBatcher batcher = client.batch().objectsBatcher()) {
       Map<String, Document> docGeneratedUUIDMap = new HashMap<>();
@@ -167,7 +167,7 @@ public class WeaviateIndexer extends Indexer {
 
         if (errorResponse != null) {
           Document docWithResponseUUID = docGeneratedUUIDMap.get(response.getId());
-          failedDocs.add(Pair.of(docWithResponseUUID, errorResponse.toString()));
+          failedDocs.add(Pair.of(docWithResponseUUID, new IndexerException(errorResponse.toString())));
         }
       }
     } catch (Exception e) {

--- a/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
+++ b/lucille-plugins/lucille-weaviate/src/test/java/com/kmwllc/lucille/weaviate/indexer/WeaviateIndexerTest.java
@@ -205,7 +205,7 @@ public class WeaviateIndexerTest {
     Document failedDoc2 = Document.create("failedDoc2", "test_run");
 
     WeaviateIndexer indexer = new WeaviateIndexer(config, messenger, mockClient, "testing");
-    Set<Pair<Document, String>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3, failedDoc1, failedDoc2));
+    Set<Pair<Document, Exception>> failedDocs = indexer.sendToIndex(List.of(doc, doc2, doc3, failedDoc1, failedDoc2));
 
     assertEquals(2, failedDocs.size());
 
@@ -271,7 +271,7 @@ public class WeaviateIndexerTest {
     }
 
     @Override
-    public Set<Pair<Document, String>> sendToIndex(List<Document> docs) throws Exception {
+    public Set<Pair<Document, Exception>> sendToIndex(List<Document> docs) throws Exception {
       throw new Exception("Test that errors when sending to indexer are correctly handled");
     }
   }


### PR DESCRIPTION
this PR builds on the changes in https://github.com/kmwtechnology/lucille/pull/468

- Indexer base class now wraps the abstract sendToIndex call in a retry handler implemented via a new dependency, resilience4j
- Indexer accepts new optional params maxRetries, retryWaitDurationMs, retryableStatusCodes; default behavior when these params are not set is no retries
- For a retry to occur, the Indexer subclass must throw IndexerRetryableException from sendToIndex() and the exception must contain one of the status codes configured as retryable
- OpenSearchIndexer is updated in this PR to throw IndexerRetryableException where appropriate; ElasticsearchIndexer and SolrIndexer have NOT been updated and this work should be tracked in separate tickets
- Test coverage includes testRetryAgainstLiveServer() which starts an embedded HttpServer, important for validating that retry logic is actually working, since mocking can give a false sense of security in this context

What's new here:

there is additional logic to support retries in the case where search API doesn't throw an exception but returns a response containing some per-document errors that are retryable

if we send a batch of documents to the search backend and get a response containing per-document statuses, we want to retry the batch if at least one of the per-document statuses is retryable

to implement this, we might want the sendToIndex implementation to inspect the client response and throw IndexerRetryableException in this case

the problem is that if IndexerRetryableException is always thrown from sendToIndex when there's a per-doc retryable error, then sendToIndex can never return the Set<Pair<Document, String>> that allows Indexer to log detailed error information for each document, so we lose that info and it never gets logged

here, we change the return value of sendToIndex from  Set<Pair<Document, String>>  to Set<Pair<Document, Exception>> and we now expect sendToIndex to place a IndexerRetryableExceptions in this return value, paired with the documents that had possibly-retryable errors, if the search client returnd a response containing an item-level error

Indexer now looks for IndexerRetryableExceptions inside the return value of sendToIndex and initiates retry if at least one is present

when retries are exhausted without success, if we have captured a return value from the most recent call to sendToIndex, we iterate through the return value and log detailed error information for each doc that failed
