### PR TITLE
Create missing troubleshooting file

### DIFF
--- a/doc/site/content/en/docs/prod/troubleshooting.md
+++ b/doc/site/content/en/docs/prod/troubleshooting.md
@@ -1,0 +1,1 @@
+# This page no longer exists.


### PR DESCRIPTION
The getting started file in the docs from our old releases links to a troubleshooting.md file, which gets removed in LC-867's doc site updates. This is a temporary fix to add that file back in, which will prevent the site from breaking on deployment.