### PR TITLE
LC-851: doc site search returns correct versions

### DIFF
--- a/.github/scripts/versionsworkflow.sh
+++ b/.github/scripts/versionsworkflow.sh
@@ -78,7 +78,6 @@ linkTitle: Docs-pre-release
 weight: 20
 cascade:
   type: docs
-  exclude_search: true
 ---
 EOF
 # Append everything after the metadata from the working branches top level docs _index.md so the pre-release landing
@@ -117,7 +116,6 @@ linkTitle: Docs-$tag
 weight: 20
 cascade:
   type: docs
-  exclude_search: true
 ---
 EOF
   fi

--- a/doc/site/assets/json/offline-search-index.json
+++ b/doc/site/assets/json/offline-search-index.json
@@ -1,0 +1,18 @@
+{{- $.Scratch.Add "offline-search-index" slice -}}
+{{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
+{{- /* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */ -}}
+{{- /* Individual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */ -}}
+{{- $.Scratch.Add
+    "offline-search-index"
+    (dict
+        "ref" .RelPermalink
+        "title" .Title
+        "categories" (.Params.categories | default "")
+        "tags" (.Params.tags | default "")
+        "description" (.Description | default "")
+        "body" (.Plain | htmlUnescape)
+        "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)
+    )
+-}}
+{{- end -}}
+{{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/doc/site/assets/json/offline-search-index.json
+++ b/doc/site/assets/json/offline-search-index.json
@@ -1,5 +1,7 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
+{{- $section := .Section -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
+{{- if eq .Section $section -}}
 {{- /* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */ -}}
 {{- /* Individual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */ -}}
 {{- $.Scratch.Add
@@ -14,5 +16,6 @@
         "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)
     )
 -}}
+{{- end -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/doc/site/layouts/partials/search-input.html
+++ b/doc/site/layouts/partials/search-input.html
@@ -25,37 +25,58 @@
 {{ if .Site.Params.offlineSearch -}}
 {{ .Scratch.Add "docsy-search" 1 -}}
 
-{{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . -}}
-{{ if hugo.IsProduction -}}
-{{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */ -}}
-{{ $offlineSearchIndex = $offlineSearchIndex | fingerprint "md5" -}}
-{{ end -}}
-{{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
+{{- /*
+Each docs section (docs, docs-pre-release, docs-<tag>) gets its own offline
+  search index so results are scoped to the version the user is viewing. Pages
+  outside any docs section (homepage, taxonomies) fall back to the "docs"
+  (latest) index.
+  */ -}}
+  {{ $currentSection := .Section -}}
+  {{ if or (not $currentSection) (not (or (eq $currentSection "docs") (hasPrefix $currentSection "docs-"))) -}}
+  {{ $currentSection = "docs" -}}
+  {{ end -}}
 
-<div class="td-search td-search--offline">
-  <div class="td-search__icon"></div>
-  <input
-      type="search"
-      class="td-search__input form-control"
-      placeholder="{{ T "ui_search" }}"
-  aria-label="{{ T "ui_search" }}"
-  autocomplete="off"
-  {{/*
-  The data attribute name of the json file URL must end with `src` since
-  Hugo's absurlreplacer requires `src`, `href`, `action` or `srcset` suffix for the attribute name.
-  If the absurlreplacer is not applied, the URL will start with `/`.
-  It causes the json file loading error when when relativeURLs is enabled.
-  https://github.com/google/docsy/issues/181
-  */}}
-  data-offline-search-index-json-src="{{ $offlineSearchLink }}"
-  data-offline-search-base-href="/"
-  data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
-  >
-</div>
+  {{ $offlineSearchLink := "" -}}
+  {{ range .Site.Sections -}}
+  {{ if or (eq .Section "docs") (hasPrefix .Section "docs-") -}}
+  {{ $name := printf "offline-search-index-%s.json" .Section -}}
+  {{ $idx := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate $name . -}}
+  {{ if hugo.IsProduction -}}
+  {{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */ -}}
+  {{ $idx = $idx | fingerprint "md5" -}}
+  {{ end -}}
+  {{ $link := $idx.RelPermalink -}}
+  {{ if eq .Section $currentSection -}}
+  {{ $offlineSearchLink = $link -}}
+  {{ end -}}
+  {{ end -}}
+  {{ end -}}
 
-{{- end -}}
+  <div class="td-search td-search--offline">
+    <div class="td-search__icon"></div>
+    <input
+        type="search"
+        class="td-search__input form-control"
+        placeholder="{{ T "ui_search" }}"
+    aria-label="{{ T "ui_search" }}"
+    autocomplete="off"
+    {{/*
+    The data attribute name of the json file URL must end with `src` since
+    Hugo's absurlreplacer requires `src`, `href`, `action` or `srcset` suffix for the attribute name.
+    If the absurlreplacer is not applied, the URL will start with `/`.
+    It causes the json file loading error when when relativeURLs is enabled.
+    https://github.com/google/docsy/issues/181
+    */}}
+    data-offline-search-index-json-src="{{ $offlineSearchLink }}"
+    data-offline-search-base-href="/"
+    data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
+    >
+  </div>
 
-{{ if gt (.Scratch.Get "docsy-search") 1 -}}
-{{ warnf `You have more than one site-search option configured: choose only one.
-For details, see https://www.docsy.dev/docs/content/search.` -}}
-{{ end -}}
+  {{- end -}}
+
+  {{ if gt (.Scratch.Get "docsy-search") 1 -}}
+  {{ warnf `You have more than one site-search option configured: choose only one.
+  For details, see https://www.docsy.dev/docs/content/search.` -}}
+  {{ end -}}
+

--- a/doc/site/layouts/partials/search-input.html
+++ b/doc/site/layouts/partials/search-input.html
@@ -1,0 +1,61 @@
+{{ .Scratch.Set "docsy-search" 0 -}}
+
+{{ if .Site.Params.gcs_engine_id -}}
+{{ .Scratch.Add "docsy-search" 1 -}}
+
+<div class="td-search">
+  <div class="td-search__icon"></div>
+  <input type="search" class="td-search__input form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+</div>
+
+{{- end -}}
+
+
+{{ if and .Site.Params.search (isset .Site.Params.search "algolia") -}}
+{{ .Scratch.Add "docsy-search" 1 -}}
+{{ .Scratch.Add "docsearch-id-num" 1 -}}
+
+<div class="td-search">
+  <div class="td-search--algolia" id="docsearch-{{ mod (.Scratch.Get "docsearch-id-num") 2 }}"></div>
+</div>
+
+{{- end -}}
+
+
+{{ if .Site.Params.offlineSearch -}}
+{{ .Scratch.Add "docsy-search" 1 -}}
+
+{{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . -}}
+{{ if hugo.IsProduction -}}
+{{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */ -}}
+{{ $offlineSearchIndex = $offlineSearchIndex | fingerprint "md5" -}}
+{{ end -}}
+{{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
+
+<div class="td-search td-search--offline">
+  <div class="td-search__icon"></div>
+  <input
+      type="search"
+      class="td-search__input form-control"
+      placeholder="{{ T "ui_search" }}"
+  aria-label="{{ T "ui_search" }}"
+  autocomplete="off"
+  {{/*
+  The data attribute name of the json file URL must end with `src` since
+  Hugo's absurlreplacer requires `src`, `href`, `action` or `srcset` suffix for the attribute name.
+  If the absurlreplacer is not applied, the URL will start with `/`.
+  It causes the json file loading error when when relativeURLs is enabled.
+  https://github.com/google/docsy/issues/181
+  */}}
+  data-offline-search-index-json-src="{{ $offlineSearchLink }}"
+  data-offline-search-base-href="/"
+  data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
+  >
+</div>
+
+{{- end -}}
+
+{{ if gt (.Scratch.Get "docsy-search") 1 -}}
+{{ warnf `You have more than one site-search option configured: choose only one.
+For details, see https://www.docsy.dev/docs/content/search.` -}}
+{{ end -}}


### PR DESCRIPTION
We would like the search feature on the doc site to get back pages from the current version of the site that is selected. This required
- Removing exclude-search: true from the _index.md of each version
- Override offline-search-index.json so that it only emits pages where the .Section matches that of the version you are in
- Override search-input.html so that it builds one index JSON for each version of the docs.