### PR TITLE
LC-873: Transient failure on TextExtractorTest.testTimeout

### DIFF
--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -413,7 +413,7 @@ public class TextExtractorTest {
     stage.processDocument(doc);
 
     // Give it a bit of time for the async task to be interrupted and set the flag
-    Thread.sleep(200);
+    Thread.sleep(400);
 
     // If timeout works, it should have returned within much less than 1000ms
     // and interrupted should be true (if we interrupt the thread)


### PR DESCRIPTION
We didn't sleep for long enough to reliably trigger the timeout 100% of the time, so this was causing occasional transient failures. Increased sleep duration from 200ms -> 400ms