### PR TITLE
LC-871: Cleanup for RunDetails Map

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
@@ -2,14 +2,13 @@ package com.kmwllc.lucille.core;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.typesafe.config.Config;
@@ -27,19 +26,21 @@ public class RunnerManager {
   // null in the event of no limit
   private final Integer MAX_HISTORY;
 
-  // RunID keyed maps, the first is for active runs, the second is for historical runs
-  // Ultimately the goal is to limit the size of the historical, active will be (theoretically) unbound.
-  // Importantly, we operate under the following contract:
+  // RunID keyed maps, the first is for active runs, the second is for historical runs.
+  // We do this to optionally allow for a limited number of historical runs to be stored.
+  // Regarding thread safety, the following should be noted:
   // - RunDetails are only "moved" to the historical details map AFTER the run "isDone"
   // - Therefore, all RunDetails in the historicalDetailsMap should have isDone == true
   // - RunDetails in the activeDetailsMap may (for a short time) have isDone == true, therefore,
   //   the presence of a runID in the activeDetailsMap alone is not enough to assert that a run is running/is not done.
   // - RunDetails may (briefly) be present in both maps.
   private final Map<String, RunDetails> activeDetailsMap = new ConcurrentHashMap<>();
-  private final Map<String, RunDetails> historicalDetailsMap = new ConcurrentHashMap<>();
-  private final Queue<String> historicalEntryOrder = new ConcurrentLinkedQueue<>();
 
-  private final Object historicalLock = new Object();
+  // protected modifications by historicalLock
+  private final Map<String, RunDetails> historicalDetailsMap =
+      new LinkedHashMap<>();
+
+  private final Object historicalModificationsLock = new Object();
 
   // An in memory map of configs which can be used to create new Lucille runs
   private final Map<String, Config> configMap = new ConcurrentHashMap<>();
@@ -54,8 +55,15 @@ public class RunnerManager {
   /**
    * Creates a RunnerManager with the provided limit on the number of historical <code>RunDetails</code> that are stored.
    * @param maxHistory The maximum number of RunDetails for historical, completed runs that will be stored.
+   *                   <code>null</code> stores all history, <code>0</code> stores no history.
+   * @throws IllegalArgumentException If maxHistory is negative.
    */
   public RunnerManager(Integer maxHistory) {
+    if (maxHistory != null && maxHistory < 0) {
+      throw new IllegalArgumentException("maxHistory, when specified, must be non-negative.");
+    }
+
+
     this.MAX_HISTORY = maxHistory;
   }
 
@@ -167,13 +175,12 @@ public class RunnerManager {
         log.error("Failed to run lucille with ID '{}' via the Runner Manager.", runId, e);
         runDetails.setThrowable(e);
       } finally {
-        synchronized (historicalLock) {
+        synchronized (historicalModificationsLock) {
           historicalDetailsMap.put(runId, runDetails);
-          historicalEntryOrder.add(runId);
 
-          while (MAX_HISTORY != null && historicalDetailsMap.size() > MAX_HISTORY) {
-            String oldestRunId = historicalEntryOrder.poll();
-            historicalDetailsMap.remove(oldestRunId);
+          if (MAX_HISTORY != null && historicalDetailsMap.size() > MAX_HISTORY) {
+            String runIdToRemove = historicalDetailsMap.keySet().iterator().next();
+            historicalDetailsMap.remove(runIdToRemove);
           }
         }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.core;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,8 +25,16 @@ public class RunnerManager {
   // Singleton instance
   private static final RunnerManager instance = new RunnerManager();
 
-  // A runID keyed map containing run details of current and historical Lucille runs
-  private final Map<String, RunDetails> runDetailsMap = new ConcurrentHashMap<>();
+  // RunID keyed maps, the first is for active runs, the second is for historical runs
+  // Ultimately the goal is to limit the size of the historical, active will be (theoretically) unbound.
+  // Importantly, we operate under the following contract:
+  // - RunDetails are only "moved" to the historical details map AFTER the run "isDone"
+  // - Therefore, all RunDetails in the historicalDetailsMap should have isDone == true
+  // - RunDetails in the activeDetailsMap may (for a short time) have isDone == true, therefore,
+  //   the presence of a runID in the activeDetailsMap alone is not enough to assert that a run is running/is not done.
+  // - RunDetails may (briefly) be present in both maps.
+  private final Map<String, RunDetails> activeDetailsMap = new ConcurrentHashMap<>();
+  private final Map<String, RunDetails> historicalDetailsMap = new ConcurrentHashMap<>();
 
   // An in memory map of configs which can be used to create new Lucille runs
   private final Map<String, Config> configMap = new ConcurrentHashMap<>();
@@ -43,7 +52,7 @@ public class RunnerManager {
    * @return true if the run exists and is not completed; false otherwise
    */
   public synchronized boolean isRunning(String runId) {
-    RunDetails details = runDetailsMap.get(runId);
+    RunDetails details = activeDetailsMap.get(runId);
     return details != null && !details.isDone();
   }
 
@@ -54,7 +63,8 @@ public class RunnerManager {
    * @throws Exception if the run throws an exception or is interrupted
    */
   public void waitForRunCompletion(String runId) throws Exception {
-    RunDetails details = runDetailsMap.get(runId);
+    RunDetails details = getRunDetails(runId);
+
     if (details != null) {
       details.getFuture().get();
     } else {
@@ -115,7 +125,7 @@ public class RunnerManager {
       throw new RunnerManagerException("runId cannot be null");
     }
     
-    if (runDetailsMap.containsKey(runId)) {
+    if (activeDetailsMap.containsKey(runId) || historicalDetailsMap.containsKey(runId)) {
       throw new RunnerManagerException("Run with runId " + runId + " already defined - cannot use this runId again");
     }
 
@@ -125,7 +135,7 @@ public class RunnerManager {
     }
     
     final RunDetails runDetails = new RunDetails(runId, configId);
-    runDetailsMap.put(runId, runDetails);
+    activeDetailsMap.put(runId, runDetails);
 
 
     runDetails.setFuture(CompletableFuture.runAsync(() -> {
@@ -143,6 +153,9 @@ public class RunnerManager {
       } catch (Exception e) {
         log.error("Failed to run lucille with ID '{}' via the Runner Manager.", runId, e);
         runDetails.setThrowable(e);
+      } finally {
+        historicalDetailsMap.put(runId, runDetails);
+        activeDetailsMap.remove(runId);
       }
     }));
 
@@ -156,7 +169,16 @@ public class RunnerManager {
    * @return the RunDetails object, or null if no such run exists
    */
   public RunDetails getRunDetails(String runId) {
-    return runDetailsMap.get(runId);
+    // As detailed above, the runDetails may briefly be in both maps.
+    // If it exists, it goes from active to historical. So, we check
+    // the runs in that order.
+    RunDetails activeDetails = activeDetailsMap.get(runId);
+
+    if (activeDetails == null) {
+      return historicalDetailsMap.get(runId);
+    } else {
+      return activeDetails;
+    }
   }
 
   /**
@@ -165,7 +187,11 @@ public class RunnerManager {
    * @return
    */
   public List<RunDetails> getRunDetails() {
-    return new ArrayList<>(runDetailsMap.values());
+    // We have potential duplicates - runs may be in both maps briefly -
+    // but we keep the same RunDetails instance, which the set can still consolidate.
+    Set<RunDetails> results = new HashSet<>(activeDetailsMap.values());
+    results.addAll(historicalDetailsMap.values());
+    return new ArrayList<>(results);
   }
 
   /**

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.typesafe.config.Config;
@@ -22,6 +24,9 @@ public class RunnerManager {
 
   private static final Logger log = LoggerFactory.getLogger(RunnerManager.class);
 
+  // null in the event of no limit
+  private final Integer MAX_HISTORY;
+
   // RunID keyed maps, the first is for active runs, the second is for historical runs
   // Ultimately the goal is to limit the size of the historical, active will be (theoretically) unbound.
   // Importantly, we operate under the following contract:
@@ -32,11 +37,27 @@ public class RunnerManager {
   // - RunDetails may (briefly) be present in both maps.
   private final Map<String, RunDetails> activeDetailsMap = new ConcurrentHashMap<>();
   private final Map<String, RunDetails> historicalDetailsMap = new ConcurrentHashMap<>();
+  private final Queue<String> historicalEntryOrder = new ConcurrentLinkedQueue<>();
+
+  private final Object historicalLock = new Object();
 
   // An in memory map of configs which can be used to create new Lucille runs
   private final Map<String, Config> configMap = new ConcurrentHashMap<>();
 
-  public RunnerManager() {}
+  /**
+   * Creates a RunnerManager with no limit on the number of historical <code>RunDetails</code> that are stored.
+   */
+  public RunnerManager() {
+    this.MAX_HISTORY = null;
+  }
+
+  /**
+   * Creates a RunnerManager with the provided limit on the number of historical <code>RunDetails</code> that are stored.
+   * @param maxHistory The maximum number of RunDetails for historical, completed runs that will be stored.
+   */
+  public RunnerManager(Integer maxHistory) {
+    this.MAX_HISTORY = maxHistory;
+  }
 
   /**
    * Check whether a specific run is still in progress.
@@ -130,7 +151,6 @@ public class RunnerManager {
     final RunDetails runDetails = new RunDetails(runId, configId);
     activeDetailsMap.put(runId, runDetails);
 
-
     runDetails.setFuture(CompletableFuture.runAsync(() -> {
       try {
         log.info("Starting lucille run with ID '{}' via the Runner Manager using configId {}.",
@@ -147,7 +167,16 @@ public class RunnerManager {
         log.error("Failed to run lucille with ID '{}' via the Runner Manager.", runId, e);
         runDetails.setThrowable(e);
       } finally {
-        historicalDetailsMap.put(runId, runDetails);
+        synchronized (historicalLock) {
+          historicalDetailsMap.put(runId, runDetails);
+          historicalEntryOrder.add(runId);
+
+          while (MAX_HISTORY != null && historicalDetailsMap.size() > MAX_HISTORY) {
+            String oldestRunId = historicalEntryOrder.poll();
+            historicalDetailsMap.remove(oldestRunId);
+          }
+        }
+
         activeDetailsMap.remove(runId);
       }
     }));

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
@@ -22,9 +22,6 @@ public class RunnerManager {
 
   private static final Logger log = LoggerFactory.getLogger(RunnerManager.class);
 
-  // Singleton instance
-  private static final RunnerManager instance = new RunnerManager();
-
   // RunID keyed maps, the first is for active runs, the second is for historical runs
   // Ultimately the goal is to limit the size of the historical, active will be (theoretically) unbound.
   // Importantly, we operate under the following contract:
@@ -39,11 +36,7 @@ public class RunnerManager {
   // An in memory map of configs which can be used to create new Lucille runs
   private final Map<String, Config> configMap = new ConcurrentHashMap<>();
 
-  private RunnerManager() {}
-
-  public static RunnerManager getInstance() {
-    return instance;
-  }
+  public RunnerManager() {}
 
   /**
    * Check whether a specific run is still in progress.

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
@@ -29,7 +29,7 @@ public class RunnerManagerTest {
 
   @Test
   public void testRunnerManagerFull() throws Exception {
-    RunnerManager runnerManager = RunnerManager.getInstance();
+    RunnerManager runnerManager = new RunnerManager();
     Config config = ConfigFactory.load("RunnerManagerTest/sleep.conf");
     String runId = Runner.generateRunId();
 
@@ -62,7 +62,7 @@ public class RunnerManagerTest {
 
   @Test
   public void testWaitForRunCompletion() throws Exception {
-    RunnerManager runnerManager = RunnerManager.getInstance();
+    RunnerManager runnerManager = new RunnerManager();
     Config config = ConfigFactory.load("RunnerManagerTest/sleep.conf");
     String configId = runnerManager.createConfig(config);
     String runId = Runner.generateRunId();
@@ -91,7 +91,7 @@ public class RunnerManagerTest {
   @Test
   public void testSimultaneousRuns() throws Exception {
     Config config = ConfigFactory.load("RunnerManagerTest/sleep.conf");
-    RunnerManager runnerManager = RunnerManager.getInstance();
+    RunnerManager runnerManager = new RunnerManager();
     String configId = runnerManager.createConfig(config);
     List<String> runIds = new ArrayList();
     List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -145,7 +145,7 @@ public class RunnerManagerTest {
       outputFile2.delete();
       outputFile3.delete();
 
-      RunnerManager runnerManager = RunnerManager.getInstance();
+      RunnerManager runnerManager = new RunnerManager();
       List<String> runIds = new ArrayList<>();
       List<CompletableFuture<Void>> futures = new ArrayList<>();
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
@@ -235,6 +235,30 @@ public class RunnerManagerTest {
     assertNull(runnerManager.getRunDetails("run-2"));
   }
 
+  @Test
+  public void testNoHistory() throws Exception {
+    RunnerManager runnerManager = new RunnerManager(0);
+    Config noopConfig = ConfigFactory.load("RunnerManagerTest/noop.conf");
+    String noopId = runnerManager.createConfig(noopConfig);
+
+    runnerManager.runWithConfig("run-1", noopId);
+    runnerManager.waitForRunCompletion("run-1");
+
+    // as currently implemented, this shouldn't be vulnerable to a race condition / transient failure
+    assertEquals(0, runnerManager.getRunDetails().size());
+
+    // noting that, since it is cleared from the history, we *are* able to reuse the id
+    runnerManager.runWithConfig("run-1", noopId);
+    runnerManager.waitForRunCompletion("run-1");
+
+    assertEquals(0, runnerManager.getRunDetails().size());
+  }
+
+  @Test
+  public void testInvalidMaxHistory() {
+    assertThrows(IllegalArgumentException.class, () -> new RunnerManager(-1));
+  }
+
   private void validateRun1Reader(CSVReader run1Reader) {
     for (String[] line : run1Reader) {
       assertEquals(4, line.length);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.core;
 
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -195,6 +196,43 @@ public class RunnerManagerTest {
       outputFile2.delete();
       outputFile3.delete();
     }
+  }
+
+  @Test
+  public void testHistoricalLimit() throws Exception {
+    RunnerManager runnerManager = new RunnerManager(3);
+    Config noopConfig = ConfigFactory.load("RunnerManagerTest/noop.conf");
+    String noopId = runnerManager.createConfig(noopConfig);
+
+    Config badConfig = ConfigFactory.load("RunnerManagerTest/invalid.conf");
+    String badId = runnerManager.createConfig(badConfig);
+
+    // these three are run serially, so we know the order in which
+    // they ought to be removed from the history.
+    runnerManager.runWithConfig("run-1", noopId);
+    runnerManager.waitForRunCompletion("run-1");
+
+    runnerManager.runWithConfig("run-2", noopId);
+    runnerManager.waitForRunCompletion("run-2");
+
+    // still gets stored
+    runnerManager.runWithConfig("run-3", badId);
+    runnerManager.waitForRunCompletion("run-3");
+
+    assertEquals(3, runnerManager.getRunDetails().size());
+
+    runnerManager.runWithConfig("run-4", noopId);
+    runnerManager.waitForRunCompletion("run-4");
+
+    assertEquals(3, runnerManager.getRunDetails().size());
+    assertNull(runnerManager.getRunDetails("run-1"));
+
+    // errored run still creates / clears history
+    runnerManager.runWithConfig("run-5", badId);
+    runnerManager.waitForRunCompletion("run-5");
+
+    assertEquals(3, runnerManager.getRunDetails().size());
+    assertNull(runnerManager.getRunDetails("run-2"));
   }
 
   private void validateRun1Reader(CSVReader run1Reader) {

--- a/lucille-core/src/test/resources/RunnerManagerTest/invalid.conf
+++ b/lucille-core/src/test/resources/RunnerManagerTest/invalid.conf
@@ -1,0 +1,3 @@
+{
+  lucille: "This isn't really a lucille config."
+}

--- a/lucille-core/src/test/resources/RunnerManagerTest/noop.conf
+++ b/lucille-core/src/test/resources/RunnerManagerTest/noop.conf
@@ -1,0 +1,17 @@
+connectors: [
+  {
+    class: "com.kmwllc.lucille.connector.NoOpConnector"
+    name: "no-op"
+    pipeline: "pipeline1"
+  }
+]
+
+pipelines: [{
+  name: "pipeline1"
+  stages: []
+}]
+
+indexer {
+  type: "NoOpIndexer"
+  class: "com.kmwllc.lucille.indexer.NopIndexer"
+}

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
@@ -96,7 +96,7 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
     log.info(String.format("starting lucille-api from %s config %s env %s",
         System.getProperty("user.dir"), config, env));
 
-    RunnerManager runnerManager = RunnerManager.getInstance();
+    RunnerManager runnerManager = new RunnerManager();
 
     boolean authEnabled = config.getAuthConfig().isEnabled();
 

--- a/lucille-plugins/lucille-api/src/test/java/auth/BasicAuthenticatorTest.java
+++ b/lucille-plugins/lucille-api/src/test/java/auth/BasicAuthenticatorTest.java
@@ -22,7 +22,7 @@ public class BasicAuthenticatorTest {
      * The Authentication should pass when any user is passed to the endpoints
      */
     Optional<PrincipalImpl> user = Optional.of(new PrincipalImpl("test"));
-    RunnerManager runnerManager = RunnerManager.getInstance();
+    RunnerManager runnerManager = new RunnerManager();
     LucilleResource api = new LucilleResource(runnerManager, authHandler);
     String configBody = "pipeline = \"testPipeline\"";
     Response status = api.createConfig(user, configBody);
@@ -35,7 +35,7 @@ public class BasicAuthenticatorTest {
      * If an empty Optional is passed the Authentication should fail
      */
     Optional<PrincipalImpl> noUser = Optional.empty();
-    RunnerManager runnerManager = RunnerManager.getInstance();
+    RunnerManager runnerManager = new RunnerManager();
     LucilleResource api = new LucilleResource(runnerManager, authHandler);
     String configBody = "pipeline = \"testPipeline\"";
     Response status = api.createConfig(noUser, configBody);

--- a/lucille-plugins/lucille-api/src/test/java/endpoints/LucilleResourceTest.java
+++ b/lucille-plugins/lucille-api/src/test/java/endpoints/LucilleResourceTest.java
@@ -22,7 +22,7 @@ public class LucilleResourceTest {
 
   @Before
   public void setUp() {
-    runnerManager = RunnerManager.getInstance();
+    runnerManager = new RunnerManager();
     // Use real AuthHandler, disable auth for most tests (can enable as needed)
     AuthHandler authHandler = new AuthHandler(false);
     lucilleResource = new LucilleResource(runnerManager, authHandler);


### PR DESCRIPTION
This is a draft that addresses one of the two primary issues we have pointed out. 

I feel a bit icky about these changes and how brittle this class is but it is accomplishing what we want. In particular we are a bit constrained by a need to fulfill `isRunning` and `waitForRunCompletion`

(it doesn't expose this into the API config yet!)