### PR TITLE
LC-832: Run maven.yml with ubuntu instead of macos

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR resolves a source of discrepancy between our CI for pushes to a PR, and our CI for pushes to main.

If there is a difference in the case of any characters in a file name and a test referencing it, the test will pass on the maven.yml workflow when a commit is pushed to a branch. However, upon merging this branch, one will find that the release-snapshot.yml workflow will fail.

An example of this is addressed [here](https://github.com/kmwtechnology/lucille/pull/493).

The reason for this is that our PR CI maven.yml uses macos, whereas our push to main CI, release-snapshot.yml, uses ubuntu. macos is fundamentally case-insensitive but case-preserving, meaning tests will incorrectly pass on maven.yml if they have this file name issue.

Beyond this, every other workflow we have runs on ubuntu-latest. The reason this one doesn't is because we changed it back in 2023 to address an issue with RunnerTest hanging, which was a bandaid fix for that specific PR: 
[LC-292](https://github.com/kmwtechnology/lucille/pull/12/changes)

I recommend that we try using ubuntu here, make sure it works, and go with that from now on for consistency.