### PR TITLE
LC-890: Metrics Cleanup

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
@@ -3,8 +3,6 @@ package com.kmwllc.lucille.core;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.kmwllc.lucille.util.LogUtils;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
@@ -1,5 +1,10 @@
 package com.kmwllc.lucille.core;
 
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.kmwllc.lucille.util.LogUtils;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -175,6 +180,9 @@ public class RunnerManager {
 
           activeDetailsMap.remove(runId);
         }
+
+        // metrics cleanup
+        SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG).removeMatching(MetricFilter.startsWith(runId));
       }
     }));
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerManagerTest.java
@@ -8,6 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.kmwllc.lucille.util.LogUtils;
 import com.opencsv.CSVReader;
 import java.io.File;
 import java.io.FileReader;
@@ -238,6 +241,36 @@ public class RunnerManagerTest {
     } finally {
       RunnerManager.resetMaxHistoryForTesting();
     }
+  }
+
+  @Test
+  public void testMetricsCleanup() throws Exception {
+    SharedMetricRegistries.clear();
+    assertEquals(0, SharedMetricRegistries.names().size());
+
+    // adding a dummy metric to flex that all metrics starting
+    // with the run id get removed.
+    SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG).counter("run-1.dummy.metric");
+    SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG).counter("run-2.dummy.metric");
+
+    RunnerManager runnerManager = RunnerManager.getInstance();
+    Config noopConfig = ConfigFactory.load("RunnerManagerTest/noop.conf");
+    String noopConfigId = runnerManager.createConfig(noopConfig);
+
+    runnerManager.runWithConfig("run-1", noopConfigId);
+    runnerManager.runWithConfig("run-2", noopConfigId);
+
+    runnerManager.waitForRunCompletion("run-1");
+    runnerManager.waitForRunCompletion("run-2");
+
+    // default registry gets recreated, but should be empty
+    MetricRegistry metricRegistry = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
+
+    // Two indexer metrics get "left behind" but are not related to a specific run.
+    // I wonder if this means there is a bug with indexer metrics in API?
+    assertFalse(metricRegistry.getNames().stream().anyMatch(name -> name.startsWith("run-1")));
+    assertFalse(metricRegistry.getNames().stream().anyMatch(name -> name.startsWith("run-2")));
+    assertEquals(2, metricRegistry.getNames().size());
   }
 
   private void validateRun1Reader(CSVReader run1Reader) {


### PR DESCRIPTION
Lucille Runs create `MetricRegistry`s under the `SharedMetricsRegistry`. In many cases (and for every run in the API), these are prefixed by the runID. They have never been cleaned up. This PR has the `RunnerManager` remove, after a run, all metrics starting with the runID. A straightforward unit test ensures this works, but it will also warn us if additional metrics are being introduced and not removed when needed. 