### PR TITLE
LC-822: Documentation for worker timeout

### DIFF
--- a/application-example.conf
+++ b/application-example.conf
@@ -247,6 +247,8 @@ worker {
 
   # maximum time to spend processing a message, after which the worker will assume a problem and shut down, assuming that
   # worker.exitOnTimeout=true
+  # this should at least be greater than Lucille's poll timeout, which is 50ms for local mode and 2s for distributed mode,
+  # otherwise an idle worker can be incorrectly flagged as stuck.
   maxProcessingSecs: 600 # 10 minutes
 
   # maximum number of times across all workers that an attempt should be made to process any given document;


### PR DESCRIPTION
If maxProcessingSecs is set as lower than the poll timeout for the worker config, the worker can be incorrectly flagged as stuck. This PR simply adds a comment documenting this in our example config