### PR TITLE
LC-272: optimize dropped documents in pipeline

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
@@ -139,9 +139,6 @@ public abstract class Stage {
    * @return boolean representing - should we process this doc according to its conditionals?
    */
   public boolean shouldProcess(Document doc) {
-    if (doc.isDropped() || doc.isSkipped()) {
-      return false;
-    }
     return condition.test(doc);
   }
 
@@ -261,6 +258,10 @@ public abstract class Stage {
         Document d = docs.next();
         if (d == null) {
           return null;
+        }
+
+        if (d.isDropped() || d.isSkipped()) {
+          return d;
         }
 
         try {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
@@ -139,6 +139,9 @@ public abstract class Stage {
    * @return boolean representing - should we process this doc according to its conditionals?
    */
   public boolean shouldProcess(Document doc) {
+    if (doc.isDropped() || doc.isSkipped()) {
+      return false;
+    }
     return condition.test(doc);
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
@@ -11,6 +11,11 @@ import org.apache.commons.collections4.IteratorUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -235,13 +240,14 @@ public class PipelineTest {
     pipeline.addStage(new Stage1(config));
     pipeline.addStage(new Stage2(config));
   }
-  
+
   @Test
   public void testDroppedDocumentSkipsDownstreamStages() throws Exception {
     Pipeline pipeline = new Pipeline();
     Config config = ConfigFactory.empty();
     pipeline.addStage(new DropDocument(config));
-    pipeline.addStage(new Stage1(config));
+    Stage downstream = Mockito.spy(new Stage1(config));
+    pipeline.addStage(downstream);
 
     Document doc = Document.create("d1");
 
@@ -250,9 +256,9 @@ public class PipelineTest {
     pipeline.stopStages();
 
     assertEquals(1, results.size());
-    Document result = results.get(0);
-    assertTrue(result.isDropped());
-    assertFalse(result.has("s1"));
+    assertTrue(results.get(0).isDropped());
+
+    verify(downstream, never()).processConditional(any());
   }
 
   private static class Stage1 extends Stage {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
@@ -3,6 +3,7 @@ package com.kmwllc.lucille.core;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.SpecBuilder;
 import com.kmwllc.lucille.stage.CreateChildrenStage;
+import com.kmwllc.lucille.stage.DropDocument;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -233,6 +234,25 @@ public class PipelineTest {
     Config config = ConfigFactory.empty().withValue("name", ConfigValueFactory.fromAnyRef("stage1"));
     pipeline.addStage(new Stage1(config));
     pipeline.addStage(new Stage2(config));
+  }
+  
+  @Test
+  public void testDroppedDocumentSkipsDownstreamStages() throws Exception {
+    Pipeline pipeline = new Pipeline();
+    Config config = ConfigFactory.empty();
+    pipeline.addStage(new DropDocument(config));
+    pipeline.addStage(new Stage1(config));
+
+    Document doc = Document.create("d1");
+
+    pipeline.startStages();
+    List<Document> results = IteratorUtils.toList(pipeline.processDocument(doc));
+    pipeline.stopStages();
+
+    assertEquals(1, results.size());
+    Document result = results.get(0);
+    assertTrue(result.isDropped());
+    assertFalse(result.has("s1"));
   }
 
   private static class Stage1 extends Stage {


### PR DESCRIPTION
moves checking of dropped and skipped logic to next() method to prevent unnecessary method calls on documents which don't need to be looked at in the pipeline