### PR TITLE
LC-912: Jackson Upgrade

### DIFF
--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -108,7 +108,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.21.4</version>
+        <version>2.22.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Jackson so we can resolve a CVE in `jackson-databind`