### PR TITLE
LC-909: Transient Tika Test Failure

### DIFF
--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -405,15 +407,18 @@ public class TextExtractorTest {
   public void testTimeout() throws Exception {
     InterruptTrackingParser.interrupted.set(false);
 
-    TextExtractor stage = (TextExtractor) factory.get("TextExtractorTest/timeout.conf");
+    Stage stage = factory.get("TextExtractorTest/timeout.conf");
 
     Document doc = Document.create("doc1");
     doc.setField("path", Paths.get("src/test/resources/TextExtractorTest/tika.txt").toAbsolutePath().toString());
 
     stage.processDocument(doc);
 
-    // Give it a bit of time for the async task to be interrupted and set the flag
-    Thread.sleep(400);
+    // poll for the parser to be interrupted. give it max ~5 sec. to do so
+    Instant deadline = Instant.now().plus(5, ChronoUnit.SECONDS);
+    while (!InterruptTrackingParser.interrupted.get() && Instant.now().isBefore(deadline)) {
+      Thread.sleep(50);
+    }
 
     // If timeout works, it should have returned within much less than 1000ms
     // and interrupted should be true (if we interrupt the thread)

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -420,7 +420,7 @@ public class TextExtractorTest {
       Thread.sleep(50);
     }
 
-    // If timeout works, it should have returned within much less than 1000ms
+    // If timeout works, it should have returned within much less than our 5 sec. max
     // and interrupted should be true (if we interrupt the thread)
     assertTrue("Parser should have been interrupted", InterruptTrackingParser.interrupted.get());
     // Document should not have text (or at least not from the parser)


### PR DESCRIPTION
Updates the test to just poll for an interrupt. Polls for up to five seconds. 

It seems we are expecting the test to have race conditions. This should be more resilient.