### PR TITLE
LC-911: Transient Lucille API Test Failure

### DIFF
--- a/lucille-plugins/lucille-api/src/test/java/endpoints/SystemStatsResourceTest.java
+++ b/lucille-plugins/lucille-api/src/test/java/endpoints/SystemStatsResourceTest.java
@@ -7,6 +7,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.kmwllc.lucille.util.LogUtils;
+import java.util.UUID;
 import org.junit.Test;
 import com.kmwllc.lucille.endpoints.SystemStatsResource;
 import jakarta.ws.rs.core.Response;
@@ -32,26 +33,21 @@ public class SystemStatsResourceTest {
 
   @Test
   public void testDropwizardMetricsEndpoint() {
-    try {
-      SharedMetricRegistries.remove(LogUtils.METRICS_REG);
-    } catch (Exception ignored) {}
-
-    MetricRegistry reg = new MetricRegistry();
-    reg.counter("test.counter").inc(3);
-    SharedMetricRegistries.add(LogUtils.METRICS_REG, reg);
+    // Using UUID for the counter name to prevent transient failures due to race conditions
+    MetricRegistry reg = SharedMetricRegistries.getOrCreate(LogUtils.METRICS_REG);
+    String counterName = "test.counter." + UUID.randomUUID();
+    reg.counter(counterName).inc(3);
 
     Response response;
     try {
       response = resource.getDropwizardMetrics();
     } finally {
-      try {
-        SharedMetricRegistries.remove(LogUtils.METRICS_REG);
-      } catch (Exception ignored) {}
+      reg.remove(counterName);
     }
 
     assertEquals(200, response.getStatus());
     JsonNode root = (JsonNode) response.getEntity();
     assertTrue(root.has("counters"));
-    assertEquals(3, root.get("counters").get("test.counter").get("count").asInt());
+    assertEquals(3, root.get("counters").get(counterName).get("count").asInt());
   }
 }


### PR DESCRIPTION
The call to `SharedMetricRegistries.add(LogUtils.METRICS_REG, reg)` was subject to a race condition. If the `METRICS_REG` is recreated between the `remove` call this `add` call, the registry we create is not added.

This PR updates the test to simply add a metric with a UUID in its name, increment it, get the metrics, remove the metric from the register, and then ensure this metric is retrieved appropriately.