### PR TITLE
LC-874: Disabling Stages (& GetLegalProperties Refactor)

### DIFF
--- a/doc/site/content/en/docs/architecture/components/stage/_index.md
+++ b/doc/site/content/en/docs/architecture/components/stage/_index.md
@@ -28,6 +28,11 @@ Rather than supporting sub-pipelines or branching, Lucille provides per-stage co
 
 Conditions are evaluated by the framework before invoking the Stage. A Stage author never implements conditional logic — they write a Stage that does one thing, and the configuration determines which documents it applies to. This separation means Stages are simpler to write, simpler to test, and reusable across pipelines with different condition configurations.
 
+## Disabling Stages
+
+As a convenience, you can set `enabled: false` on any Stage in your Config. By doing so, the Stage is _not_ instantiated, `start()` and `stop()` are never called,
+and no Document is processed by that Stage. The Stage will still be validated against its Spec, warning you of any missing, invalid, or unknown properties in the Config.  
+
 ## Child Document Emission
 
 A Stage can produce additional documents — children — that flow through the remaining pipeline stages independently. This is how Lucille handles 1-to-N fan-out (e.g., chunking a document into embedding-sized pieces). Children are tracked by the Publisher's accounting system and indexed as independent records.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Pipeline.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Pipeline.java
@@ -25,18 +25,6 @@ public class Pipeline {
     return stages;
   }
 
-  public void addStage(Stage stage, String metricsPrefix) throws PipelineException, StageException {
-    stage.initialize(stages.size() + 1, metricsPrefix);
-    if (stages.stream().anyMatch(s -> stage.getName().equals(s.getName()))) {
-      throw new PipelineException("Two stages cannot have the same name: " + stage.getName());
-    }
-    stages.add(stage);
-  }
-
-  public void addStage(Stage stage) throws PipelineException, StageException {
-    addStage(stage, "default");
-  }
-
   public void startStages() throws StageException {
     for (Stage stage : stages) {
       stage.start();
@@ -55,6 +43,11 @@ public class Pipeline {
     }
   }
 
+  /**
+   * Returns a list of exceptions that occurred during initialization and validation of stages
+   * in the config. Validation is performed on every stage config that is provided, whether
+   * or not it is enabled.
+   */
   public static List<Exception> validateStages(Config config, String name)
       throws Exception {
     return validateStages(getPipelineStages(config, name));
@@ -62,7 +55,8 @@ public class Pipeline {
 
   /**
    * Returns a list of exceptions that occurred during initialization and validation of stages
-   * in the given list
+   * in the given list. Validation is performed on every stage config that is provided, whether
+   * or not it is enabled.
    */
   public static List<Exception> validateStages(List<? extends Config> stages) {
     List<Exception> exceptions = new ArrayList<>();
@@ -80,11 +74,17 @@ public class Pipeline {
   /**
    * Instantiates a Pipeline from the designated list of Stage Configs.
    * The Config for each Stage must specify the stage's class.
+   * <br> Configs with <code>enabled: false</code> will not be instantiated or part of the returned Pipeline.
    */
   public static Pipeline fromConfig(List<? extends Config> stages, String metricsPrefix) throws
       Exception {
     Pipeline pipeline = new Pipeline();
     for (Config c : stages) {
+      // skip configs with "enabled: false"
+      if (c.hasPath("enabled") && !c.getBoolean("enabled")) {
+        continue;
+      }
+
       Stage stage = Stage.fromConfig(c);
       pipeline.addStage(stage, metricsPrefix);
     }
@@ -96,6 +96,7 @@ public class Pipeline {
    *
    * The Config is expected to have a "pipeline.&lt;name&gt;.stages" element
    * containing a List of stages and their settings. The list element for each Stage must specify the stage's class.
+   * Stage configs with <code>enabled: false</code> will not be instantiated or part of the returned Pipeline.
    */
   public static Pipeline fromConfig(Config config, String name, String metricsPrefix)
       throws Exception {
@@ -158,4 +159,18 @@ public class Pipeline {
     return result;
   }
 
+  // These "direct" methods are private since "adding" a Stage needs to be a more protected operation, as this class
+  // bears the burden of ensuring the Stage is "enabled".
+  /** Add the given Stage to the pipeline. Package access for unit testing. */
+  void addStage(Stage stage) throws PipelineException, StageException {
+    addStage(stage, "default");
+  }
+
+  private void addStage(Stage stage, String metricsPrefix) throws PipelineException, StageException {
+    stage.initialize(stages.size() + 1, metricsPrefix);
+    if (stages.stream().anyMatch(s -> stage.getName().equals(s.getName()))) {
+      throw new PipelineException("Two stages cannot have the same name: " + stage.getName());
+    }
+    stages.add(stage);
+  }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
@@ -360,7 +360,7 @@ public abstract class Stage {
    * @return The unique property names for this Stage declared in its Spec. Does not return the default properties
    * for a Stage (such as "name" and "conditions").
    */
-  public Set<String> getUniqueProperties() {
+  public Set<String> getNonDefaultLegalProperties() {
     Set<String> propNames = getSpec().getLegalProperties();
 
     Set<String> defaultPropNames = DEFAULT_LEGAL_PROPERTIES.stream().map(Property::getName).collect(Collectors.toSet());

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
@@ -4,8 +4,13 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.kmwllc.lucille.core.spec.BooleanProperty;
+import com.kmwllc.lucille.core.spec.ListProperty;
+import com.kmwllc.lucille.core.spec.Property;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.SpecBuilder;
+import com.kmwllc.lucille.core.spec.StringProperty;
 import com.kmwllc.lucille.util.LogUtils;
 import com.typesafe.config.Config;
 import java.lang.reflect.Constructor;
@@ -45,7 +50,20 @@ import java.util.stream.Collectors;
  * </ul>
  */
 public abstract class Stage {
+
   private static final Logger docLogger = LoggerFactory.getLogger("com.kmwllc.lucille.core.DocLogger");
+
+  public static final Set<Property> DEFAULT_LEGAL_PROPERTIES = Set.of(
+      new StringProperty("name", false),
+      new StringProperty("class", false),
+      new BooleanProperty("enabled", false),
+      new ListProperty("conditions", false, SpecBuilder.withoutDefaults()
+          .optionalString("operator")
+          .optionalString("valuesPath")
+          .optionalList("values", new TypeReference<List<String>>(){})
+          .requiredList("fields", new TypeReference<List<String>>(){}).build()),
+      new StringProperty("conditionPolicy", false)
+  );
 
   protected Config config;
   private final Predicate<Document> condition;
@@ -338,8 +356,17 @@ public abstract class Stage {
     return config;
   }
 
-  public Set<String> getLegalProperties() {
-    return getSpec().getLegalProperties();
+  /**
+   * @return The unique property names for this Stage declared in its Spec. Does not return the default properties
+   * for a Stage (such as "name" and "conditions").
+   */
+  public Set<String> getUniqueProperties() {
+    Set<String> propNames = getSpec().getLegalProperties();
+
+    Set<String> defaultPropNames = DEFAULT_LEGAL_PROPERTIES.stream().map(Property::getName).collect(Collectors.toSet());
+    propNames.removeAll(defaultPropNames);
+
+    return propNames;
   }
 
   /**

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Stage.java
@@ -26,7 +26,13 @@ import java.util.stream.Collectors;
  * reflectively in the super constructor, so the Stage will not function without declaring a Spec. The Config provided
  * to <code>super()</code> will be validated against the Spec. Validation errors will reference the Stage's <code>name</code>.
  *
- * <p> A {@link SpecBuilder#stage()} always has "name", "class", "conditions", and "conditionPolicy" as legal properties.
+ * <p> A {@link SpecBuilder#stage()} always has "name", "class", "conditions", "enabled", and "conditionPolicy" as legal properties.
+ *
+ * <p> Stages can be disabled by setting <code>enabled: false</code>. Stages default to being enabled.
+ * When <code>enabled</code> is <code>false</code>, the Stage should not even be instantiated.
+ * {@link Stage#start()} and {@link Stage#stop()} must not be called. So, it is the responsibility for <b>users</b> of the Stage
+ * class to ensure that Stages are <code>enabled</code> when appropriate. The Stage class itself holds no information pertaining
+ * to the <code>enabled</code> property.
  *
  * <p> Config Parameters (Conditions):
  * <ul>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/spec/SpecBuilder.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/spec/SpecBuilder.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.core.spec;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.kmwllc.lucille.core.Stage;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -34,16 +35,7 @@ public class SpecBuilder {
    * @return a Spec with default legal properties suitable for a Stage.
    */
   public static SpecBuilder stage() {
-    return new SpecBuilder(Set.of(
-        new StringProperty("name", false),
-        new StringProperty("class", false),
-        new BooleanProperty("enabled", false),
-        new ListProperty("conditions", false, SpecBuilder.withoutDefaults()
-            .optionalString("operator")
-            .optionalString("valuesPath")
-            .optionalList("values", new TypeReference<List<String>>(){})
-            .requiredList("fields", new TypeReference<List<String>>(){}).build()),
-        new StringProperty("conditionPolicy", false)));
+    return new SpecBuilder(Stage.DEFAULT_LEGAL_PROPERTIES);
   }
 
   /**

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/spec/SpecBuilder.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/spec/SpecBuilder.java
@@ -29,14 +29,15 @@ public class SpecBuilder {
   // ********** "Constructors" **********
 
   /**
-   * Creates a Spec with default legal properties suitable for a Stage. Includes name, class, conditions, and
-   * conditionPolicy.
+   * Creates a Spec with default legal properties suitable for a Stage. Includes name, class, conditions, enabled,
+   * and conditionPolicy.
    * @return a Spec with default legal properties suitable for a Stage.
    */
   public static SpecBuilder stage() {
     return new SpecBuilder(Set.of(
         new StringProperty("name", false),
         new StringProperty("class", false),
+        new BooleanProperty("enabled", false),
         new ListProperty("conditions", false, SpecBuilder.withoutDefaults()
             .optionalString("operator")
             .optionalString("valuesPath")

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
@@ -261,6 +261,37 @@ public class PipelineTest {
     verify(downstream, never()).processConditional(any());
   }
 
+  @Test
+  public void testDisabledStages() throws Exception {
+    Config pipelineConfig = ConfigFactory.load("PipelineTest/some-disabled.conf");
+    Pipeline pipeline = Pipeline.fromConfig(pipelineConfig, "my-pipeline", "");
+
+    assertEquals(2, pipeline.getStages().size());
+    assertEquals("PrintEnabled", pipeline.getStages().get(0).getName());
+    assertEquals("TimestampEnabled", pipeline.getStages().get(1).getName());
+  }
+
+  @Test
+  public void testAllDisabledStages() throws Exception {
+    Config pipelineConfig = ConfigFactory.load("PipelineTest/all-disabled.conf");
+    Pipeline pipeline = Pipeline.fromConfig(pipelineConfig, "my-pipeline", "");
+
+    // two of the stages have invalid config (missing "destField"). Note that no validation
+    // errors are thrown!
+    assertEquals(0, pipeline.getStages().size());
+  }
+
+  @Test
+  public void testDisabledStagesAreValidated() throws Exception {
+    // all three stages are disabled. the two timestamp stages do not have the "destField".
+    Config pipelineConfig = ConfigFactory.load("PipelineTest/all-disabled.conf");
+    List<Exception> validationErrors = Pipeline.validateStages(pipelineConfig, "my-pipeline");
+
+    assertEquals(2, validationErrors.size());
+    assertTrue(validationErrors.get(0).getMessage().contains("destField"));
+    assertTrue(validationErrors.get(1).getMessage().contains("destField"));
+  }
+
   private static class Stage1 extends Stage {
 
     public static final Spec SPEC = SpecBuilder.stage().build();

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/PipelineTest.java
@@ -276,8 +276,10 @@ public class PipelineTest {
     Config pipelineConfig = ConfigFactory.load("PipelineTest/all-disabled.conf");
     Pipeline pipeline = Pipeline.fromConfig(pipelineConfig, "my-pipeline", "");
 
-    // two of the stages have invalid config (missing "destField"). Note that no validation
-    // errors are thrown!
+    // Note: two of the stages have invalid config (missing "destField").
+    // However, no validation errors are thrown - since disabled stages are not instantiated in Pipeline.fromConfig()
+    // (Disabled Stages are still validated in Pipeline.validateStages()... see next test. So, from the end user's perspective,
+    // disabled Stages "are validated" - the Runner does validation before building & starting a pipeline.)
     assertEquals(0, pipeline.getStages().size());
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
@@ -1073,6 +1073,18 @@ public class RunnerTest {
   }
 
   @Test
+  public void testPreRunValidationAbortsOnInvalidButDisabledStage() throws Exception {
+    // has one stage (Timestamp) that is disabled but is missing a required property
+    Config config = ConfigFactory.load("RunnerTest/singleDocInvalid.conf");
+
+    RunResult result = Runner.run(config, Runner.RunType.TEST);
+
+    assertFalse(result.getStatus());
+    assertNotNull(result.getHistory());
+    assertTrue(result.getHistory().isEmpty());
+  }
+
+  @Test
   public void testRunnerStateSetAndCleared() throws Exception {
 
     // when executing a run in a way that doesn't involve main(), no instances of RunnerState should be created

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/spec/SpecBuilderTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/spec/SpecBuilderTest.java
@@ -66,6 +66,6 @@ public class SpecBuilderTest {
     assertTrue(combinedSpec.getLegalProperties().contains("field3"));
     assertTrue(combinedSpec.getLegalProperties().contains("field4"));
 
-    assertEquals(9, combinedSpec.getLegalProperties().size());
+    assertEquals(10, combinedSpec.getLegalProperties().size());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyRegexTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyRegexTest.java
@@ -169,7 +169,7 @@ public class ApplyRegexTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("ApplyRegexTest/config.conf");
     assertEquals(
         Set.of(
@@ -177,14 +177,10 @@ public class ApplyRegexTest {
             "regex",
             "updateMode",
             "multiline",
-            "name",
             "source",
             "dest",
-            "conditions",
-            "class",
             "dotall",
-            "literal",
-            "conditionPolicy"),
-        stage.getLegalProperties());
+            "literal"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyRegexTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyRegexTest.java
@@ -169,7 +169,7 @@ public class ApplyRegexTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("ApplyRegexTest/config.conf");
     assertEquals(
         Set.of(
@@ -181,6 +181,6 @@ public class ApplyRegexTest {
             "dest",
             "dotall",
             "literal"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ConcatenateTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ConcatenateTest.java
@@ -58,10 +58,10 @@ public class ConcatenateTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("ConcatenateTest/config.conf");
     assertEquals(
-        Set.of("updateMode", "name", "formatString", "dest", "conditions", "class", "conditionPolicy", "defaultInputs"),
-        stage.getLegalProperties());
+        Set.of("updateMode", "formatString", "dest", "defaultInputs"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ConcatenateTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ConcatenateTest.java
@@ -58,10 +58,10 @@ public class ConcatenateTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("ConcatenateTest/config.conf");
     assertEquals(
         Set.of("updateMode", "formatString", "dest", "defaultInputs"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ContainsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ContainsTest.java
@@ -48,11 +48,10 @@ public class ContainsTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("ContainsTest/config.conf");
     assertEquals(
-        Set.of(
-            "output", "contains", "ignoreCase", "name", "fields", "conditions", "value", "class", "conditionPolicy"),
-        stage.getLegalProperties());
+        Set.of("output", "contains", "ignoreCase", "fields", "value"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ContainsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ContainsTest.java
@@ -48,10 +48,10 @@ public class ContainsTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("ContainsTest/config.conf");
     assertEquals(
         Set.of("output", "contains", "ignoreCase", "fields", "value"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/CopyFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/CopyFieldsTest.java
@@ -152,10 +152,10 @@ public class CopyFieldsTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("CopyFieldsTest/replace.conf");
     assertEquals(
         Set.of("fieldMapping", "isNested", "updateMode"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/CopyFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/CopyFieldsTest.java
@@ -152,10 +152,10 @@ public class CopyFieldsTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("CopyFieldsTest/replace.conf");
     assertEquals(
-        Set.of("class", "conditionPolicy", "conditions", "fieldMapping", "isNested", "name", "updateMode"),
-        stage.getLegalProperties());
+        Set.of("fieldMapping", "isNested", "updateMode"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/CreateStaticTeaserTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/CreateStaticTeaserTest.java
@@ -51,10 +51,10 @@ public class CreateStaticTeaserTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("CreateStaticTeaserTest/config.conf");
     assertEquals(
-        Set.of("updateMode", "name", "source", "dest", "conditions", "class", "maxLength", "conditionPolicy"),
-        stage.getLegalProperties());
+        Set.of("updateMode", "source", "dest", "maxLength"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/CreateStaticTeaserTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/CreateStaticTeaserTest.java
@@ -51,10 +51,10 @@ public class CreateStaticTeaserTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("CreateStaticTeaserTest/config.conf");
     assertEquals(
         Set.of("updateMode", "source", "dest", "maxLength"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DeleteFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DeleteFieldsTest.java
@@ -39,8 +39,8 @@ public class DeleteFieldsTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("DeleteFieldsTest/config.conf");
-    assertEquals(Set.of("name", "fields", "conditions", "class", "conditionPolicy"), stage.getLegalProperties());
+    assertEquals(Set.of("fields"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DeleteFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DeleteFieldsTest.java
@@ -39,8 +39,8 @@ public class DeleteFieldsTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("DeleteFieldsTest/config.conf");
-    assertEquals(Set.of("fields"), stage.getUniqueProperties());
+    assertEquals(Set.of("fields"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DetectLanguageTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DetectLanguageTest.java
@@ -47,7 +47,7 @@ public class DetectLanguageTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("DetectLanguageTest/config.conf");
     assertEquals(
         Set.of(
@@ -58,6 +58,6 @@ public class DetectLanguageTest {
             "minProbability",
             "source",
             "maxLength"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DetectLanguageTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DetectLanguageTest.java
@@ -47,7 +47,7 @@ public class DetectLanguageTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("DetectLanguageTest/config.conf");
     assertEquals(
         Set.of(
@@ -56,12 +56,8 @@ public class DetectLanguageTest {
             "languageConfidenceField",
             "updateMode",
             "minProbability",
-            "name",
             "source",
-            "conditions",
-            "class",
-            "maxLength",
-            "conditionPolicy"),
-        stage.getLegalProperties());
+            "maxLength"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DictionaryLookupTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DictionaryLookupTest.java
@@ -71,25 +71,21 @@ public class DictionaryLookupTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("DictionaryLookupTest/config.conf");
     assertEquals(
         Set.of(
             "ignoreCase",
             "usePayloads",
             "updateMode",
-            "name",
             "source",
             "dest",
-            "conditions",
-            "class",
             "dictPath",
             "setOnly",
             "useAnyMatch",
             "ignoreMissingSource",
-            "conditionPolicy",
             "gcp", "azure", "s3"),
-        stage.getLegalProperties());
+        stage.getUniqueProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DictionaryLookupTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DictionaryLookupTest.java
@@ -71,7 +71,7 @@ public class DictionaryLookupTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("DictionaryLookupTest/config.conf");
     assertEquals(
         Set.of(
@@ -85,7 +85,7 @@ public class DictionaryLookupTest {
             "useAnyMatch",
             "ignoreMissingSource",
             "gcp", "azure", "s3"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DropValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DropValuesTest.java
@@ -40,9 +40,8 @@ public class DropValuesTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("DropValuesTest/config.conf");
-    assertEquals(
-        Set.of("values", "name", "source", "conditions", "class", "conditionPolicy"), stage.getLegalProperties());
+    assertEquals(Set.of("values", "source"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/DropValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/DropValuesTest.java
@@ -40,8 +40,8 @@ public class DropValuesTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("DropValuesTest/config.conf");
-    assertEquals(Set.of("values", "source"), stage.getUniqueProperties());
+    assertEquals(Set.of("values", "source"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/EmitNestedChildrenTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/EmitNestedChildrenTest.java
@@ -85,7 +85,7 @@ public class EmitNestedChildrenTest {
   @Test
   public void testPipeline() throws Exception {
     // create pipeline with one EmitNestedChildren stage, with dropParent: false
-    Config config = ConfigFactory.load("EmitNestedChildrenTest/emitchild.conf");
+    Config config = ConfigFactory.load("EmitNestedChildrenTest/emitchild-pipeline.conf");
     Pipeline pipeline = Pipeline.fromConfig(config, "pipeline", "");
 
     Document parent = Document.create("parentId");

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/EmitNestedChildrenTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/EmitNestedChildrenTest.java
@@ -5,9 +5,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.kmwllc.lucille.core.Document;
 import com.kmwllc.lucille.core.Pipeline;
-import com.kmwllc.lucille.core.PipelineException;
 import com.kmwllc.lucille.core.Stage;
 import com.kmwllc.lucille.core.StageException;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -83,9 +84,9 @@ public class EmitNestedChildrenTest {
 
   @Test
   public void testPipeline() throws Exception {
-    Pipeline pipeline = new Pipeline();
-    Stage stage = factory.get("EmitNestedChildrenTest/emitchild.conf");
-    pipeline.addStage(stage);
+    // create pipeline with one EmitNestedChildren stage, with dropParent: false
+    Config config = ConfigFactory.load("EmitNestedChildrenTest/emitchild.conf");
+    Pipeline pipeline = Pipeline.fromConfig(config, "pipeline", "");
 
     Document parent = Document.create("parentId");
     Document child = Document.create("child1");

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ExtractFirstCharacterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ExtractFirstCharacterTest.java
@@ -57,8 +57,8 @@ public class ExtractFirstCharacterTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("ExtractFirstCharacterTest/config.conf");
-    assertEquals(Set.of("name", "conditions", "replacement", "class", "conditionPolicy", "fieldMapping"), stage.getLegalProperties());
+    assertEquals(Set.of("replacement", "fieldMapping"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ExtractFirstCharacterTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ExtractFirstCharacterTest.java
@@ -57,8 +57,8 @@ public class ExtractFirstCharacterTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("ExtractFirstCharacterTest/config.conf");
-    assertEquals(Set.of("replacement", "fieldMapping"), stage.getUniqueProperties());
+    assertEquals(Set.of("replacement", "fieldMapping"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/LengthTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/LengthTest.java
@@ -29,8 +29,8 @@ public class LengthTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("LengthTest/config.conf");
-    assertEquals(Set.of("fieldMapping"), stage.getUniqueProperties());
+    assertEquals(Set.of("fieldMapping"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/LengthTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/LengthTest.java
@@ -29,8 +29,8 @@ public class LengthTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("LengthTest/config.conf");
-    assertEquals(Set.of("name", "conditions", "class", "conditionPolicy", "fieldMapping"), stage.getLegalProperties());
+    assertEquals(Set.of("fieldMapping"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/MatchQueryTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/MatchQueryTest.java
@@ -62,9 +62,9 @@ public class MatchQueryTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("MatchQueryTest/config.conf");
-    assertEquals(Set.of("matchedQueriesField", "fields", "queries"), stage.getUniqueProperties());
+    assertEquals(Set.of("matchedQueriesField", "fields", "queries"), stage.getNonDefaultLegalProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/MatchQueryTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/MatchQueryTest.java
@@ -62,11 +62,9 @@ public class MatchQueryTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("MatchQueryTest/config.conf");
-    assertEquals(
-        Set.of("matchedQueriesField", "name", "fields", "conditions", "queries", "class", "conditionPolicy"),
-        stage.getLegalProperties());
+    assertEquals(Set.of("matchedQueriesField", "fields", "queries"), stage.getUniqueProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeFieldNamesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeFieldNamesTest.java
@@ -32,10 +32,8 @@ public class NormalizeFieldNamesTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("FieldNormalizerTest/config.conf");
-    assertEquals(
-        Set.of("delimiter", "name", "conditions", "class", "nonAlphanumReplacement", "conditionPolicy"),
-        stage.getLegalProperties());
+    assertEquals(Set.of("delimiter", "nonAlphanumReplacement"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeFieldNamesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeFieldNamesTest.java
@@ -32,8 +32,8 @@ public class NormalizeFieldNamesTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("FieldNormalizerTest/config.conf");
-    assertEquals(Set.of("delimiter", "nonAlphanumReplacement"), stage.getUniqueProperties());
+    assertEquals(Set.of("delimiter", "nonAlphanumReplacement"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeTextTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeTextTest.java
@@ -51,8 +51,8 @@ public class NormalizeTextTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("NormalizeTextTest/lowercase.conf");
-    assertEquals(Set.of("mode", "updateMode", "source", "dest"), stage.getUniqueProperties());
+    assertEquals(Set.of("mode", "updateMode", "source", "dest"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeTextTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/NormalizeTextTest.java
@@ -51,10 +51,8 @@ public class NormalizeTextTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("NormalizeTextTest/lowercase.conf");
-    assertEquals(
-        Set.of("mode", "updateMode", "name", "source", "dest", "conditions", "class", "conditionPolicy"),
-        stage.getLegalProperties());
+    assertEquals(Set.of("mode", "updateMode", "source", "dest"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
@@ -59,21 +59,17 @@ public class ParseDateTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("ParseDateTest/config.conf");
     assertEquals(
         Set.of(
             "formatters",
             "updateMode",
-            "name",
             "formatStrs",
             "source",
             "dest",
-            "conditions",
-            "class",
-            "timeZoneId",
-            "conditionPolicy"),
-        stage.getLegalProperties());
+            "timeZoneId"),
+        stage.getUniqueProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseDateTest.java
@@ -59,7 +59,7 @@ public class ParseDateTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("ParseDateTest/config.conf");
     assertEquals(
         Set.of(
@@ -69,7 +69,7 @@ public class ParseDateTest {
             "source",
             "dest",
             "timeZoneId"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
@@ -257,10 +257,10 @@ public class ParseJsonTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("ParseJson/config.conf");
     assertEquals(Set.of("src", "sourceIsBase64", "jsonFieldPaths", "updateMode"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ParseJsonTest.java
@@ -257,10 +257,10 @@ public class ParseJsonTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("ParseJson/config.conf");
-    assertEquals(Set.of("src", "name", "sourceIsBase64", "conditions", "class", "conditionPolicy", "jsonFieldPaths", "updateMode"),
-        stage.getLegalProperties());
+    assertEquals(Set.of("src", "sourceIsBase64", "jsonFieldPaths", "updateMode"),
+        stage.getUniqueProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/PrintTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/PrintTest.java
@@ -104,11 +104,10 @@ public class PrintTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("PrintTest/config.conf");
-    assertEquals(Set.of("overwriteFile", "outputFile", "shouldLog", "name", "blacklist", "whitelist", "conditions", "class",
-            "conditionPolicy", "appendThreadName"),
-        stage.getLegalProperties());
+    assertEquals(Set.of("overwriteFile", "outputFile", "shouldLog", "blacklist", "whitelist", "appendThreadName"),
+        stage.getUniqueProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/PrintTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/PrintTest.java
@@ -104,10 +104,10 @@ public class PrintTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("PrintTest/config.conf");
     assertEquals(Set.of("overwriteFile", "outputFile", "shouldLog", "blacklist", "whitelist", "appendThreadName"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/QueryDatabaseTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/QueryDatabaseTest.java
@@ -134,7 +134,7 @@ public class QueryDatabaseTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws Exception {
+  public void testGetUniqueProperties() throws Exception {
     Stage stage = factory.get("QueryDatabaseTest/animal.conf");
     assertEquals(
         Set.of(
@@ -143,16 +143,12 @@ public class QueryDatabaseTest {
             "driver",
             "jdbcUser",
             "keyFields",
-            "name",
             "jdbcPassword",
-            "conditions",
-            "class",
             "sql",
             "connectionRetries",
             "connectionRetryPause",
-            "conditionPolicy",
             "fieldMapping"),
-        stage.getLegalProperties());
+        stage.getUniqueProperties());
 
     stage.stop();
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/QueryDatabaseTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/QueryDatabaseTest.java
@@ -134,7 +134,7 @@ public class QueryDatabaseTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws Exception {
+  public void testSpec() throws Exception {
     Stage stage = factory.get("QueryDatabaseTest/animal.conf");
     assertEquals(
         Set.of(
@@ -148,7 +148,7 @@ public class QueryDatabaseTest {
             "connectionRetries",
             "connectionRetryPause",
             "fieldMapping"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
 
     stage.stop();
   }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveDuplicateValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveDuplicateValuesTest.java
@@ -146,8 +146,8 @@ public class RemoveDuplicateValuesTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("RemoveDuplicateValuesTest/config.conf");
-    assertEquals(Set.of("fieldMapping"), stage.getUniqueProperties());
+    assertEquals(Set.of("fieldMapping"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveDuplicateValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveDuplicateValuesTest.java
@@ -146,8 +146,8 @@ public class RemoveDuplicateValuesTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("RemoveDuplicateValuesTest/config.conf");
-    assertEquals(Set.of("name", "conditions", "class", "conditionPolicy", "fieldMapping"), stage.getLegalProperties());
+    assertEquals(Set.of("fieldMapping"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveEmptyFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveEmptyFieldsTest.java
@@ -26,8 +26,8 @@ public class RemoveEmptyFieldsTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("RemoveEmptyFieldsTest/config.conf");
-    assertEquals(Set.of("name", "conditions", "class", "conditionPolicy"), stage.getLegalProperties());
+    assertEquals(Set.of(), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveEmptyFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/RemoveEmptyFieldsTest.java
@@ -26,8 +26,8 @@ public class RemoveEmptyFieldsTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("RemoveEmptyFieldsTest/config.conf");
-    assertEquals(Set.of(), stage.getUniqueProperties());
+    assertEquals(Set.of(), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/RenameFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/RenameFieldsTest.java
@@ -101,8 +101,8 @@ public class RenameFieldsTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("RenameFieldsTest/config.conf");
-    assertEquals(Set.of("updateMode", "applyToChildren", "fieldMapping"), stage.getUniqueProperties());
+    assertEquals(Set.of("updateMode", "applyToChildren", "fieldMapping"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/RenameFieldsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/RenameFieldsTest.java
@@ -101,8 +101,8 @@ public class RenameFieldsTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("RenameFieldsTest/config.conf");
-    assertEquals(Set.of("updateMode", "applyToChildren", "name", "conditions", "class", "conditionPolicy", "fieldMapping"), stage.getLegalProperties());
+    assertEquals(Set.of("updateMode", "applyToChildren", "fieldMapping"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ReplacePatternsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ReplacePatternsTest.java
@@ -135,7 +135,7 @@ public class ReplacePatternsTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("ReplacePatternsTest/config.conf");
     assertEquals(
         Set.of(
@@ -143,16 +143,12 @@ public class ReplacePatternsTest {
             "regex",
             "updateMode",
             "multiline",
-            "name",
             "source",
             "dest",
-            "conditions",
             "replacement",
             "replacementField",
-            "class",
             "dotall",
-            "literal",
-            "conditionPolicy"),
-        stage.getLegalProperties());
+            "literal"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ReplacePatternsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ReplacePatternsTest.java
@@ -135,7 +135,7 @@ public class ReplacePatternsTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("ReplacePatternsTest/config.conf");
     assertEquals(
         Set.of(
@@ -149,6 +149,6 @@ public class ReplacePatternsTest {
             "replacementField",
             "dotall",
             "literal"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
@@ -55,8 +55,8 @@ public class SetStaticValuesTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("SetStaticValuesTest/config.conf");
-    assertEquals(Set.of("updateMode", "staticValues", "skipDocument"), stage.getUniqueProperties());
+    assertEquals(Set.of("updateMode", "staticValues", "skipDocument"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SetStaticValuesTest.java
@@ -55,8 +55,8 @@ public class SetStaticValuesTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("SetStaticValuesTest/config.conf");
-    assertEquals(Set.of("updateMode", "name", "conditions", "class", "conditionPolicy", "staticValues", "skipDocument"), stage.getLegalProperties());
+    assertEquals(Set.of("updateMode", "staticValues", "skipDocument"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SplitFieldValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SplitFieldValuesTest.java
@@ -53,10 +53,10 @@ public class SplitFieldValuesTest {
 
   
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("SplitFieldValuesTest/config.conf");
     assertEquals(
         Set.of("inputField", "delimiter", "trimWhitespace", "outputField"),
-        stage.getUniqueProperties());
+        stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/SplitFieldValuesTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/SplitFieldValuesTest.java
@@ -53,18 +53,10 @@ public class SplitFieldValuesTest {
 
   
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("SplitFieldValuesTest/config.conf");
     assertEquals(
-        Set.of(
-            "inputField",
-            "delimiter",
-            "trimWhitespace",
-            "name",
-            "conditions",
-            "class",
-            "outputField",
-            "conditionPolicy"),
-        stage.getLegalProperties());
+        Set.of("inputField", "delimiter", "trimWhitespace", "outputField"),
+        stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/StageTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/StageTest.java
@@ -188,9 +188,9 @@ public class StageTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testGetNonDefaultLegalProperties() throws StageException {
     Stage stage = factory.get("StageTest/processMust.conf");
-    assertEquals(Set.of(), stage.getUniqueProperties());
+    assertEquals(Set.of(), stage.getNonDefaultLegalProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/StageTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/StageTest.java
@@ -188,9 +188,9 @@ public class StageTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("StageTest/processMust.conf");
-    assertEquals(Set.of("name", "conditions", "class", "conditionPolicy"), stage.getLegalProperties());
+    assertEquals(Set.of(), stage.getUniqueProperties());
   }
 
   @Test

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/TimestampTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/TimestampTest.java
@@ -35,8 +35,8 @@ public class TimestampTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("TimestampTest/config.conf");
-    assertEquals(Set.of("destField", "name", "conditions", "class", "conditionPolicy"), stage.getLegalProperties());
+    assertEquals(Set.of("destField"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/TimestampTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/TimestampTest.java
@@ -35,8 +35,8 @@ public class TimestampTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("TimestampTest/config.conf");
-    assertEquals(Set.of("destField"), stage.getUniqueProperties());
+    assertEquals(Set.of("destField"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/TrimWhitespaceTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/TrimWhitespaceTest.java
@@ -43,8 +43,8 @@ public class TrimWhitespaceTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("TrimWhitespaceTest/config.conf");
-    assertEquals(Set.of("name", "fields", "conditions", "class", "conditionPolicy"), stage.getLegalProperties());
+    assertEquals(Set.of("fields"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/TrimWhitespaceTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/TrimWhitespaceTest.java
@@ -43,8 +43,8 @@ public class TrimWhitespaceTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("TrimWhitespaceTest/config.conf");
-    assertEquals(Set.of("fields"), stage.getUniqueProperties());
+    assertEquals(Set.of("fields"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/XPathExtractorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/XPathExtractorTest.java
@@ -132,8 +132,8 @@ public class XPathExtractorTest {
   }
 
   @Test
-  public void testGetLegalProperties() throws StageException {
+  public void testGetUniqueProperties() throws StageException {
     Stage stage = factory.get("XPathExtractorTest/config.conf");
-    assertEquals(Set.of("xmlField", "name", "conditions", "class", "conditionPolicy", "fieldMapping"), stage.getLegalProperties());
+    assertEquals(Set.of("xmlField", "fieldMapping"), stage.getUniqueProperties());
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/XPathExtractorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/XPathExtractorTest.java
@@ -132,8 +132,8 @@ public class XPathExtractorTest {
   }
 
   @Test
-  public void testGetUniqueProperties() throws StageException {
+  public void testSpec() throws StageException {
     Stage stage = factory.get("XPathExtractorTest/config.conf");
-    assertEquals(Set.of("xmlField", "fieldMapping"), stage.getUniqueProperties());
+    assertEquals(Set.of("xmlField", "fieldMapping"), stage.getNonDefaultLegalProperties());
   }
 }

--- a/lucille-core/src/test/resources/EmitNestedChildrenTest/emitchild-pipeline.conf
+++ b/lucille-core/src/test/resources/EmitNestedChildrenTest/emitchild-pipeline.conf
@@ -1,0 +1,12 @@
+pipelines: [
+  {
+    name: "pipeline"
+    stages: [
+      {
+        name: "ENCTest"
+        class: "com.kmwllc.lucille.stage.EmitNestedChildren"
+        dropParent: false
+      }
+    ]
+  }
+]

--- a/lucille-core/src/test/resources/EmitNestedChildrenTest/emitchild.conf
+++ b/lucille-core/src/test/resources/EmitNestedChildrenTest/emitchild.conf
@@ -1,3 +1,12 @@
-{
-  dropParent : false
-}
+pipelines: [
+  {
+    name: "pipeline"
+    stages: [
+      {
+        name: "ENCTest"
+        class: "com.kmwllc.lucille.stage.EmitNestedChildren"
+        dropParent: false
+      }
+    ]
+  }
+]

--- a/lucille-core/src/test/resources/EmitNestedChildrenTest/emitchild.conf
+++ b/lucille-core/src/test/resources/EmitNestedChildrenTest/emitchild.conf
@@ -1,12 +1,5 @@
-pipelines: [
-  {
-    name: "pipeline"
-    stages: [
-      {
-        name: "ENCTest"
-        class: "com.kmwllc.lucille.stage.EmitNestedChildren"
-        dropParent: false
-      }
-    ]
-  }
-]
+{
+  name: "ENCTest"
+  class: "com.kmwllc.lucille.stage.EmitNestedChildren"
+  dropParent: false
+}

--- a/lucille-core/src/test/resources/PipelineTest/all-disabled.conf
+++ b/lucille-core/src/test/resources/PipelineTest/all-disabled.conf
@@ -1,0 +1,24 @@
+pipelines: [
+  {
+    name: "my-pipeline"
+    stages: [
+      {
+        name: "PrintDisabled"
+        class: "com.kmwllc.lucille.stage.Print"
+        enabled: false
+      }
+      {
+        name: "TimestampDisabled"
+        class: "com.kmwllc.lucille.stage.Timestamp"
+        enabled: false
+        # missing "destField"
+      }
+      {
+        name: "TimestampAlsoDisabled"
+        class: "com.kmwllc.lucille.stage.Timestamp"
+        enabled: false
+        # missing "destField"
+      }
+    ]
+  }
+]

--- a/lucille-core/src/test/resources/PipelineTest/some-disabled.conf
+++ b/lucille-core/src/test/resources/PipelineTest/some-disabled.conf
@@ -1,0 +1,23 @@
+pipelines: [
+  {
+    name: "my-pipeline"
+    stages: [
+      {
+        name: "PrintEnabled"
+        class: "com.kmwllc.lucille.stage.Print"
+      }
+      {
+        name: "TimestampDisabled"
+        class: "com.kmwllc.lucille.stage.Timestamp"
+        enabled: false
+        destField: "time"
+      }
+      {
+        name: "TimestampEnabled"
+        class: "com.kmwllc.lucille.stage.Timestamp"
+        enabled: true
+        destField: "time"
+      }
+    ]
+  }
+]

--- a/lucille-core/src/test/resources/RunnerTest/singleDocInvalid.conf
+++ b/lucille-core/src/test/resources/RunnerTest/singleDocInvalid.conf
@@ -1,0 +1,26 @@
+connectors: [
+  {
+    name: "connector1",
+    class: "com.kmwllc.lucille.connector.CSVConnector",
+    pipeline: "pipeline1",
+    idField: "id",
+    path: "classpath:RunnerTest/singleDoc.csv", 
+  }
+]
+
+pipelines: [
+  {
+    name: "pipeline1", 
+    stages: [
+      {
+        class: "com.kmwllc.lucille.stage.Timestamp"
+        enabled: false
+        # missing required "destField" property
+      }
+    ]
+  }
+]
+
+indexer: {
+  type: "solr"
+}


### PR DESCRIPTION
Allows users of any Stage to set the `enabled` property to `false` in the Config. In doing so, the Stage is not constructed, `start()` and `stop()` are not called, and documents are not processed by the `Stage`. 

Due to how Stage is used, the onus is on users (namely, `Pipeline`) to check this property and handle disabled stages as appropriate. In fact, the `Stage` class itself has no knowledge of the property (besides declaring the default legal property in `SpecBuilder`). 

Disabled stages are still validated in both validation mode and when kicking off a regular run. I could see going either way on this. It would be a straightforward change to _not_ validate Stages that are disabled, if desired!

Since we are changing one of the Stage default properties, this was also a good opportunity to revisit `GetLegalProperties`. It was renamed to `getUniqueProperties`, and only returns the properties _unique_ to a Stage. (It no longer returns properties like name and class.) So, those unit tests have been updated and renamed appropriately as well.