### PR TITLE
LC-514: Replace -usekafka and -local with -distributed and -external

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
@@ -68,8 +69,8 @@ public class Runner {
   public enum RunType {
     LOCAL, // launch Worker(s) and Indexer as threads; have all components communicate via in-memory queues
     TEST, // same as LOCAL, but bypass Solr, and store message traffic so it can be inspected after the run
-    KAFKA_LOCAL, // launch Worker(s) and Indexer as threads; have all components communicate via Kafka
-    KAFKA_DISTRIBUTED // assume Workers/Indexers were started separately (don't launch threads); have all components communicate via Kafka
+    DISTRIBUTED, // launch Worker(s) and Indexer as threads; have all components communicate via Kafka
+    DISTRIBUTED_SANDBOX // assume Workers/Indexers were started separately (don't launch threads); have all components communicate via Kafka
   }
 
   // no need to instantiate Runner; all methods currently static
@@ -155,10 +156,10 @@ public class Runner {
    * no args: pipelines workers and indexers will be executed in separate threads within the same JVM; communication
    * between components will take place in memory and Kafka will not be used
    * <p>
-   * -useKafka: connectors will be run, sending documents and receiving events via Kafka. Pipeline workers
+   * -distributed: connectors will be run, sending documents and receiving events via Kafka. Pipeline workers
    * and indexers will not be run. The assumption is that these have been deployed as separate processes.
    * <p>
-   * -local: modifies -useKafka so that workers and indexers are started as separate threads within the same JVM;
+   * -distributedSandbox: modified distributed where workers and indexers are started as separate threads within the same JVM;
    * kafka is still used for communication between them.
    * <p>
    * -render: prints out the effective/actual config in the exact form it will be seen by Lucille during the run
@@ -169,11 +170,18 @@ public class Runner {
     // during the run
     state = new RunnerState();
 
+    Option distributedOpt = Option.builder("distributed").hasArg(false)
+    .desc("Uses Kafka for inter-component communication and doesn't execute pipelines locally.")
+    .build();
+
+    Option distributedSandboxOpt = Option.builder("distributedsandbox").hasArg(false)
+        .desc("Modified distributed mode to execute pipelines locally.")
+        .build();
+
+    OptionGroup distributedType = new OptionGroup().addOption(distributedOpt).addOption(distributedSandboxOpt);
+
     Options cliOptions = new Options()
-        .addOption(Option.builder("usekafka").hasArg(false)
-            .desc("Use Kafka for inter-component communication and don't execute pipelines locally.").build())
-        .addOption(Option.builder("local").hasArg(false)
-            .desc("Modifies useKafka mode to execute pipelines locally").build())
+        .addOptionGroup(distributedType)
         .addOption(Option.builder("validate").hasArg(false)
             .desc("Validate the configuration and exit").build())
         .addOption(Option.builder("render").hasArg(false)
@@ -183,16 +191,12 @@ public class Runner {
     try {
       args = Arrays.stream(args).map(String::toLowerCase).toArray(String[]::new);
       cli = new DefaultParser().parse(cliOptions, args);
-    } catch (UnrecognizedOptionException | MissingOptionException e) {
-      try (StringWriter writer = new StringWriter();
-          PrintWriter printer = new PrintWriter(writer)) {
 
-        String header = "Run a sequence of connectors";
-        new HelpFormatter().printHelp(printer, 256, "Runner", header, cliOptions,
-            2, 10, "", true);
-        log.info(writer.toString());
+      if (!cli.getArgList().isEmpty()) {
+        printHelpAndExit(cliOptions, "Unrecognized argument(s): " + cli.getArgList());
       }
-      SystemHelper.exit(1);
+    } catch (UnrecognizedOptionException | MissingOptionException | AlreadySelectedException e) {
+      printHelpAndExit(cliOptions, e.getMessage());
     }
 
     Config config = ConfigFactory.load();
@@ -218,7 +222,7 @@ public class Runner {
       SystemHelper.exit(0);
     });
 
-    RunType runType = getRunType(cli.hasOption("usekafka"), cli.hasOption("local"));
+    RunType runType = getRunType(cli.hasOption("distributed"), cli.hasOption("distributedsandbox"));
 
     // Kick off the run with a log of the result
     RunResult result = runAndLogResult(config, runType, true);
@@ -434,15 +438,13 @@ public class Runner {
   }
 
   /**
-   * Derives the RunType for the new run from the 'useKafka' and 'local' parameters.
+   * Derives the RunType for the new run from the 'distributed' and 'distributedSandbox' parameters.
    */
-  static RunType getRunType(boolean useKafka, boolean local) {
-    if (useKafka) {
-      if (local) {
-        return RunType.KAFKA_LOCAL;
-      } else {
-        return RunType.KAFKA_DISTRIBUTED;
-      }
+  static RunType getRunType(boolean distributed, boolean distributedSandbox) {
+    if (distributed) {
+      return RunType.DISTRIBUTED;
+    } else if (distributedSandbox) {
+      return RunType.DISTRIBUTED_SANDBOX;
     } else {
       return RunType.LOCAL;
     }
@@ -540,7 +542,7 @@ public class Runner {
     List<Connector> connectors = Connector.fromConfig(config);
     List<ConnectorResult> connectorResults = new ArrayList<>();
 
-    boolean startWorkerAndIndexer = !type.equals(RunType.KAFKA_DISTRIBUTED);
+    boolean startWorkerAndIndexer = !type.equals(RunType.DISTRIBUTED);
     boolean bypassSolr = type.equals(RunType.TEST);
 
     Map<String, TestMessenger> history = type.equals(RunType.TEST) ? new HashMap<>() : null;
@@ -826,5 +828,25 @@ public class Runner {
       log.error("Error obtaining metrics logging level", e);
     }
     return Slf4jReporter.LoggingLevel.DEBUG;
+  }
+
+  /**
+   * Prints CLI help text and exits the JVM
+   */
+  private static void printHelpAndExit(Options cliOptions, String message) {
+    if (message != null) {
+      log.warn(message);
+    }
+
+    try (StringWriter writer = new StringWriter();
+        PrintWriter printer = new PrintWriter(writer)) {
+      String header = "Run a sequence of connectors";
+      new HelpFormatter().printHelp(printer, 256, "Runner", header, cliOptions,
+          2, 10, "", true);
+      log.info(writer.toString());
+    } catch (IOException e) {
+      log.debug("Unexpected IOException", e);
+    }
+    SystemHelper.exit(1);
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Runner.java
@@ -69,8 +69,8 @@ public class Runner {
   public enum RunType {
     LOCAL, // launch Worker(s) and Indexer as threads; have all components communicate via in-memory queues
     TEST, // same as LOCAL, but bypass Solr, and store message traffic so it can be inspected after the run
-    DISTRIBUTED, // launch Worker(s) and Indexer as threads; have all components communicate via Kafka
-    DISTRIBUTED_SANDBOX // assume Workers/Indexers were started separately (don't launch threads); have all components communicate via Kafka
+    EXTERNAL, // launch Worker(s) and Indexer as threads; have all components communicate via Kafka
+    DISTRIBUTED// assume Workers/Indexers were started separately (don't launch threads); have all components communicate via Kafka
   }
 
   // no need to instantiate Runner; all methods currently static
@@ -159,8 +159,8 @@ public class Runner {
    * -distributed: connectors will be run, sending documents and receiving events via Kafka. Pipeline workers
    * and indexers will not be run. The assumption is that these have been deployed as separate processes.
    * <p>
-   * -distributedSandbox: modified distributed where workers and indexers are started as separate threads within the same JVM;
-   * kafka is still used for communication between them.
+   * -external: modified local mode where workers and indexers are started as separate threads within the same JVM and kafka is
+   * used for communication between them.
    * <p>
    * -render: prints out the effective/actual config in the exact form it will be seen by Lucille during the run
    */
@@ -174,11 +174,12 @@ public class Runner {
     .desc("Uses Kafka for inter-component communication and doesn't execute pipelines locally.")
     .build();
 
-    Option distributedSandboxOpt = Option.builder("distributedsandbox").hasArg(false)
-        .desc("Modified distributed mode to execute pipelines locally.")
+    Option external = Option.builder("external").hasArg(false)
+        .desc("Modified local mode where workers and indexers are separate threads within the JVM communicating "
+            + "through kafka")
         .build();
 
-    OptionGroup distributedType = new OptionGroup().addOption(distributedOpt).addOption(distributedSandboxOpt);
+    OptionGroup distributedType = new OptionGroup().addOption(distributedOpt).addOption(external);
 
     Options cliOptions = new Options()
         .addOptionGroup(distributedType)
@@ -193,10 +194,14 @@ public class Runner {
       cli = new DefaultParser().parse(cliOptions, args);
 
       if (!cli.getArgList().isEmpty()) {
-        printHelpAndExit(cliOptions, "Unrecognized argument(s): " + cli.getArgList());
+        printHelp(cliOptions, "Unrecognized argument(s): " + cli.getArgList());
+        SystemHelper.exit(1);
+        return;
       }
     } catch (UnrecognizedOptionException | MissingOptionException | AlreadySelectedException e) {
-      printHelpAndExit(cliOptions, e.getMessage());
+      printHelp(cliOptions, e.getMessage());
+      SystemHelper.exit(1);
+      return;
     }
 
     Config config = ConfigFactory.load();
@@ -222,7 +227,7 @@ public class Runner {
       SystemHelper.exit(0);
     });
 
-    RunType runType = getRunType(cli.hasOption("distributed"), cli.hasOption("distributedsandbox"));
+    RunType runType = getRunType(cli.hasOption("distributed"), cli.hasOption("external"));
 
     // Kick off the run with a log of the result
     RunResult result = runAndLogResult(config, runType, true);
@@ -438,13 +443,13 @@ public class Runner {
   }
 
   /**
-   * Derives the RunType for the new run from the 'distributed' and 'distributedSandbox' parameters.
+   * Derives the RunType for the new run from the 'distributed' and 'external' parameters.
    */
-  static RunType getRunType(boolean distributed, boolean distributedSandbox) {
+  static RunType getRunType(boolean distributed, boolean external) {
     if (distributed) {
       return RunType.DISTRIBUTED;
-    } else if (distributedSandbox) {
-      return RunType.DISTRIBUTED_SANDBOX;
+    } else if (external) {
+      return RunType.EXTERNAL;
     } else {
       return RunType.LOCAL;
     }
@@ -564,7 +569,7 @@ public class Runner {
         workerMessengerFactory = WorkerMessengerFactory.getConstantFactory(messenger);
         indexerMessengerFactory = IndexerMessengerFactory.getConstantFactory(messenger);
         publisherMessengerFactory = PublisherMessengerFactory.getConstantFactory(messenger);
-      } else { // RunType.KAFKA_LOCAL.equals(type) || RunType.KAFKA_DISTRIBUTED.equals(type)
+      } else { // RunType.EXTERNAL.equals(type) || RunType.DISTRIBUTED.equals(type)
         workerMessengerFactory = WorkerMessengerFactory.getKafkaFactory(config, connector.getPipelineName());
         indexerMessengerFactory = IndexerMessengerFactory.getKafkaFactory(config, connector.getPipelineName());
         publisherMessengerFactory = PublisherMessengerFactory.getKafkaFactory(config);
@@ -831,9 +836,9 @@ public class Runner {
   }
 
   /**
-   * Prints CLI help text and exits the JVM
+   * Prints CLI help text
    */
-  private static void printHelpAndExit(Options cliOptions, String message) {
+  private static void printHelp(Options cliOptions, String message) {
     if (message != null) {
       log.warn(message);
     }
@@ -847,6 +852,5 @@ public class Runner {
     } catch (IOException e) {
       log.debug("Unexpected IOException", e);
     }
-    SystemHelper.exit(1);
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/RunnerManager.java
@@ -199,7 +199,7 @@ public class RunnerManager {
             runId, configId);
 
         // For now, we will always use local mode without Kafka
-        runDetails.setRunType(Runner.getRunType(false, true));
+        runDetails.setRunType(Runner.getRunType(false, false));
 
         log.debug(config.entrySet().toString());
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
@@ -69,7 +69,7 @@ public class KafkaTest {
         .withValue("kafka.bootstrapServers", ConfigValueFactory.fromAnyRef(brokers))
         .withFallback(base);
     RunResult result =
-        Runner.run(config, Runner.RunType.KAFKA_LOCAL);
+        Runner.run(config, Runner.RunType.DISTRIBUTED_SANDBOX);
     assertTrue(result.getStatus());
 
     // connector1 will feed 3 documents to pipeline1, so there should be 3 messages in each of

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/KafkaTest.java
@@ -69,7 +69,7 @@ public class KafkaTest {
         .withValue("kafka.bootstrapServers", ConfigValueFactory.fromAnyRef(brokers))
         .withFallback(base);
     RunResult result =
-        Runner.run(config, Runner.RunType.DISTRIBUTED_SANDBOX);
+        Runner.run(config, Runner.RunType.EXTERNAL);
     assertTrue(result.getStatus());
 
     // connector1 will feed 3 documents to pipeline1, so there should be 3 messages in each of

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
@@ -851,12 +851,12 @@ public class RunnerTest {
   public void testRunTypeCliFlags() throws Exception {
     assertEquals(Runner.RunType.LOCAL, runTypeForArgs());
 
-    assertEquals(Runner.RunType.KAFKA_DISTRIBUTED, runTypeForArgs("-usekafka"));
-    assertEquals(Runner.RunType.KAFKA_DISTRIBUTED, runTypeForArgs("-useKafka"));
-    assertEquals(Runner.RunType.KAFKA_DISTRIBUTED, runTypeForArgs("-USEKAFKA"));
+    assertEquals(Runner.RunType.DISTRIBUTED, runTypeForArgs("-distributed"));
+    assertEquals(Runner.RunType.DISTRIBUTED, runTypeForArgs("-distributed"));
+    assertEquals(Runner.RunType.DISTRIBUTED, runTypeForArgs("-DISTRIBUTED"));
 
-    assertEquals(Runner.RunType.KAFKA_LOCAL, runTypeForArgs("-usekafka", "-local"));
-    assertEquals(Runner.RunType.KAFKA_LOCAL, runTypeForArgs("-useKafka", "-LOCAL"));
+    assertEquals(Runner.RunType.DISTRIBUTED_SANDBOX, runTypeForArgs("-distributedsandbox"));
+    assertEquals(Runner.RunType.DISTRIBUTED_SANDBOX, runTypeForArgs("-DISTRIBUTEDSANDBOX"));
   }
 
   /**

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/RunnerTest.java
@@ -855,8 +855,8 @@ public class RunnerTest {
     assertEquals(Runner.RunType.DISTRIBUTED, runTypeForArgs("-distributed"));
     assertEquals(Runner.RunType.DISTRIBUTED, runTypeForArgs("-DISTRIBUTED"));
 
-    assertEquals(Runner.RunType.DISTRIBUTED_SANDBOX, runTypeForArgs("-distributedsandbox"));
-    assertEquals(Runner.RunType.DISTRIBUTED_SANDBOX, runTypeForArgs("-DISTRIBUTEDSANDBOX"));
+    assertEquals(Runner.RunType.EXTERNAL, runTypeForArgs("-external"));
+    assertEquals(Runner.RunType.EXTERNAL, runTypeForArgs("-EXTERNAL"));
   }
 
   /**

--- a/lucille-examples/lucille-distributed-example/runner/scripts/run.sh
+++ b/lucille-examples/lucille-distributed-example/runner/scripts/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-java -Dconfig.file=/conf/main.conf -cp '/target/lib/*' com.kmwllc.lucille.core.Runner -useKafka
+java -Dconfig.file=/conf/main.conf -cp '/target/lib/*' com.kmwllc.lucille.core.Runner -distributed


### PR DESCRIPTION
Replaced -usekafka and -local flags with -distributed and -distributedsandbox respectively with enforced mutual exclusivity. 

-distributed: Used exactly how -usekafka was earlier.

-distributedsandbox: Results in a local kafka run, mutually exclusive from -distributed. 

No flag: default to fully local mode (unchanged from previous default).

Additional validation for flags added. An argument not matching any options or one entered without leading dashes will print a help message and exit the system.

Testing: All tests pass, including the containerized nightly smoke test.