### PR TITLE
LC-915: CVEs for impending 0.11.0 release

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.10.1</version>
+        <version>1.11.1</version>
     </dependency>
 
     <dependency>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -35,6 +35,14 @@
       <version>4.0.5</version>
     </dependency>
 
+    <!-- Pin parsson to 1.1.8 — opensearch-java drags in 1.1.7 transitively, which is vulnerable to
+         SNYK-JAVA-ORGECLIPSEPARSSON-17817925 (unbounded resource allocation). Fixed in 1.1.8. -->
+    <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+      <version>1.1.8</version>
+    </dependency>
+
     <!--  Solr (indexer integration) wanted  -->
     <dependency>
       <groupId>jakarta.annotation</groupId>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/util/ElasticsearchUtils.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/util/ElasticsearchUtils.java
@@ -3,22 +3,25 @@ package com.kmwllc.lucille.util;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.kmwllc.lucille.core.spec.Spec;
 import com.kmwllc.lucille.core.spec.SpecBuilder;
 import com.typesafe.config.Config;
 import java.util.Map;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.elasticsearch.client.RestClient;
 
 import java.net.URI;
 
@@ -36,41 +39,54 @@ public class ElasticsearchUtils {
   public static ElasticsearchClient getElasticsearchOfficialClient(Config config) throws Exception {
     URI hostUri = URI.create(getElasticsearchUrl(config));
 
-    final CredentialsProvider provider = new BasicCredentialsProvider();
+    HttpHost host = new HttpHost(hostUri.getScheme(), hostUri.getHost(), hostUri.getPort());
 
     // get user info from URI if present and setup BasicAuth credentials if needed
+    final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     String userInfo = hostUri.getUserInfo();
     if (userInfo != null) {
       int pos = userInfo.indexOf(":");
       String username = userInfo.substring(0, pos);
       String password = userInfo.substring(pos + 1);
-      provider.setCredentials(AuthScope.ANY,
-          new UsernamePasswordCredentials(username, password));
+      credentialsProvider.setCredentials(new AuthScope(host),
+          new UsernamePasswordCredentials(username, password.toCharArray()));
     }
 
     // Potentially disable SSL/TLS verification for when testing locally
     boolean allowInvalidCert = getAllowInvalidCert(config);
     SSLContext sslContext;
-    HostnameVerifier hostnameVerifier;
+    TlsStrategy tlsStrategy;
 
     if (allowInvalidCert) {
       sslContext = SSLContextBuilder.create()
           .loadTrustMaterial(null, (chains, authType) -> true)
           .build();
-      hostnameVerifier = NoopHostnameVerifier.INSTANCE;
+      tlsStrategy = ClientTlsStrategyBuilder.create()
+          .setSslContext(sslContext)
+          .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+          .build();
     } else {
       sslContext = SSLContextBuilder.create()
           .build();
-      // set host name verifier to null to pick up default.
-      hostnameVerifier = null;
+      tlsStrategy = ClientTlsStrategyBuilder.create()
+          .setSslContext(sslContext)
+          .build();
     }
 
-    RestClient restClient = RestClient.builder(new HttpHost(hostUri.getHost(), hostUri.getPort(), hostUri.getScheme()))
-        .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder.setDefaultCredentialsProvider(provider)
-            .setSSLContext(sslContext)
-            .setSSLHostnameVerifier(hostnameVerifier)).build();
+    // elasticsearch-java 9.x uses the Apache HttpClient 5 based Rest5Client transport; the legacy
+    // org.elasticsearch.client.RestClient (HttpClient 4) is no longer bundled.
+    CloseableHttpAsyncClient httpClient = HttpAsyncClients.custom()
+        .setDefaultCredentialsProvider(credentialsProvider)
+        .setConnectionManager(PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .build())
+        .build();
 
-    ElasticsearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+    Rest5Client rest5Client = Rest5Client.builder(host)
+        .setHttpClient(httpClient)
+        .build();
+
+    ElasticsearchTransport transport = new Rest5ClientTransport(rest5Client, new JacksonJsonpMapper());
     return new ElasticsearchClient(transport);
   }
 

--- a/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/util/ElasticsearchUtilsTest.java
@@ -13,14 +13,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder;
 
 import java.util.HashMap;
+import javax.net.ssl.SSLContext;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.TrustStrategy;
-import org.apache.http.HttpHost;
 import java.util.Map;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
@@ -86,22 +87,23 @@ public class ElasticsearchUtilsTest {
   public void testGetElasticsearchOfficialClient() throws Exception {
     Config config = mock(Config.class);
     String url = "http://user:pass@localhost:9200";
-    RestClient restClient = mock(RestClient.class);
+    Rest5Client rest5Client = mock(Rest5Client.class);
     when(ElasticsearchUtils.getElasticsearchUrl(config)).thenReturn(url);
     when(ElasticsearchUtils.getAllowInvalidCert(config)).thenReturn(false);
 
-    try (MockedStatic<RestClient> mockRestClient = mockStatic(RestClient.class);
+    try (MockedStatic<Rest5Client> mockRest5Client = mockStatic(Rest5Client.class);
         MockedStatic<SSLContextBuilder> mockSSLContextBuilder = mockStatic(SSLContextBuilder.class)) {
-      RestClientBuilder builder = mock(RestClientBuilder.class);
+      Rest5ClientBuilder builder = mock(Rest5ClientBuilder.class);
 
       ArgumentCaptor<HttpHost> hostCaptor = ArgumentCaptor.forClass(HttpHost.class);
-      mockRestClient.when(() -> RestClient.builder(hostCaptor.capture())).thenReturn(builder);
-      when(builder.setHttpClientConfigCallback(any())).thenReturn(builder);
-      when(builder.build()).thenReturn(restClient);
+      mockRest5Client.when(() -> Rest5Client.builder(hostCaptor.capture())).thenReturn(builder);
+      when(builder.setHttpClient(any())).thenReturn(builder);
+      when(builder.build()).thenReturn(rest5Client);
 
       SSLContextBuilder mockSSLBuilder = mock(SSLContextBuilder.class);
       mockSSLContextBuilder.when(SSLContextBuilder::create).thenReturn(mockSSLBuilder);
       when(mockSSLBuilder.loadTrustMaterial(any(), (TrustStrategy) any())).thenReturn(mockSSLBuilder);
+      when(mockSSLBuilder.build()).thenReturn(SSLContext.getDefault());
 
 
       ElasticsearchClient result = ElasticsearchUtils.getElasticsearchOfficialClient(config);
@@ -116,7 +118,7 @@ public class ElasticsearchUtilsTest {
       verify(mockSSLBuilder, times(0)).loadTrustMaterial(any(), (TrustStrategy) any());
 
       // verify that setting up of client was called once
-      verify(builder, times(1)).setHttpClientConfigCallback(any());
+      verify(builder, times(1)).setHttpClient(any());
     }
   }
 
@@ -125,22 +127,23 @@ public class ElasticsearchUtilsTest {
     Config config = mock(Config.class);
     when (config.getString("elasticsearch.acceptInvalidCert")).thenReturn("true");
     String url = "http://user:pass@localhost:9200";
-    RestClient restClient = mock(RestClient.class);
+    Rest5Client rest5Client = mock(Rest5Client.class);
     when(ElasticsearchUtils.getElasticsearchUrl(config)).thenReturn(url);
     when(ElasticsearchUtils.getAllowInvalidCert(config)).thenReturn(true);
 
-    try (MockedStatic<RestClient> mockRestClient = mockStatic(RestClient.class);
+    try (MockedStatic<Rest5Client> mockRest5Client = mockStatic(Rest5Client.class);
         MockedStatic<SSLContextBuilder> mockSSLContextBuilder = mockStatic(SSLContextBuilder.class)) {
-      RestClientBuilder builder = mock(RestClientBuilder.class);
+      Rest5ClientBuilder builder = mock(Rest5ClientBuilder.class);
 
       ArgumentCaptor<HttpHost> hostCaptor = ArgumentCaptor.forClass(HttpHost.class);
-      mockRestClient.when(() -> RestClient.builder(hostCaptor.capture())).thenReturn(builder);
-      when(builder.setHttpClientConfigCallback(any())).thenReturn(builder);
-      when(builder.build()).thenReturn(restClient);
+      mockRest5Client.when(() -> Rest5Client.builder(hostCaptor.capture())).thenReturn(builder);
+      when(builder.setHttpClient(any())).thenReturn(builder);
+      when(builder.build()).thenReturn(rest5Client);
 
       SSLContextBuilder mockSSLBuilder = mock(SSLContextBuilder.class);
       mockSSLContextBuilder.when(SSLContextBuilder::create).thenReturn(mockSSLBuilder);
       when(mockSSLBuilder.loadTrustMaterial(any(), (TrustStrategy) any())).thenReturn(mockSSLBuilder);
+      when(mockSSLBuilder.build()).thenReturn(SSLContext.getDefault());
 
       ElasticsearchClient result = ElasticsearchUtils.getElasticsearchOfficialClient(config);
 
@@ -155,7 +158,7 @@ public class ElasticsearchUtilsTest {
       verify(mockSSLBuilder, times(1)).loadTrustMaterial(any(), (TrustStrategy) any());
 
       // verify that setting up of client was called once
-      verify(builder, times(1)).setHttpClientConfigCallback(any());
+      verify(builder, times(1)).setHttpClient(any());
     }
   }
 
@@ -166,7 +169,7 @@ public class ElasticsearchUtilsTest {
     when(ElasticsearchUtils.getElasticsearchUrl(config)).thenReturn(invalidUrl);
 
     // will throw error if config contains invalid url
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(Exception.class, () -> {
       ElasticsearchUtils.getElasticsearchOfficialClient(config);
     });
   }

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -51,7 +51,7 @@
     <opensearch-java.version>3.9.0</opensearch-java.version>
     <httpcore5.version>5.4.3</httpcore5.version>
     <httpclient5.version>5.6.2</httpclient5.version>
-    <elasticsearch.version>8.19.19</elasticsearch.version>
+    <elasticsearch.version>9.0.0</elasticsearch.version>
     <aws-java-sdk.version>1.12.769</aws-java-sdk.version>
     <log4j.version>2.26.1</log4j.version>
     <slf4j.version>2.0.7</slf4j.version>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -49,22 +49,22 @@
     <opensearch-rest-client.version>1.2.0</opensearch-rest-client.version>
     <opensearch.version>0.1.0</opensearch.version>
     <opensearch-java.version>3.9.0</opensearch-java.version>
-    <httpcore5.version>5.3.1</httpcore5.version>
-    <httpclient5.version>5.6.1</httpclient5.version>
-    <elasticsearch.version>8.18.4</elasticsearch.version>
+    <httpcore5.version>5.4.3</httpcore5.version>
+    <httpclient5.version>5.6.2</httpclient5.version>
+    <elasticsearch.version>8.19.19</elasticsearch.version>
     <aws-java-sdk.version>1.12.769</aws-java-sdk.version>
-    <log4j.version>2.26.0</log4j.version>
+    <log4j.version>2.26.1</log4j.version>
     <slf4j.version>2.0.7</slf4j.version>
     <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>
     <apache-commons-text.version>1.10.0</apache-commons-text.version>
     <protobuf.version>3.25.5</protobuf.version>
-    <netty.version>4.1.135.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <grpc.version>1.82.1</grpc.version>
     <!--  TODO: dropwizard-testing-junit4 is currently at 5.0.0 since 5.0.2 did not exist at time of upgrade. Bring back to use ${dropwizard-core.version} -->
     <dropwizard-core.version>5.0.2</dropwizard-core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit4.version>4.13.2</junit4.version>
-    <aws-sdk.version>2.46.13</aws-sdk.version>
+    <aws-sdk.version>2.49.4</aws-sdk.version>
     <hadoop.version>3.5.0</hadoop.version>
   </properties>
 
@@ -146,6 +146,25 @@
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-context</artifactId>
         <version>1.56.0</version>
+      </dependency>
+
+      <!-- Force the whole httpcore5 family to a single fixed version. opensearch-java pulls in
+           httpcore5-h2/httpcore5-reactive transitively; without this, httpcore5-h2 resolves to 5.4.2
+           which is vulnerable to CVE-2026-54428 (unbounded HPACK header allocation). Fixed in 5.4.3. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${httpcore5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${httpcore5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-reactive</artifactId>
+        <version>${httpcore5.version}</version>
       </dependency>
 
       <dependency>

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -148,9 +148,8 @@
         <version>1.56.0</version>
       </dependency>
 
-      <!-- Force the whole httpcore5 family to a single fixed version. opensearch-java pulls in
-           httpcore5-h2/httpcore5-reactive transitively; without this, httpcore5-h2 resolves to 5.4.2
-           which is vulnerable to CVE-2026-54428 (unbounded HPACK header allocation). Fixed in 5.4.3. -->
+      <!-- Force the whole httpcore5 family to a single fixed version. As of 7/28/26, opensearch-java is pulling
+      in httpcore5-h2: 5.4.2, which has a CVE fixed in 5.4.3, which we are fixing to. -->
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>

--- a/lucille-plugins/lucille-api/pom.xml
+++ b/lucille-plugins/lucille-api/pom.xml
@@ -134,6 +134,20 @@
         <artifactId>logback-access</artifactId>
         <version>1.5.36</version>
       </dependency>
+
+      <!-- Pin jetty-server to 12.1.10 — Dropwizard drags in 12.1.9 which has a CVE -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>12.1.10</version>
+      </dependency>
+
+      <!-- Pin jetty-security to 12.1.10 — Dropwizard drags in 12.1.9 which has a CVE -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>12.1.10</version>
+      </dependency>
     </dependencies>
 
     <build>

--- a/lucille-plugins/lucille-api/pom.xml
+++ b/lucille-plugins/lucille-api/pom.xml
@@ -135,14 +135,12 @@
         <version>1.5.36</version>
       </dependency>
 
-      <!-- Pin jetty-server to 12.1.10 — Dropwizard drags in 12.1.9 which has a CVE -->
+      <!--  Two Jetty related CVEs fixed in 12.1.10 (previously pulling in 12.1.9) -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>12.1.10</version>
       </dependency>
-
-      <!-- Pin jetty-security to 12.1.10 — Dropwizard drags in 12.1.9 which has a CVE -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>


### PR DESCRIPTION
Upgrades were relatively straightforward so far. The only "major" upgrade was for Elasticsearch (8.18.4 --> 9.0.0), which is a **breaking change** + required code changes