### PR TITLE
LC-909: Transient Tika Test Failure (Again)

### DIFF
--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -395,7 +395,10 @@ public class TextExtractorTest {
     public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
         throws TikaException, IOException, SAXException {
       try {
-        Thread.sleep(200);
+        // Block for a long time (10s) to reduce risk of a racy test.
+        // We don't want some race condition where this parse is able to complete causing the test to fail.
+        // Interrupt should cut the sleep short - we do not wait for this entire time.
+        Thread.sleep(10_000);
         super.parse(stream, handler, metadata, context);
       } catch (InterruptedException e) {
         interrupted.set(true);

--- a/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/notimeout.conf
+++ b/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/notimeout.conf
@@ -2,5 +2,6 @@
   class = "com.kmwllc.lucille.tika.stage.TextExtractor"
   textField = "text"
   filePathField = "path"
-  tikaConfigPath = "src/test/resources/TextExtractorTest/tika-config-timeout.xml"
+  # using a normal parser which runs synchronously on the test thread, not with a long sleep
+  tikaConfigPath = "src/test/resources/TextExtractorTest/tika-config.xml"
 }

--- a/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/timeout.conf
+++ b/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/timeout.conf
@@ -2,6 +2,8 @@
   class = "com.kmwllc.lucille.tika.stage.TextExtractor"
   textField = "text"
   filePathField = "path"
-  parseTimeout = 100
+  # need enough wiggle room to reliably start the parsing before the timeout fires, this test
+  # is seen to be a little flaky on GH Actions
+  parseTimeout = 1000
   tikaConfigPath = "src/test/resources/TextExtractorTest/tika-config-timeout.xml"
 }


### PR DESCRIPTION
In the previous PR, we were looking at the wrong `Thread.sleep()` call to identify a race condition.

This PR increases the sleep in the `InterruptTrackingParser` substantially to prevent the parse from completing before the test is ready to check for an interrupt. We do not wait for this entire duration - because it gets _interrupted_.