### PR TITLE
LC-921: CVEs for 0.11.0 (Pt. 3)

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -748,41 +748,26 @@
     </dependency>
 
     <!-- GraalVM SDK -->
-    <!-- Version 25.0.0 is required for Python dependencies, but requires JDK 21 -->
     <dependency>
        <groupId>org.graalvm.sdk</groupId>
        <artifactId>graal-sdk</artifactId>
-       <version>24.2.2</version>
+       <version>25.0.4</version>
     </dependency>
 
     <!-- GraalVM JavaScript -->
     <dependency>
        <groupId>org.graalvm.js</groupId>
        <artifactId>js</artifactId>
-       <version>24.2.2</version>
+       <version>25.0.4</version>
        <type>pom</type>
     </dependency>
 
     <!-- GraalVM Python -->
-    <!-- Version 25.0.0 is required for Python dependencies, but requires JDK 21 -->
     <dependency>
         <groupId>org.graalvm.python</groupId>
         <artifactId>python-language</artifactId>
-        <version>24.2.2</version>
+        <version>25.0.4</version>
     </dependency>
-
-    <!-- Force upgrade of bouncycastle to patch CVEs from transitive graalvm python dependency -->
-    <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk18on</artifactId>
-        <version>1.84</version>
-    </dependency>
-    <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk18on</artifactId>
-        <version>1.84</version>
-    </dependency>
-
     
     <!-- Py4J Python -->
     <dependency>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -680,7 +680,7 @@
     <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
-        <version>1.17.2</version>
+        <version>1.23.1</version>
     </dependency>
 
     <!-- dependency for OpenAiEmbedding Stage -->

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -253,6 +253,13 @@
       <version>12.0.33</version>
       <scope>test</scope>
     </dependency>
+    <!-- Pin jetty-util to 12.0.35 — solr-solrj-jetty drags in 12.0.27 which has a CVE -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>12.0.35</version>
+      <scope>test</scope>
+    </dependency>
 
     <!--  Note that this is also one of the dependencies for solr that we had to pull in manually. However,
        it is not test scoped because we use this in RunDetails.java as well. -->

--- a/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSoupTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/stage/ApplyJSoupTest.java
@@ -210,7 +210,7 @@ public class ApplyJSoupTest {
 
     assertEquals(3, doc.getFieldNames().size());
     assertEquals("doc1", doc.getString("id"));
-    assertEquals(List.of("<div>\n foo\n</div>", "<div>\n bar\n</div>"), doc.getStringList("destination"));
+    assertEquals(List.of("<div>foo</div>", "<div>bar</div>"), doc.getStringList("destination"));
     assertEquals(html, doc.getString("string"));
   }
 }


### PR DESCRIPTION
Bumps python language and removes unnecessary bouncy castle dependency / pin. Also small bump of JSoup + small test change for low CVE. Test is changed to reflect how JSoup returns lists now.