### PR TITLE
LC-831 NPE if auth type is not set in config for api

### DIFF
--- a/lucille-plugins/lucille-api/README.md
+++ b/lucille-plugins/lucille-api/README.md
@@ -100,7 +100,7 @@ Authentication is configured under the `auth` block. When `enabled: true`, every
 
 | Property |            Description                |
 |----------|-------------------------------------- |
-| type     | currently only `basicAuth` is supported |
+| type     | required when `enabled` is `true`, currently only `basicAuth` is supported |
 | enabled  | `true` to require auth, `false` to disable |
 | password | the password Basic Auth requests must match |
 

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
@@ -91,6 +91,7 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
    * Starts the Lucille API server, configures authentication, and registers resources. Throws Exception on unsupported auth type, aborting startup.
    * @param config the Lucille API configuration
    * @param env the Dropwizard environment
+   * @throws IllegalArgumentException if authentication is enabled but no auth type is set
    * @throws Exception if authentication type is unsupported (startup abort) or other startup failures
    */
   @Override
@@ -104,7 +105,13 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
 
     // Enable Basic Auth only if it's enabled in the configuration
     if (authEnabled) {
-      if (config.getAuthConfig().getType().equals(AuthType.BASIC_AUTH)) {
+      AuthType authType = config.getAuthConfig().getType();
+
+      if (authType == null) {
+        throw new IllegalArgumentException("auth.type must be set when auth.enabled is true.");
+      }
+
+      if (AuthType.BASIC_AUTH.equals(authType)) {
         env.jersey()
             .register(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<PrincipalImpl>()
                 .setAuthenticator(new BasicAuthenticator(config.getAuthConfig().getPassword()))
@@ -112,7 +119,7 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
         env.jersey().register(new AuthValueFactoryProvider.Binder<>(PrincipalImpl.class));
         log.info("Basic authentication has been enabled.");
       } else {
-        throw new Exception("Unsupported auth type configured for the Lucille Admin API.");
+        throw new Exception("Unsupported auth type configured for the Lucille Admin API: " + authType);
       }
     } else {
       log.info("Authentication is disabled.");

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
@@ -88,11 +88,11 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
   }
 
   /**
-   * Starts the Lucille API server, configures authentication, and registers resources. Throws Exception on unsupported auth type, aborting startup.
+   * Starts the Lucille API server, configures authentication, and registers resources.
    * @param config the Lucille API configuration
    * @param env the Dropwizard environment
-   * @throws IllegalArgumentException if authentication is enabled but no auth type is set
-   * @throws Exception if authentication type is unsupported (startup abort) or other startup failures
+   * @throws IllegalArgumentException if authentication is enabled and AuthType is not basicAuth
+   * @throws Exception for other startup failures
    */
   @Override
   public void run(LucilleAPIConfiguration config, Environment env) throws Exception {
@@ -108,19 +108,15 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
       AuthType authType = config.getAuthConfig().getType();
 
       if (AuthType.NO_AUTH.equals(authType)) {
-        throw new IllegalArgumentException("auth.type must be set when auth.enabled is true.");
+        throw new IllegalArgumentException("auth.type must be set to basicAuth when auth.enabled is true.");
       }
 
-      if (AuthType.BASIC_AUTH.equals(authType)) {
-        env.jersey()
-            .register(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<PrincipalImpl>()
-                .setAuthenticator(new BasicAuthenticator(config.getAuthConfig().getPassword()))
-                .buildAuthFilter()));
-        env.jersey().register(new AuthValueFactoryProvider.Binder<>(PrincipalImpl.class));
-        log.info("Basic authentication has been enabled.");
-      } else {
-        throw new Exception("Unsupported auth type configured for the Lucille Admin API: " + authType);
-      }
+      env.jersey()
+          .register(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<PrincipalImpl>()
+              .setAuthenticator(new BasicAuthenticator(config.getAuthConfig().getPassword()))
+              .buildAuthFilter()));
+      env.jersey().register(new AuthValueFactoryProvider.Binder<>(PrincipalImpl.class));
+      log.info("Basic authentication has been enabled.");
     } else {
       log.info("Authentication is disabled.");
     }

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
@@ -91,6 +91,7 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
    * Starts the Lucille API server, configures authentication, and registers resources. Throws Exception on unsupported auth type, aborting startup.
    * @param config the Lucille API configuration
    * @param env the Dropwizard environment
+   * @throws IllegalArgumentException if authentication is enabled but no auth type is set
    * @throws Exception if authentication type is unsupported (startup abort) or other startup failures
    */
   @Override
@@ -104,7 +105,14 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
 
     // Enable Basic Auth only if it's enabled in the configuration
     if (authEnabled) {
-      if (config.getAuthConfig().getType().equals(AuthType.BASIC_AUTH)) {
+      AuthType authType = config.getAuthConfig().getType();
+
+      if (authType == null) {
+        throw new IllegalArgumentException(
+            "auth.type must be set when auth.enabled is true.");
+      }
+
+      if (AuthType.BASIC_AUTH.equals(authType)) {
         env.jersey()
             .register(new AuthDynamicFeature(new BasicCredentialAuthFilter.Builder<PrincipalImpl>()
                 .setAuthenticator(new BasicAuthenticator(config.getAuthConfig().getPassword()))
@@ -112,7 +120,8 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
         env.jersey().register(new AuthValueFactoryProvider.Binder<>(PrincipalImpl.class));
         log.info("Basic authentication has been enabled.");
       } else {
-        throw new Exception("Unsupported auth type configured for the Lucille Admin API.");
+        throw new Exception(
+            "Unsupported auth type configured for the Lucille Admin API: " + authType);
       }
     } else {
       log.info("Authentication is disabled.");

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/APIApplication.java
@@ -107,7 +107,7 @@ public class APIApplication extends Application<LucilleAPIConfiguration> {
     if (authEnabled) {
       AuthType authType = config.getAuthConfig().getType();
 
-      if (authType == null) {
+      if (AuthType.NO_AUTH.equals(authType)) {
         throw new IllegalArgumentException("auth.type must be set when auth.enabled is true.");
       }
 

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
@@ -32,7 +32,7 @@ public final class AuthConfiguration {
   }
 
   /**
-   * The authentication type to use. Defaults to NO_AUTH if not specified.
+   * The authentication type to use. Defaults to NO_AUTH if not specified and required when authentication is enabled.
    */
   private AuthType type;
 
@@ -61,11 +61,7 @@ public final class AuthConfiguration {
    */
   @JsonProperty
   public void setType(String type) {
-    if (type.equals("basicAuth")) {
-      this.type = AuthType.BASIC_AUTH;
-    } else {
-      this.type = AuthType.NO_AUTH;
-    }
+    this.type = "basicAuth".equals(type) ? AuthType.BASIC_AUTH : AuthType.NO_AUTH;
   }
   
   /**

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
@@ -1,7 +1,6 @@
 package com.kmwllc.lucille.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.auth.Auth;
 
 /**
  * Configuration for authentication in the Lucille Admin API.

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
@@ -1,6 +1,7 @@
 package com.kmwllc.lucille.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.auth.Auth;
 
 /**
  * Configuration for authentication in the Lucille Admin API.
@@ -32,9 +33,9 @@ public final class AuthConfiguration {
   }
 
   /**
-   * The authentication type to use. Defaults to NO_AUTH if empty and required when authentication is enabled.
+   * The authentication type to use. Defaults to NO_AUTH if empty and must be BASIC_AUTH when authentication is enabled.
    */
-  private AuthType type;
+  private AuthType type = AuthType.NO_AUTH;
 
   /**
    * Password for BASIC_AUTH authentication.
@@ -56,18 +57,18 @@ public final class AuthConfiguration {
   }
 
   /**
-   * Sets the authentication type from a string. "basicAuth" sets BASIC_AUTH and empty string sets NO_AUTH.
+   * Sets the authentication type from a string. "basicAuth" sets BASIC_AUTH and null or empty sets NO_AUTH.
    * @param type the authentication type as a string
    * @throws IllegalArgumentException if AuthType is not recognized
    */
   @JsonProperty
-  public void setType(String type) throws Exception {
-    if (type.equals("basicAuth")) {
-      this.type = AuthType.BASIC_AUTH;
-    } else if (type.isEmpty()) {
+  public void setType(String type) {
+    if (type == null || type.isEmpty()) {
       this.type = AuthType.NO_AUTH;
+    } else if (type.equals("basicAuth")) {
+      this.type = AuthType.BASIC_AUTH;
     } else {
-      throw new Exception("Unsupported auth type configured for the Lucille Admin API: " + type);
+      throw new IllegalArgumentException("Unsupported auth type configured for the Lucille Admin API: " + type);
     }
   }
   

--- a/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
+++ b/lucille-plugins/lucille-api/src/main/java/com/kmwllc/lucille/config/AuthConfiguration.java
@@ -32,7 +32,7 @@ public final class AuthConfiguration {
   }
 
   /**
-   * The authentication type to use. Defaults to NO_AUTH if not specified and required when authentication is enabled.
+   * The authentication type to use. Defaults to NO_AUTH if empty and required when authentication is enabled.
    */
   private AuthType type;
 
@@ -56,12 +56,19 @@ public final class AuthConfiguration {
   }
 
   /**
-   * Sets the authentication type from a string. "basicAuth" sets BASIC_AUTH, otherwise NO_AUTH.
+   * Sets the authentication type from a string. "basicAuth" sets BASIC_AUTH and empty string sets NO_AUTH.
    * @param type the authentication type as a string
+   * @throws IllegalArgumentException if AuthType is not recognized
    */
   @JsonProperty
-  public void setType(String type) {
-    this.type = "basicAuth".equals(type) ? AuthType.BASIC_AUTH : AuthType.NO_AUTH;
+  public void setType(String type) throws Exception {
+    if (type.equals("basicAuth")) {
+      this.type = AuthType.BASIC_AUTH;
+    } else if (type.isEmpty()) {
+      this.type = AuthType.NO_AUTH;
+    } else {
+      throw new Exception("Unsupported auth type configured for the Lucille Admin API: " + type);
+    }
   }
   
   /**

--- a/lucille-plugins/lucille-api/src/test/java/APIApplicationAuthTest.java
+++ b/lucille-plugins/lucille-api/src/test/java/APIApplicationAuthTest.java
@@ -1,0 +1,51 @@
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.kmwllc.lucille.APIApplication;
+import com.kmwllc.lucille.config.AuthConfiguration;
+import com.kmwllc.lucille.config.AuthConfiguration.AuthType;
+import com.kmwllc.lucille.config.LucilleAPIConfiguration;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.ResourceHelpers;
+import org.junit.Test;
+
+public class APIApplicationAuthTest {
+
+  @Test
+  public void testStartupWithMissingAuthType() {
+    DropwizardTestSupport<LucilleAPIConfiguration> support = new DropwizardTestSupport<>(
+        APIApplication.class, ResourceHelpers.resourceFilePath("test-conf-missing-auth-type.yml"));
+
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, support::before);
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains("auth.type"));
+  }
+
+  @Test
+  public void testTypeNotRequiredWhenAuthDisabled() throws Exception {
+    AuthConfiguration authConfig = new AuthConfiguration();
+    authConfig.setEnabled(false);
+
+    assertNull(authConfig.getType());
+
+    LucilleAPIConfiguration config = new LucilleAPIConfiguration();
+    config.setAuthConfig(authConfig);
+
+    new APIApplication().run(config, new Environment("auth-disabled-test"));
+  }
+
+  @Test
+  public void testBlankAuthTypeIsNoAuth() {
+    AuthConfiguration authConfig = new AuthConfiguration();
+
+    authConfig.setType(null);
+    assertEquals(AuthType.NO_AUTH, authConfig.getType());
+
+    authConfig.setType("");
+    assertEquals(AuthType.NO_AUTH, authConfig.getType());
+  }
+}

--- a/lucille-plugins/lucille-api/src/test/java/APIApplicationAuthTest.java
+++ b/lucille-plugins/lucille-api/src/test/java/APIApplicationAuthTest.java
@@ -1,0 +1,50 @@
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.kmwllc.lucille.APIApplication;
+import com.kmwllc.lucille.config.AuthConfiguration;
+import com.kmwllc.lucille.config.AuthConfiguration.AuthType;
+import com.kmwllc.lucille.config.LucilleAPIConfiguration;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.ResourceHelpers;
+import org.junit.Test;
+
+public class APIApplicationAuthTest {
+
+  @Test
+  public void testStartupWithMissingAuthType() {
+    DropwizardTestSupport<LucilleAPIConfiguration> support = new DropwizardTestSupport<>(
+        APIApplication.class, ResourceHelpers.resourceFilePath("test-conf-missing-auth-type.yml"));
+
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, support::before);
+
+    assertTrue(thrown.getMessage(), thrown.getMessage().contains("auth.type"));
+  }
+
+  @Test
+  public void testTypeNotRequiredWhenAuthDisabled() throws Exception {
+    AuthConfiguration authConfig = new AuthConfiguration();
+    authConfig.setEnabled(false);
+
+    assertNull(authConfig.getType());
+
+    LucilleAPIConfiguration config = new LucilleAPIConfiguration();
+    config.setAuthConfig(authConfig);
+
+    new APIApplication().run(config, new Environment("auth-disabled-test"));
+  }
+
+  @Test
+  public void testBlankAuthTypeIsNoAuth() {
+    AuthConfiguration authConfig = new AuthConfiguration();
+
+    authConfig.setType(null);
+    assertEquals(AuthType.NO_AUTH, authConfig.getType());
+
+    authConfig.setType("");
+    assertEquals(AuthType.NO_AUTH, authConfig.getType());
+  }
+}

--- a/lucille-plugins/lucille-api/src/test/java/APIApplicationAuthTest.java
+++ b/lucille-plugins/lucille-api/src/test/java/APIApplicationAuthTest.java
@@ -1,5 +1,4 @@
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -29,7 +28,7 @@ public class APIApplicationAuthTest {
     AuthConfiguration authConfig = new AuthConfiguration();
     authConfig.setEnabled(false);
 
-    assertNull(authConfig.getType());
+    assertEquals(AuthType.NO_AUTH, authConfig.getType());
 
     LucilleAPIConfiguration config = new LucilleAPIConfiguration();
     config.setAuthConfig(authConfig);
@@ -38,13 +37,18 @@ public class APIApplicationAuthTest {
   }
 
   @Test
-  public void testBlankAuthTypeIsNoAuth() {
+  public void testAuthTypeSetter() {
     AuthConfiguration authConfig = new AuthConfiguration();
+
+    authConfig.setType("");
+    assertEquals(AuthType.NO_AUTH, authConfig.getType());
 
     authConfig.setType(null);
     assertEquals(AuthType.NO_AUTH, authConfig.getType());
 
-    authConfig.setType("");
-    assertEquals(AuthType.NO_AUTH, authConfig.getType());
+    authConfig.setType("basicAuth");
+    assertEquals(AuthType.BASIC_AUTH, authConfig.getType());
+
+    assertThrows(IllegalArgumentException.class, () -> authConfig.setType("enhancedAuth"));
   }
 }

--- a/lucille-plugins/lucille-api/src/test/resources/test-conf-missing-auth-type.yml
+++ b/lucille-plugins/lucille-api/src/test/resources/test-conf-missing-auth-type.yml
@@ -1,0 +1,16 @@
+server:
+  type: default
+  requestLog:
+    type: external
+logging:
+  type: external
+auth:
+  password: "password"
+
+swagger:
+  resourcePackage: "com.kmwllc.lucille.endpoints"
+  title: Lucille API
+  description: Lucille API
+  version: 0.0.1
+  contact: info@kmwllc.com
+  license: Apache 2.0


### PR DESCRIPTION
Problem: If AuthType was not assigned in the config and Auth was enabled, .equals() would be called on a null string and crash with an NPE. 

Fix: 
- Null Check AuthType before use
- Unsupported AuthType now errors 
- New tests to confirm behavior