### PR TITLE
LC-923 Resolved CVE's for 0.11.1

### DIFF
--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -629,7 +629,7 @@
     <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-storage-blob</artifactId>
-        <version>12.35.0</version>
+        <version>12.35.1</version>
     </dependency>
 
     <dependency>

--- a/lucille-core/pom.xml
+++ b/lucille-core/pom.xml
@@ -245,20 +245,19 @@
       <version>${solr.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- Pin jetty-http to 12.0.33 — solr-solrj-jetty drags in 12.0.27 which has a CVE; 12.1.x (used by
-         lucille-api via Dropwizard) is unaffected so the pin lives here rather than in the parent -->
+    <!-- Floor for jetty-http: solr-solrj-zookeeper pulls 12.0.27 (CVE-2026-2332).
+    Not test-scoped so it propagates downstream. -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
       <version>12.0.33</version>
-      <scope>test</scope>
     </dependency>
-    <!-- Pin jetty-util to 12.0.35 — solr-solrj-jetty drags in 12.0.27 which has a CVE -->
+     <!-- Floor for jetty-util: solr-solrj-zookeeper pulls 12.0.27 (CVE-2026-8384).
+     Not test-scoped so it propagates downstream. -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>12.0.35</version>
-      <scope>test</scope>
     </dependency>
 
     <!--  Note that this is also one of the dependencies for solr that we had to pull in manually. However,

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -64,7 +64,7 @@
     <dropwizard-core.version>5.0.2</dropwizard-core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit4.version>4.13.2</junit4.version>
-    <aws-sdk.version>2.49.4</aws-sdk.version>
+    <aws-sdk.version>2.52.1</aws-sdk.version>
     <hadoop.version>3.5.0</hadoop.version>
   </properties>
 

--- a/lucille-parent/pom.xml
+++ b/lucille-parent/pom.xml
@@ -50,7 +50,7 @@
     <opensearch.version>0.1.0</opensearch.version>
     <opensearch-java.version>3.9.0</opensearch-java.version>
     <httpcore5.version>5.4.3</httpcore5.version>
-    <httpclient5.version>5.6.2</httpclient5.version>
+    <httpclient5.version>5.6.3</httpclient5.version>
     <elasticsearch.version>9.0.0</elasticsearch.version>
     <aws-java-sdk.version>1.12.769</aws-java-sdk.version>
     <log4j.version>2.26.1</log4j.version>
@@ -58,7 +58,7 @@
     <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>
     <apache-commons-text.version>1.10.0</apache-commons-text.version>
     <protobuf.version>3.25.5</protobuf.version>
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <grpc.version>1.82.1</grpc.version>
     <!--  TODO: dropwizard-testing-junit4 is currently at 5.0.0 since 5.0.2 did not exist at time of upgrade. Bring back to use ${dropwizard-core.version} -->
     <dropwizard-core.version>5.0.2</dropwizard-core.version>


### PR DESCRIPTION
CVE bumps for lucille-core dependencies.

| Change | CVE |
|---|---|
| `httpclient5` 5.6.2 → 5.6.3 | CVE-2026-64607 |
| `netty` 4.1.136.Final → 4.1.137.Final | CVE-2026-59903 (`netty-codec-http`) |
| `jetty-http` / `jetty-util` — removed `<scope>test</scope>` | CVE-2026-2332, CVE-2026-8384 |

The two version bumps in `lucille-parent` cover the Snyk findings against `azure-storage-blob`, `awssdk:s3`, `elasticsearch-java`, `opensearch-java` and `opensearch-log4j-appender`. They were all flagged for `httpclient5` / `netty-codec-http`, so the libraries themselves don't need upgrading.

The Jetty pins were test-scoped,  every downstream module still resolved the vulnerable 12.0.27 at runtime. Removing the scope makes the updated version propagate. The pinned versions were not changed.