### PR TITLE
LC-926: Replace SynchronizedBag with ConcurrentHashMap in PublisherImpl to eliminate lock contention under multi-threaded publishing

### DIFF
--- a/application-example.conf
+++ b/application-example.conf
@@ -338,7 +338,8 @@ publisher {
   # this setting should ONLY be used in hybrid or distributed mode where the Runner is a separate process from the Workers/Indexer
   # in local mode, the queueCapcity effectively controls the number of docs that can be pending at any time
   #
-  # this is a non-strict max and can be exceeded by the number of threads calling publish()
+  # this is a non-strict max: it can be exceeded by the number of threads calling publish(), and it
+  # counts distinct document IDs (not individual occurrences when the same ID is published multiple times)
   maxPendingDocs: 80000
 }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/Publisher.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/Publisher.java
@@ -47,10 +47,11 @@ public interface Publisher {
   long numReceived();
 
   /**
-   * Returns the number of documents for which we are still awaiting a terminal event.
+   * Returns the number of distinct document IDs for which we are still awaiting a terminal event.
    *
-   * This number includes documents published via publish() as well as child documents generated
-   * during pipeline execution.
+   * This count includes documents published via publish() as well as child documents generated
+   * during pipeline execution. If the same document ID is published multiple times (e.g. in
+   * streaming mode), it is counted once here, not once per occurrence.
    */
   long numPending();
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
@@ -82,10 +82,11 @@ public class PublisherImpl implements Publisher {
 
   // Map of published document IDs that have not reached a terminal state. Also tracks children.
   // Uses ConcurrentHashMap for lock-free concurrent access from multiple publishing threads and
-  // the event-handling thread. The AtomicInteger value is a count: if two documents with the same
-  // ID are published (e.g. create + update in streaming mode, or at-least-once redelivery), we
-  // expect to receive separate terminal events for each, so each add increments and each remove
-  // decrements. The entry is evicted when the count reaches zero.
+  // the event-handling thread. The AtomicInteger value is used as a mutable int counter (its
+  // atomicity is not relied upon — all access is within compute() which holds the bin lock).
+  // If two documents with the same ID are published (e.g. create + update in streaming mode,
+  // or at-least-once redelivery), we expect to receive separate terminal events for each, so
+  // each add increments and each remove decrements. The entry is evicted when the count reaches zero.
   //
   // Note that a Publisher may be shared by a Runner and a Connector: the connector may be publishing
   // new Documents (via publish()) while the Runner is receiving Events and calling handleEvent().

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
@@ -9,13 +9,12 @@ import com.kmwllc.lucille.util.LogUtils;
 import com.typesafe.config.Config;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.Condition;
-import org.apache.commons.collections4.Bag;
-import org.apache.commons.collections4.bag.HashBag;
-import org.apache.commons.collections4.bag.SynchronizedBag;
 import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,18 +80,23 @@ public class PublisherImpl implements Publisher {
   private final ReentrantLock lockForPauseResume = new ReentrantLock();
   private volatile Condition resumeCondition = null;
 
-  // Bag of published documents that have not reached a terminal state. Also includes children of published documents.
-  // Note that this is a Bag, not a Set, because if two documents with the same ID are published, we would
-  // expect to receive two separate terminal events relating to those documents, and we will therefore make
-  // two attempts to remove the ID. Upon each removal attempt, we would like there to be something present
-  // to remove; otherwise we would classify the event as an "early" terminal event and treat it specially.
-  // Also note that a Publisher may be shared by a Runner and a Connector: the connector may be publishing
-  // new Documents while the Connector is receiving Events and calling handleEvent().
-  // publish() and handleEvent() both update docIdsToTrack so the bag should be synchronized.
-  private final Bag<String> docIdsToTrack = SynchronizedBag.synchronizedBag(new HashBag<>());
+  // Map of published document IDs that have not reached a terminal state. Also tracks children.
+  // Uses ConcurrentHashMap for lock-free concurrent access from multiple publishing threads and
+  // the event-handling thread. The AtomicInteger value is a count: if two documents with the same
+  // ID are published (e.g. create + update in streaming mode, or at-least-once redelivery), we
+  // expect to receive separate terminal events for each, so each add increments and each remove
+  // decrements. The entry is evicted when the count reaches zero.
+  //
+  // Note that a Publisher may be shared by a Runner and a Connector: the connector may be publishing
+  // new Documents (via publish()) while the Runner is receiving Events and calling handleEvent().
+  // These operations run in separate threads and both update docIdsToTrack.
+  private final ConcurrentHashMap<String, AtomicInteger> docIdsToTrack = new ConcurrentHashMap<>();
 
-  // Bag of child documents for which a terminal event has been received early, before the corresponding CREATE event
-  private final Bag<String> docIdsIndexedBeforeTracking = SynchronizedBag.synchronizedBag(new HashBag<>());
+  // Map of child document IDs for which a terminal event (FINISH/FAIL/DROP) has been received
+  // early, before the corresponding CREATE event. When a CREATE event later arrives for such a
+  // docId, we check this map first: if present, we decrement rather than adding to docIdsToTrack,
+  // since the document has already completed and doesn't need tracking.
+  private final ConcurrentHashMap<String, AtomicInteger> docIdsIndexedBeforeTracking = new ConcurrentHashMap<>();
 
   public PublisherImpl(Config config, PublisherMessenger messenger, String runId,
       String pipelineName, String metricsPrefix, boolean isCollapsing) throws Exception {
@@ -261,14 +265,14 @@ public class PublisherImpl implements Publisher {
     // As soon as the document has been sent for processing, the publisher could begin receiving Events relating to that document.
     // If the publisher quickly receives a DROP event, for example, we want to be sure that the docId has already been
     // added to docIdsToTrack so that it can be found there and removed, not mistakenly added to docIdsIndexedBeforeTracking
-    docIdsToTrack.add(docId);
+    docIdsToTrack.computeIfAbsent(docId, k -> new AtomicInteger(0)).incrementAndGet();
 
     try {
       messenger.sendForProcessing(document);
     } catch (Exception e) {
       // we assume that if an exception was encountered here, the doc was not actually made available for processing,
       // and that we won't be receiving any Events relating to it, so we can stop tracking its docId now
-      docIdsToTrack.remove(docId, 1);
+      decrementOrRemove(docIdsToTrack, docId);
       throw e;
     }
 
@@ -314,8 +318,8 @@ public class PublisherImpl implements Publisher {
       // if we're learning that a child document has been created, we need to begin tracking it unless
       // we have already received an early confirmation that it was indexed
       // TODO: this does not handle redundant create events
-      if (!docIdsIndexedBeforeTracking.remove(docId, 1)) {
-        docIdsToTrack.add(docId);
+      if (!decrementOrRemove(docIdsIndexedBeforeTracking, docId)) {
+        docIdsToTrack.computeIfAbsent(docId, k -> new AtomicInteger(0)).incrementAndGet();
       }
 
     } else {
@@ -332,13 +336,13 @@ public class PublisherImpl implements Publisher {
       // but if we weren't previously tracking it, we need to remember that we've seen it so that
       // if we receive an out-of-order or late create event for this document in the future,
       // we won't start tracking it then
-      if (!docIdsToTrack.remove(docId, 1)) {
-        docIdsIndexedBeforeTracking.add(docId);
+      if (!decrementOrRemove(docIdsToTrack, docId)) {
+        docIdsIndexedBeforeTracking.computeIfAbsent(docId, k -> new AtomicInteger(0)).incrementAndGet();
       } else {
         if (maxPendingDocs != null) {
           try {
             lockForPendingDocs.lock();
-            // since we have removed a docID from the bag of docIdsToTrack (and this is the main place where we do this),
+            // since we have removed a docID from docIdsToTrack (and this is the main place where we do this),
             // check to see if the number of pending docs has fallen below the specified max and
             // notify any threads that are waiting on that condition; specifically, notify the connector thread(s)
             // where publish() is being called
@@ -475,5 +479,25 @@ public class PublisherImpl implements Publisher {
 
   public Integer getMaxPendingDocs() {
     return maxPendingDocs;
+  }
+
+  /**
+   * Decrements the count for the given key in the map and removes the entry if the count reaches
+   * zero. Returns true if the key was present (and decremented), false otherwise.
+   *
+   * Called from publish threads (error path in sendForProcessing) and the event-handling thread
+   * (handleEvent). Concurrent calls on different keys are fully safe (ConcurrentHashMap). Concurrent
+   * calls on the same key are safe in practice: AtomicInteger.decrementAndGet() is atomic, and if
+   * two threads both see count <= 0 and call map.remove(), the second remove is a no-op.
+   */
+  private static boolean decrementOrRemove(ConcurrentHashMap<String, AtomicInteger> map, String key) {
+    AtomicInteger count = map.get(key);
+    if (count == null) {
+      return false;
+    }
+    if (count.decrementAndGet() <= 0) {
+      map.remove(key);
+    }
+    return true;
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/PublisherImpl.java
@@ -265,7 +265,11 @@ public class PublisherImpl implements Publisher {
     // As soon as the document has been sent for processing, the publisher could begin receiving Events relating to that document.
     // If the publisher quickly receives a DROP event, for example, we want to be sure that the docId has already been
     // added to docIdsToTrack so that it can be found there and removed, not mistakenly added to docIdsIndexedBeforeTracking
-    docIdsToTrack.computeIfAbsent(docId, k -> new AtomicInteger(0)).incrementAndGet();
+    docIdsToTrack.compute(docId, (k, count) -> {
+      if (count == null) return new AtomicInteger(1);
+      count.incrementAndGet();
+      return count;
+    });
 
     try {
       messenger.sendForProcessing(document);
@@ -319,7 +323,11 @@ public class PublisherImpl implements Publisher {
       // we have already received an early confirmation that it was indexed
       // TODO: this does not handle redundant create events
       if (!decrementOrRemove(docIdsIndexedBeforeTracking, docId)) {
-        docIdsToTrack.computeIfAbsent(docId, k -> new AtomicInteger(0)).incrementAndGet();
+        docIdsToTrack.compute(docId, (k, count) -> {
+          if (count == null) return new AtomicInteger(1);
+          count.incrementAndGet();
+          return count;
+        });
       }
 
     } else {
@@ -337,7 +345,11 @@ public class PublisherImpl implements Publisher {
       // if we receive an out-of-order or late create event for this document in the future,
       // we won't start tracking it then
       if (!decrementOrRemove(docIdsToTrack, docId)) {
-        docIdsIndexedBeforeTracking.computeIfAbsent(docId, k -> new AtomicInteger(0)).incrementAndGet();
+        docIdsIndexedBeforeTracking.compute(docId, (k, count) -> {
+          if (count == null) return new AtomicInteger(1);
+          count.incrementAndGet();
+          return count;
+        });
       } else {
         if (maxPendingDocs != null) {
           try {
@@ -482,22 +494,25 @@ public class PublisherImpl implements Publisher {
   }
 
   /**
-   * Decrements the count for the given key in the map and removes the entry if the count reaches
-   * zero. Returns true if the key was present (and decremented), false otherwise.
+   * Atomically decrements the count for the given key in the map and removes the entry if the
+   * count reaches zero. Returns true if the key was present (and decremented), false otherwise.
+   *
+   * Uses compute() to hold the bin lock for the key during the entire read-modify-write, preventing
+   * a concurrent increment from interleaving between the decrement and the removal.
    *
    * Called from publish threads (error path in sendForProcessing) and the event-handling thread
    * (handleEvent). Concurrent calls on different keys are fully safe (ConcurrentHashMap). Concurrent
-   * calls on the same key are safe in practice: AtomicInteger.decrementAndGet() is atomic, and if
-   * two threads both see count <= 0 and call map.remove(), the second remove is a no-op.
+   * calls on the same key are safe because compute() serializes them per bin.
    */
   private static boolean decrementOrRemove(ConcurrentHashMap<String, AtomicInteger> map, String key) {
-    AtomicInteger count = map.get(key);
-    if (count == null) {
-      return false;
-    }
-    if (count.decrementAndGet() <= 0) {
-      map.remove(key);
-    }
-    return true;
+    // single-element array allows the lambda to communicate a result back to the caller,
+    // since Java lambdas cannot assign to local variables from the enclosing scope
+    boolean[] wasPresent = {false};
+    map.compute(key, (k, count) -> {
+      if (count == null) return null;
+      wasPresent[0] = true;
+      return count.decrementAndGet() <= 0 ? null : count;
+    });
+    return wasPresent[0];
   }
 }

--- a/lucille-core/src/test/java/com/kmwllc/lucille/core/PublisherImplTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/core/PublisherImplTest.java
@@ -138,14 +138,17 @@ public class PublisherImplTest {
 
     publisher.publish(Document.create("doc1"));
     assertEquals(2, publisher.numPublished());
-    assertEquals(2, publisher.numPending());
+    // numPending reports distinct document IDs being tracked, not total occurrences;
+    // "doc1" is tracked once (with a count of 2 internally)
+    assertEquals(1, publisher.numPending());
 
     Event finishEvent = new Event(doc.getId(), "run1", "", Event.Type.FINISH);
     publisher.handleEvent(finishEvent);
     assertEquals(2, publisher.numPublished());
+    // still pending: internal count decremented from 2 to 1
     assertEquals(1, publisher.numPending());
 
-    publisher.handleEvent(finishEvent); // redundant finish event
+    publisher.handleEvent(finishEvent); // second finish event clears the entry
     assertEquals(2, publisher.numPublished());
     assertEquals(0, publisher.numPending());
   }


### PR DESCRIPTION
This PR aims to improve publishing throughput in the context of a fast, multi-threaded connector.

Previously, PublisherImpl's `docIdsToTrack` (and `docIdsIndexedBeforeTracking`) used a `SynchronizedBag` — a single-mutex wrapper around a `HashBag`. Only one publishing thread could add a new document ID to the tracking structure at a time, regardless of whether the IDs were different. Every `publish()` call acquired the same lock, serializing all publishing threads against each other and against the event-handling thread.

With this change, the tracking structures use `ConcurrentHashMap<String, AtomicInteger>`. Multiple threads can add, remove, or check distinct document IDs concurrently without acquiring a shared lock. Contention only occurs when two threads operate on the *same* key simultaneously, which is rare in practice.

This improvement is most likely to be impactful when publishing is very fast — for example, a multi-threaded connector generating lightweight documents with minimal I/O per document. In slower publishing scenarios where each thread spends most of its time doing connector work (HTTP fetches, database queries, file reads), the previous lock contention would not have been an observable bottleneck.

The original `SynchronizedBag` was introduced as a performance improvement over a `Collections.synchronizedList` (O(1) removal by value vs. O(n)) before the codebase supported multi-threaded publishing. When multi-threaded publishing was added later, the existing synchronized structure was inherited. This change is a natural follow-up to multi-threaded publishing support.

`numPending()` now reports the number of distinct document IDs being tracked, rather than the sum of all occurrence counts. Preserving the old behavior with the new data structure would require iterating the entire map and summing all `AtomicInteger` values on every call — unnecessary overhead for a value that is checked frequently (every event-poll iteration in `waitForCompletion`, every `publish()` call when `maxPendingDocs` is configured). The new semantics use `ConcurrentHashMap.size()` directly. This only differs from the old behavior when the same document ID is published multiple times (e.g. streaming-mode create/update sequences or at-least-once redelivery). The `maxPendingDocs` threshold is documented as non-strict and is unaffected in practice.