### PR TITLE
LC-925: Tika Performance Improvement

### DIFF
--- a/doc/site/content/en/docs/ingest-design/stages/all-stages.md
+++ b/doc/site/content/en/docs/ingest-design/stages/all-stages.md
@@ -521,7 +521,9 @@ Measures the byte size of a field value (e.g., a byte array or string) and store
 
 `com.kmwllc.lucille.tika.stage.TextExtractor` *(requires `lucille-tika`)*
 
-Extracts text from over 1,000 file formats — PDF, Microsoft Office documents, HTML, images with embedded OCR, and many more — using [Apache Tika](https://tika.apache.org/). Reads raw bytes from a source field and writes extracted text to a destination field.
+Extracts text from over 1,000 file formats — PDF, Microsoft Office documents, HTML, images with embedded OCR, and many more — using [Apache Tika](https://tika.apache.org/). Reads a file (from a path or raw bytes on the document) and writes the extracted text and metadata back onto the document.
+
+Provide exactly one of `filePathField` or `byteArrayField` as the source.
 
 **Maven dependency:**
 ```xml
@@ -532,14 +534,34 @@ Extracts text from over 1,000 file formats — PDF, Microsoft Office documents, 
 </dependency>
 ```
 
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `filePathField` | String | One of `filePathField`/`byteArrayField` | Document field holding the path to the file to parse. |
+| `byteArrayField` | String | One of `filePathField`/`byteArrayField` | Document field holding the file's raw bytes to parse. |
+| `textField` | String | No | Destination field for the extracted text. Defaults to `text`. |
+| `metadataPrefix` | String | No | Prefix applied to fields holding extracted metadata. Defaults to `tika`. |
+| `textContentLimit` | Integer | No | Maximum number of characters of extracted text; text beyond this is truncated. Defaults to unlimited. |
+| `parseTimeout` | Long | No | Timeout for parsing a single document, in milliseconds. |
+| `tikaConfigPath` | String | No | Path to a Tika config file. If omitted, a default `AutoDetectParser` is used. A provided config is applied to embedded documents as well as the top-level document. |
+| `skipEmbeddedContentTypePrefixes` | List\<String\> | No | Content-type prefixes for which embedded documents are skipped (not parsed), e.g. `["image/"]`. Defaults to empty (all embedded documents are parsed). Embedded parts with no content type are always parsed. |
+| `whitelist` | List\<String\> | No | Metadata names to include in the document. |
+| `blacklist` | List\<String\> | No | Metadata names to exclude from the document. |
+| `fieldNamesField` | String | No | If set, each extracted metadata field's prefixed name is added as a value to this multi-valued field. |
+| `metadataFields` | Map | No | Maps Tika metadata keys to document field names whose values are supplied to Tika as detection hints before parsing (e.g. `resourceName`, `Content-Type`). |
+| `fork` | Map | No | Runs parsing in a child JVM via Tika's `ForkParser` to isolate crashes. Keys: `enabled` (Boolean), `poolSize` (Integer), `jvmArgs` (List\<String\>), `serverPulseMillis` (Long). |
+| `s3` / `azure` / `gcp` | Map | No | Credentials for reading `filePathField` files from cloud storage. See the [File Connector]({{< relref "docs/ingest-design/connectors/file_connector" >}}) for the arguments. |
+
 ```hocon
 {
   name: "extract-text"
   class: "com.kmwllc.lucille.tika.stage.TextExtractor"
-  source: "file_content"
-  dest: "extracted_text"
+  byteArrayField: "file_content"
+  textField: "extracted_text"
 }
 ```
+
+Tika can be an intensive process. There are some small alterations we have made within the stage to improve its throughput; if
+you are working closely with `TextExtractor` and focused on performance, you may want to look into these a bit closer.
 
 ---
 

--- a/doc/site/content/en/docs/ingest-design/stages/all-stages.md
+++ b/doc/site/content/en/docs/ingest-design/stages/all-stages.md
@@ -543,7 +543,7 @@ Provide exactly one of `filePathField` or `byteArrayField` as the source.
 | `textContentLimit` | Integer | No | Maximum number of characters of extracted text; text beyond this is truncated. Defaults to unlimited. |
 | `parseTimeout` | Long | No | Timeout for parsing a single document, in milliseconds. |
 | `tikaConfigPath` | String | No | Path to a Tika config file. If omitted, a default `AutoDetectParser` is used. A provided config is applied to embedded documents as well as the top-level document. |
-| `skipEmbeddedContentTypePrefixes` | List\<String\> | No | Content-type prefixes for which embedded documents are skipped (not parsed), e.g. `["image/"]`. Defaults to empty (all embedded documents are parsed). Embedded parts with no content type are always parsed. |
+| `skipEmbeddedContentTypePrefixes` | List\<String\> | No | Content-type prefixes for which embedded documents are skipped (not parsed), e.g. `["image/"]`. Defaults to empty (all embedded documents are parsed). Embedded parts with no content type are always parsed. Not supported with `fork`. |
 | `whitelist` | List\<String\> | No | Metadata names to include in the document. |
 | `blacklist` | List\<String\> | No | Metadata names to exclude from the document. |
 | `fieldNamesField` | String | No | If set, each extracted metadata field's prefixed name is added as a value to this multi-valued field. |

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/EmbeddedContentTypeSelector.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/EmbeddedContentTypeSelector.java
@@ -1,0 +1,43 @@
+package com.kmwllc.lucille.tika.stage;
+
+import java.util.List;
+import org.apache.tika.extractor.DocumentSelector;
+import org.apache.tika.metadata.Metadata;
+
+/**
+ * A Tika {@link DocumentSelector} that skips embedded documents whose content type starts with one
+ * of a configured set of prefixes. Tika consults the selector before opening each embedded part, so
+ * skipping avoids the stream open, detection, and parse for that part entirely.
+ *
+ * <p>Driven by {@link TextExtractor}'s {@code skipEmbeddedContentTypePrefixes} config. A common use
+ * is {@code ["image/"]} to skip embedded images when only text is wanted.
+ *
+ * <p>A null content type always returns {@code true} (parse), regardless of the configured prefixes:
+ * some embedded parts (e.g. OLE 1.0 native documents) never set a content type, and skipping on null
+ * would silently drop them.
+ */
+final class EmbeddedContentTypeSelector implements DocumentSelector {
+
+  private final List<String> skipContentTypePrefixes;
+
+  EmbeddedContentTypeSelector(List<String> skipContentTypePrefixes) {
+    if (skipContentTypePrefixes == null) {
+      throw new IllegalArgumentException("skipContentTypePrefixes must not be null");
+    }
+    this.skipContentTypePrefixes = List.copyOf(skipContentTypePrefixes);
+  }
+
+  @Override
+  public boolean select(Metadata metadata) {
+    String contentType = metadata.get(Metadata.CONTENT_TYPE);
+    if (contentType == null) {
+      return true;
+    }
+    for (String prefix : skipContentTypePrefixes) {
+      if (contentType.startsWith(prefix)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/EmbeddedContentTypeSelector.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/EmbeddedContentTypeSelector.java
@@ -24,20 +24,24 @@ final class EmbeddedContentTypeSelector implements DocumentSelector {
     if (skipContentTypePrefixes == null) {
       throw new IllegalArgumentException("skipContentTypePrefixes must not be null");
     }
+
     this.skipContentTypePrefixes = List.copyOf(skipContentTypePrefixes);
   }
 
   @Override
   public boolean select(Metadata metadata) {
     String contentType = metadata.get(Metadata.CONTENT_TYPE);
+
     if (contentType == null) {
       return true;
     }
+
     for (String prefix : skipContentTypePrefixes) {
       if (contentType.startsWith(prefix)) {
         return false;
       }
     }
+
     return true;
   }
 }

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -374,6 +374,11 @@ public class TextExtractor extends Stage {
       } catch (TimeoutException e) {
         future.cancel(true);
         log.warn("Tika parsing timed out after {} ms", parseTimeout);
+        // future.cancel() doesn't stop a parse thread (may be stuck), but discard + recreate does -
+        // prevent zombie thread / blocking queued documents
+        executorService.shutdownNow();
+        executorService = Executors.newSingleThreadExecutor();
+        handleParseTimeout(inputStream);
       } catch (Exception e) {
         log.warn("Error during async Tika parsing: {}", e.getMessage());
       }
@@ -394,6 +399,13 @@ public class TextExtractor extends Stage {
         }
       }
     }
+  }
+
+  /**
+   * Hook invoked when a parse attempt times out, after the executor has been discarded and recreated.
+   * No-op by default; subclasses can override it, e.g. to record metrics on the timed-out document.
+   */
+  protected void handleParseTimeout(InputStream inputStream) {
   }
 
   private void parse(Document doc, InputStream inputStream, Metadata metadata, ContentHandler bch) throws StageException {

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -48,7 +48,9 @@ import org.xml.sax.SAXException;
  * filePathField (String, Optional) : name of field from which file path can be extracted, if filePathField
  * and byteArrayField both not provided, stage will do nothing
  * byteArrayField (String, Optional) : name of field from which byte array data can be extracted
- * tikaConfigPath (String, Optional) : path to tika config, if not provided will default to empty AutoDetectParser
+ * tikaConfigPath (String, Optional) : path to tika config, if not provided will default to empty AutoDetectParser.
+ * A provided config is applied to embedded documents as well as the top-level document; without one, Tika parses
+ * embedded documents with its default config.
  * metadataPrefix (String, Optional) : prefix to be appended to fields for metadata information extracted after parsing
  * textContentLimit (Integer, Optional) : limits how large the content of the returned text can be
  * parseTimeout (Long, Optional) : timeout for parsing in milliseconds.
@@ -190,13 +192,10 @@ public class TextExtractor extends Stage {
       }
     }
 
-    // we use an auto detect parser whether we are forking or not
-    AutoDetectParser autoParser;
-    if (this.tikaConfigPath == null) {
-      autoParser = new AutoDetectParser();
-    } else {
-      autoParser = new AutoDetectParser(getTikaConfig());
-    }
+    // we use an auto detect parser whether we are forking or not. A null path uses Tika's default
+    // config, which is what new AutoDetectParser() would build internally anyway.
+    TikaConfig tikaConfig = this.tikaConfigPath == null ? TikaConfig.getDefaultConfig() : getTikaConfig();
+    AutoDetectParser autoParser = new AutoDetectParser(tikaConfig);
 
     if (forkEnabled) {
       forkParser = new ForkParser(TextExtractor.class.getClassLoader(), autoParser);
@@ -210,6 +209,10 @@ public class TextExtractor extends Stage {
     } else {
       parser = autoParser;
       parseCtx.set(Parser.class, parser);
+      // Without a TikaConfig in the context, Tika builds a fresh one (an expensive operation) for
+      // every embedded document, so we set ours here to reuse it. We don't set it in the fork case
+      // since TikaConfig isn't Serializable and the context is sent to the child JVM.
+      parseCtx.set(TikaConfig.class, tikaConfig);
       if (parseTimeout != null) {
         // each worker is running in a single thread so we only need to run the extraction with a
         // single thread executor rather than using a thread pool.

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -186,6 +186,10 @@ public class TextExtractor extends Stage {
     if (filePathField == null && byteArrayField == null) {
       throw new StageException("Provided neither a filePathField nor byteArrayField to the TextExtractor stage");
     }
+    // DocumentSelector can't cross the fork boundary (not Serializable), so skipping can't be applied there.
+    if (forkEnabled && !skipEmbeddedContentTypePrefixes.isEmpty()) {
+      throw new StageException("skipEmbeddedContentTypePrefixes is not supported when fork.enabled is true.");
+    }
     parseCtx = new ParseContext();
 
     this.fileFetcher = FileContentFetcher.create(config);
@@ -402,6 +406,8 @@ public class TextExtractor extends Stage {
         executorService.shutdownNow();
         executorService = Executors.newSingleThreadExecutor();
         handleParseTimeout(inputStream);
+        // the parse thread may still be writing to bch/metadata, so don't read them.
+        return;
       } catch (Exception e) {
         log.warn("Error during async Tika parsing: {}", e.getMessage());
       }

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -109,6 +110,16 @@ public class TextExtractor extends Stage {
       Arrays.asList("java", "-Djava.awt.headless=true");
 
   private static final Logger log = LoggerFactory.getLogger(TextExtractor.class);
+
+  // Building TikaConfigs from files is expensive, so we cache these configs across the JVM.
+  // This is particularly helpful in multi-threaded runs, where each thread has its own instance of
+  // TextExtractor but is using the same TikaConfig.
+  // The cache is bounded by MAX_CACHED_CONFIGS. It is a "soft cap" - once it is reached,
+  // no additional TikaConfigs will be cached.
+  // Canonical paths are used as keys to prevent unwarranted collisions.
+  private static final int MAX_CACHED_CONFIGS = 100;
+  private static final ConcurrentHashMap<String, TikaConfig> TIKA_CONFIG_CACHE = new ConcurrentHashMap<>();
+
   private String textField;
   private String filePathField;
   private String tikaConfigPath;
@@ -184,13 +195,7 @@ public class TextExtractor extends Stage {
     if (this.tikaConfigPath == null) {
       autoParser = new AutoDetectParser();
     } else {
-      try {
-        File f = new File(this.tikaConfigPath);
-        TikaConfig tc = new TikaConfig(f);
-        autoParser = new AutoDetectParser(tc);
-      } catch (Exception e) {
-        throw new StageException("Error starting TextExtractor stage.", e);
-      }
+      autoParser = new AutoDetectParser(getTikaConfig());
     }
 
     if (forkEnabled) {
@@ -210,6 +215,40 @@ public class TextExtractor extends Stage {
         // single thread executor rather than using a thread pool.
         executorService = Executors.newSingleThreadExecutor();
       }
+    }
+  }
+
+  /**
+   * Returns the {@link TikaConfig} for this stage's configured {@code tikaConfigPath}, building it at
+   * most once per distinct config file across the JVM (see {@link #TIKA_CONFIG_CACHE}).
+   */
+  private TikaConfig getTikaConfig() throws StageException {
+    try {
+      // Canonical paths used to prevent errors (if relative paths are used in a distributed environment, for example)
+      String key = new File(tikaConfigPath).getCanonicalPath();
+      TikaConfig cached = TIKA_CONFIG_CACHE.get(key);
+      if (cached != null) {
+        return cached;
+      }
+
+      // Currently uses just a soft cap, since the number of unique Tika configs should be relatively low
+      if (TIKA_CONFIG_CACHE.size() >= MAX_CACHED_CONFIGS) {
+        return new TikaConfig(new File(key));
+      }
+
+      // computeIfAbsent so concurrent workers requesting the same path build it only once; a failed
+      // build propagates out and is never cached.
+      return TIKA_CONFIG_CACHE.computeIfAbsent(key, path -> {
+        try {
+          return new TikaConfig(new File(path));
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+    } catch (RuntimeException e) {
+      throw new StageException("Error starting TextExtractor stage.", e.getCause() != null ? e.getCause() : e);
+    } catch (Exception e) {
+      throw new StageException("Error starting TextExtractor stage.", e);
     }
   }
 

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.extractor.DocumentSelector;
+import org.apache.tika.exception.WriteLimitReachedException;
 import org.apache.tika.fork.ForkParser;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -54,6 +56,9 @@ import org.xml.sax.SAXException;
  * metadataPrefix (String, Optional) : prefix to be appended to fields for metadata information extracted after parsing
  * textContentLimit (Integer, Optional) : limits how large the content of the returned text can be
  * parseTimeout (Long, Optional) : timeout for parsing in milliseconds.
+ * skipEmbeddedContentTypePrefixes (List&lt;String&gt;, Optional) : content-type prefixes for which embedded documents are
+ * skipped (not parsed), e.g. ["image/"] to skip embedded images. Defaults to empty (all embedded documents parsed).
+ * Embedded parts with no content type are always parsed.
  * whitelist (List&lt;String&gt;, Optional) : list of metadata names that are to be included in document
  * blacklist (List&lt;String&gt;, Optional) : list of metadata names that are not to be included in document
  * fieldNamesField (String, Optional) : if set, each extracted metadata field's prefixed name is added as a separate value to this
@@ -104,6 +109,7 @@ public class TextExtractor extends Stage {
       .optionalList("whitelist", new TypeReference<List<String>>() {})
       .optionalList("blacklist", new TypeReference<List<String>>() {})
       .optionalNumber("textContentLimit", "parseTimeout")
+      .optionalList("skipEmbeddedContentTypePrefixes", new TypeReference<List<String>>() {})
       .optionalParent(FORK_SPEC, FileConnector.S3_PARENT_SPEC, FileConnector.GCP_PARENT_SPEC, FileConnector.AZURE_PARENT_SPEC)
       .optionalParent("metadataFields", new TypeReference<Map<String, Object>>() {})
       .include(FileContentFetcher.SPEC).build();
@@ -141,6 +147,7 @@ public class TextExtractor extends Stage {
   private ExecutorService executorService;
   private final FieldFilter fieldFilter;
   private final Map<String, Object> metadataFields;
+  private final List<String> skipEmbeddedContentTypePrefixes;
 
   public TextExtractor(Config config) throws StageException {
     super(config);
@@ -154,6 +161,9 @@ public class TextExtractor extends Stage {
     parseTimeout = config.hasPath("parseTimeout") ? config.getLong("parseTimeout") : null;
     fieldNamesField = config.hasPath("fieldNamesField") ? config.getString("fieldNamesField") : null;
     metadataFields = config.hasPath("metadataFields") ? config.getConfig("metadataFields").root().unwrapped() : null;
+    skipEmbeddedContentTypePrefixes = config.hasPath("skipEmbeddedContentTypePrefixes")
+        ? config.getStringList("skipEmbeddedContentTypePrefixes")
+        : List.of();
 
     forkEnabled = ConfigUtils.getOrDefault(config, "fork.enabled", false);
     forkPoolSize = ConfigUtils.getOrDefault(config, "fork.poolSize", 5);
@@ -213,6 +223,13 @@ public class TextExtractor extends Stage {
       // every embedded document, so we set ours here to reuse it. We don't set it in the fork case
       // since TikaConfig isn't Serializable and the context is sent to the child JVM.
       parseCtx.set(TikaConfig.class, tikaConfig);
+      // Skip parsing embedded documents whose content type matches a configured prefix, avoiding
+      // their stream open, detection, and parse entirely. Only set when configured, so the default
+      // (empty) leaves Tika's normal behavior unchanged. Non-fork only, alongside the other context
+      // hints above.
+      if (!skipEmbeddedContentTypePrefixes.isEmpty()) {
+        parseCtx.set(DocumentSelector.class, new EmbeddedContentTypeSelector(skipEmbeddedContentTypePrefixes));
+      }
       if (parseTimeout != null) {
         // each worker is running in a single thread so we only need to run the extraction with a
         // single thread executor rather than using a thread pool.
@@ -374,6 +391,12 @@ public class TextExtractor extends Stage {
       } catch (TimeoutException e) {
         future.cancel(true);
         log.warn("Tika parsing timed out after {} ms", parseTimeout);
+        // close the stream to abort a parse blocked on a stream read (the common hang case)
+        try {
+          inputStream.close();
+        } catch (IOException ioe) {
+          log.warn("Error closing input stream after parse timeout", ioe);
+        }
         // future.cancel() doesn't stop a parse thread (may be stuck), but discard + recreate does -
         // prevent zombie thread / blocking queued documents
         executorService.shutdownNow();
@@ -412,10 +435,15 @@ public class TextExtractor extends Stage {
     try {
       parser.parse(inputStream, bch, metadata, parseCtx);
     } catch (IOException | SAXException | TikaException e) {
-      if (forkEnabled) {
+      // We expect truncation when textContentLimit is reached.
+      // It is best to check this condition because exceptions tend to be rewrapped. 
+      if (WriteLimitReachedException.isWriteLimitReached(e)) {
+        log.debug("textContentLimit ({}) reached; extracted text truncated.", textContentLimit);
+      } else if (forkEnabled) {
         throw new StageException("Forked Tika process failed for document: " + doc.getId(), e);
+      } else {
+        log.warn("Tika Exception: {}", e.getMessage());
       }
-      log.warn("Tika Exception: {}", e.getMessage());
     }
   }
 }

--- a/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
+++ b/lucille-plugins/lucille-tika/src/main/java/com/kmwllc/lucille/tika/stage/TextExtractor.java
@@ -125,7 +125,7 @@ public class TextExtractor extends Stage {
   // The cache is bounded by MAX_CACHED_CONFIGS. It is a "soft cap" - once it is reached,
   // no additional TikaConfigs will be cached.
   // Canonical paths are used as keys to prevent unwarranted collisions.
-  private static final int MAX_CACHED_CONFIGS = 100;
+  private static final int MAX_CACHED_CONFIGS = 1000;
   private static final ConcurrentHashMap<String, TikaConfig> TIKA_CONFIG_CACHE = new ConcurrentHashMap<>();
 
   private String textField;

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/EmbeddedContentTypeSelectorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/EmbeddedContentTypeSelectorTest.java
@@ -1,0 +1,62 @@
+package com.kmwllc.lucille.tika.stage;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.apache.tika.metadata.Metadata;
+import org.junit.Test;
+
+public class EmbeddedContentTypeSelectorTest {
+
+  private static Metadata withContentType(String contentType) {
+    Metadata metadata = new Metadata();
+    if (contentType != null) {
+      metadata.set(Metadata.CONTENT_TYPE, contentType);
+    }
+    return metadata;
+  }
+
+  @Test
+  public void testSkipsMatchingPrefix() {
+    EmbeddedContentTypeSelector selector = new EmbeddedContentTypeSelector(List.of("image/"));
+    assertFalse(selector.select(withContentType("image/png")));
+    assertFalse(selector.select(withContentType("image/emf")));
+  }
+
+  @Test
+  public void testParsesNonMatchingPrefix() {
+    EmbeddedContentTypeSelector selector = new EmbeddedContentTypeSelector(List.of("image/"));
+    assertTrue(selector.select(withContentType("application/pdf")));
+    assertTrue(selector.select(withContentType("text/plain")));
+  }
+
+  @Test
+  public void testNullContentTypeAlwaysParses() {
+    // A null content type must be parsed regardless of prefixes, so embedded parts that never set a
+    // content type (e.g. OLE native documents) aren't silently dropped.
+    EmbeddedContentTypeSelector selector = new EmbeddedContentTypeSelector(List.of("image/"));
+    assertTrue(selector.select(withContentType(null)));
+  }
+
+  @Test
+  public void testEmptyPrefixesParsesEverything() {
+    EmbeddedContentTypeSelector selector = new EmbeddedContentTypeSelector(List.of());
+    assertTrue(selector.select(withContentType("image/png")));
+    assertTrue(selector.select(withContentType(null)));
+  }
+
+  @Test
+  public void testNullPrefixesThrows() {
+    assertThrows(IllegalArgumentException.class, () -> new EmbeddedContentTypeSelector(null));
+  }
+
+  @Test
+  public void testMultiplePrefixes() {
+    EmbeddedContentTypeSelector selector = new EmbeddedContentTypeSelector(List.of("image/", "audio/"));
+    assertFalse(selector.select(withContentType("image/jpeg")));
+    assertFalse(selector.select(withContentType("audio/mpeg")));
+    assertTrue(selector.select(withContentType("video/mp4")));
+  }
+}

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -572,6 +572,18 @@ public class TextExtractorTest {
   }
 
   @Test
+  public void testForkingSizeLimit() throws Exception {
+    // Hitting textContentLimit should be treated as expected truncation, not a document failure,
+    // even in fork mode where the write-limit exception crosses the child-JVM boundary.
+    Stage stage = factory.get("TextExtractorTest/forking-sizelimit.conf");
+    Document doc = Document.create("doc1");
+    byte[] fileContent = Files.readAllBytes(Paths.get("src/test/resources/TextExtractorTest/tika.txt"));
+    doc.setField("byte_array", fileContent);
+    stage.processDocument(doc);
+    assertEquals("Hi ", doc.getString("text"));
+  }
+
+  @Test
   public void testForkingParser() throws Exception {
     Stage stage = factory.get("TextExtractorTest/forking.conf");
     Document doc = Document.create("doc1");

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -603,6 +605,41 @@ public class TextExtractorTest {
     doc3.setField("content", tikaTxtBytes);
     stage.processDocument(doc3);
     assertEquals("Hi There!\n", doc3.getString("text"));
+  }
+
+  /**
+   * Sanity check that a TikaConfig is built once per config path and reused across stage instances,
+   * rather than rebuilt for every stage (as would happen with each worker thread in a real run).
+   */
+  @Test
+  public void testTikaConfigCaching() throws Exception {
+    // Clear the JVM-wide cache so this test doesn't depend on ordering with other tests, and so we
+    // don't leave a mock config behind for them afterward.
+    Field cacheField = TextExtractor.class.getDeclaredField("TIKA_CONFIG_CACHE");
+    cacheField.setAccessible(true);
+    Map<?, ?> cache = (Map<?, ?>) cacheField.get(null);
+    cache.clear();
+
+    // AutoDetectParser(TikaConfig) reads these four getters off the config, so delegate them to a
+    // real default config to let the mock stand in without changing what the stage builds.
+    TikaConfig realConfig = TikaConfig.getDefaultConfig();
+    try (MockedConstruction<TikaConfig> mockedConstruction = mockConstruction(TikaConfig.class,
+        (mock, context) -> {
+          when(mock.getMediaTypeRegistry()).thenReturn(realConfig.getMediaTypeRegistry());
+          when(mock.getParser()).thenReturn(realConfig.getParser());
+          when(mock.getDetector()).thenReturn(realConfig.getDetector());
+          when(mock.getAutoDetectParserConfig()).thenReturn(realConfig.getAutoDetectParserConfig());
+        })) {
+      // Two stages pointing at the same tikaConfigPath, as two worker threads would each be. Each
+      // factory.get(...) calls start(), which is what resolves the config.
+      factory.get("TextExtractorTest/tika-config.conf");
+      factory.get("TextExtractorTest/tika-config.conf");
+
+      // The config is built for the first stage and served from the cache for the second.
+      assertEquals(1, mockedConstruction.constructed().size());
+    } finally {
+      cache.clear();
+    }
   }
 
   /**

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -572,6 +572,17 @@ public class TextExtractorTest {
   }
 
   @Test
+  public void testSkipEmbeddedWithForkThrows() {
+    // DocumentSelector can't cross the fork boundary, so this combination is rejected at construction.
+    Map<String, Object> config = Map.of(
+        "class", "com.kmwllc.lucille.tika.stage.TextExtractor",
+        "byteArrayField", "byte_array",
+        "skipEmbeddedContentTypePrefixes", List.of("image/"),
+        "fork", Map.of("enabled", true));
+    assertThrows(StageException.class, () -> factory.get(config));
+  }
+
+  @Test
   public void testForkingSizeLimit() throws Exception {
     // Hitting textContentLimit should be treated as expected truncation, not a document failure,
     // even in fork mode where the write-limit exception crosses the child-JVM boundary.

--- a/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
+++ b/lucille-plugins/lucille-tika/src/test/java/com/kmwllc/lucille/tika/stage/TextExtractorTest.java
@@ -552,8 +552,9 @@ public class TextExtractorTest {
     // If timeout works, it should have returned within much less than our 5 sec. max
     // and interrupted should be true (if we interrupt the thread)
     assertTrue("Parser should have been interrupted", InterruptTrackingParser.interrupted.get());
-    // Document should not have text (or at least not from the parser)
-    assertEquals("Document should have empty text.", "", doc.getString("text"));
+    // On timeout we don't read the shared handler (the parse thread may still be writing to it), so
+    // the text field is left unset rather than populated with partial output.
+    assertFalse("Document should not have text on timeout.", doc.has("text"));
 
     stage.stop();
 

--- a/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/forking-sizelimit.conf
+++ b/lucille-plugins/lucille-tika/src/test/resources/TextExtractorTest/forking-sizelimit.conf
@@ -1,0 +1,9 @@
+{
+  class = "com.kmwllc.lucille.tika.stage.TextExtractor"
+  textField = "text"
+  byteArrayField = "byte_array"
+  textContentLimit = 3
+  fork {
+    enabled: true
+  }
+}


### PR DESCRIPTION
This PR introduces a number of improvements to the `TextExtractor` Stage, a number of which are performance-related workarounds for certain Tika use cases:

- Introduces the ability to skip certain types of embedded content types. Currently only works with the non-forked parser. 
- Creates a fixed size (1,000) cache for Tika Configs, since reading them from a file can be expensive. This is a very elementary cache that should support a number of use cases and does not have unbounded growth.
- Calling `parseCtx.set(TikaConfig.class, tikaConfig)`. This prevents a `new TikaConfig()` from being created for every embedded document. Perhaps the only change that users may need to be aware of - if they were reliant on the fact that Tika used the default config for their embedded documents. 
- `handleParseTimeout` hook / callback for subclasses
- Improved timeout handling: close the stream and discard + recreate the executor on timeout to prevent blocking documents / zombie threads 
- Better handling of a `WriteLimitReachedException` - when `textContentLimit` is reached