### PR TITLE
LC-815: Add optional multithreaded traversal to FileConnector

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -10,9 +10,17 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.kmwllc.lucille.util.ThreadNameUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.kmwllc.lucille.connector.storageclient.BaseFileReference;
@@ -45,6 +53,8 @@ import com.typesafe.config.Config;
  * <ul>
  *   <li>paths (List&lt;String&gt;, Required) : Paths or URIs to traverse (local paths or cloud storage URIs). s3 URIs must be
  *   percent-encoded; unencoded spaces or special characters will not be recognized. For example, use s3://test/folder%20with%20spaces.</li>
+ *   <li>multithreaded (Boolean, Optional) : Traverse each of the paths concurrently, on its own thread. Only applies
+ *   when more than one path is given; Requires that the paths do not overlap. Defaults to false.</li>>
  *   <li>filterOptions.includes (List&lt;String&gt;, Optional) : Regex patterns to include files.</li>
  *   <li>filterOptions.excludes (List&lt;String&gt;, Optional) : Regex patterns to exclude files.</li>
  *   <li>filterOptions.pathsToSkip (List&lt;String&gt;, Optional) : URIs of paths to directories that should be skipped and not traversed.</li>
@@ -123,6 +133,7 @@ public class FileConnector extends AbstractConnector {
 
   public static final Spec SPEC = SpecBuilder.connector()
       .requiredList("paths", new TypeReference<List<String>>(){})
+      .optionalBoolean("multithreaded")
       .optionalParent(
           SpecBuilder.parent("filterOptions")
               .optionalList("includes", new TypeReference<List<String>>(){})
@@ -147,8 +158,12 @@ public class FileConnector extends AbstractConnector {
 
   private final FileConnectorStateManager stateManager;
 
+  private final boolean multithreaded;
+
   public FileConnector(Config config) throws ConnectorException {
     super(config);
+
+    this.multithreaded = ConfigUtils.getOrDefault(config, "multithreaded", false);
 
     List<String> paths = config.getStringList("paths");
     this.storageURIs = new ArrayList<>();
@@ -200,8 +215,18 @@ public class FileConnector extends AbstractConnector {
     initialize();
 
     // discover and publish all valid file candidates
-    for (URI resource : storageURIs) {
-      traverseStoragePath(publisher, resource);
+    try {
+      if (multithreaded && storageURIs.size() > 1) {
+        traversePathsWithMultithreading(publisher);
+      } else {
+        for (URI resource : storageURIs) {
+          traverseStoragePath(publisher, resource);
+        }
+      }
+    } finally {
+      if (stateManager != null) {
+        stateManager.closeStateForThread();
+      }
     }
 
     // bump runs_not_encountered so listExpiredFiles and shutdown's deletion see up-to-date counters
@@ -286,6 +311,73 @@ public class FileConnector extends AbstractConnector {
       } catch (IOException e) {
         log.warn("Error shutting down StorageClient.", e);
       }
+    }
+  }
+
+  /**
+   * Traverses each of the storage paths on its own thread.
+   *
+   * <p> Requires the configured paths to not overlap so that concurrent traversals never touch the same row of the state database,
+   * <p> so the database's own row-level locking is all the synchronization needed.
+   */
+  private void traversePathsWithMultithreading(Publisher publisher) throws ConnectorException {
+    ThreadFactory threadFactory = new BasicThreadFactory.Builder()
+        .namingPattern(ThreadNameUtils.createName("PathTraversal") + "-%d")
+        .build();
+    ExecutorService executor = Executors.newFixedThreadPool(storageURIs.size(), threadFactory);
+
+    try {
+      List<Future<?>> traversals = new ArrayList<>();
+
+      for (URI resource : storageURIs) {
+        traversals.add(executor.submit(() -> {
+          traverseStoragePathOnThisThread(publisher, resource);
+          return null;
+        }));
+      }
+
+      // Every traversal runs to completion, even after one of them fails. Aborting the others partway through would
+      // leave only some of this run's files marked as encountered in the state database, and the unmarked ones would
+      // then be treated as expired, tombstoned and deleted.
+      ConnectorException failure = null;
+
+      for (Future<?> traversal : traversals) {
+        try {
+          traversal.get();
+        } catch (ExecutionException e) {
+          if (failure == null) {
+            failure = new ConnectorException("Error occurred while traversing.", e.getCause());
+          } else {
+            failure.addSuppressed(e.getCause());
+          }
+        }
+      }
+
+      if (failure != null) {
+        throw failure;
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ConnectorException("Interrupted while waiting for traversals to finish.", e);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  // Gives the calling thread its own TraversalState for the duration of the traversal. A JDBC Connection is not
+  // thread-safe, so each traversal thread needs its own. Which the state manager keeps track of.
+  private void traverseStoragePathOnThisThread(Publisher publisher, URI pathToTraverse) throws Exception {
+    if (stateManager == null) {
+      traverseStoragePath(publisher, pathToTraverse);
+      return;
+    }
+
+    stateManager.openStateForThread();
+
+    try {
+      traverseStoragePath(publisher, pathToTraverse);
+    } finally {
+      stateManager.closeStateForThread();
     }
   }
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -54,7 +54,7 @@ import com.typesafe.config.Config;
  *   <li>paths (List&lt;String&gt;, Required) : Paths or URIs to traverse (local paths or cloud storage URIs). s3 URIs must be
  *   percent-encoded; unencoded spaces or special characters will not be recognized. For example, use s3://test/folder%20with%20spaces.</li>
  *   <li>multithreaded (Boolean, Optional) : Traverse each of the paths concurrently, on its own thread. Only applies
- *   when more than one path is given; Requires that the paths do not overlap. Defaults to false.</li>>
+ *   when more than one path is given; Requires that the paths do not overlap. Defaults to false.</li>
  *   <li>filterOptions.includes (List&lt;String&gt;, Optional) : Regex patterns to include files.</li>
  *   <li>filterOptions.excludes (List&lt;String&gt;, Optional) : Regex patterns to exclude files.</li>
  *   <li>filterOptions.pathsToSkip (List&lt;String&gt;, Optional) : URIs of paths to directories that should be skipped and not traversed.</li>

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -341,12 +341,18 @@ public class FileConnector extends AbstractConnector {
       // then be treated as expired, tombstoned and deleted.
       ConnectorException failure = null;
 
-      for (Future<?> traversal : traversals) {
+      // traversals is in the same order as storageURIs, so the index identifies the path that failed
+      for (int i = 0; i < traversals.size(); i++) {
+        URI resource = storageURIs.get(i);
+
         try {
-          traversal.get();
+          traversals.get(i).get();
+          log.info("Finished traversing '{}'.", resource);
         } catch (ExecutionException e) {
+          log.error("Error occurred while traversing '{}', CONTINUING", resource, e.getCause());
+
           if (failure == null) {
-            failure = new ConnectorException("Error occurred while traversing.", e.getCause());
+            failure = new ConnectorException("One or more traversals failed.", e.getCause());
           } else {
             failure.addSuppressed(e.getCause());
           }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -53,7 +53,7 @@ import com.typesafe.config.Config;
  * <ul>
  *   <li>paths (List&lt;String&gt;, Required) : Paths or URIs to traverse (local paths or cloud storage URIs). s3 URIs must be
  *   percent-encoded; unencoded spaces or special characters will not be recognized. For example, use s3://test/folder%20with%20spaces.</li>
- *   <li>multithreaded (Boolean, Optional) : Traverse each of the paths concurrently, on its own thread. Only applies
+ *   <li>concurrent (Boolean, Optional) : Traverse each of the paths concurrently, on its own thread. Only applies
  *   when more than one path is given. Requires that the paths do not overlap. Defaults to false.</li>
  *   <li>filterOptions.includes (List&lt;String&gt;, Optional) : Regex patterns to include files.</li>
  *   <li>filterOptions.excludes (List&lt;String&gt;, Optional) : Regex patterns to exclude files.</li>
@@ -133,7 +133,7 @@ public class FileConnector extends AbstractConnector {
 
   public static final Spec SPEC = SpecBuilder.connector()
       .requiredList("paths", new TypeReference<List<String>>(){})
-      .optionalBoolean("multithreaded")
+      .optionalBoolean("concurrent")
       .optionalParent(
           SpecBuilder.parent("filterOptions")
               .optionalList("includes", new TypeReference<List<String>>(){})
@@ -158,12 +158,12 @@ public class FileConnector extends AbstractConnector {
 
   private final FileConnectorStateManager stateManager;
 
-  private final boolean multithreaded;
+  private final boolean concurrent;
 
   public FileConnector(Config config) throws ConnectorException {
     super(config);
 
-    this.multithreaded = ConfigUtils.getOrDefault(config, "multithreaded", false);
+    this.concurrent = ConfigUtils.getOrDefault(config, "concurrent", false);
 
     List<String> paths = config.getStringList("paths");
     this.storageURIs = new ArrayList<>();
@@ -205,6 +205,15 @@ public class FileConnector extends AbstractConnector {
       throw new IllegalArgumentException("FileConnector does not support multiple paths and moveToAfterProcessing / moveToErrorFolder. Create individual FileConnectors.");
     }
 
+    // A collapsing Publisher is not safe for concurrent publish() calls - it would merge and drop documents silently
+    if (concurrent && requiresCollapsingPublisher()) {
+      throw new IllegalArgumentException("FileConnector does not support concurrent traversal and collapse. Disable one of them.");
+    }
+
+    if (concurrent) {
+      validateNonOverlappingPaths();
+    }
+
     if (config.hasPath("filterOptions.lastPublishedCutoff") && !config.hasPath("state")) {
       log.warn("filterOptions.lastPublishedCutoff was specified, but no state configuration was provided. It will not be enforced.");
     }
@@ -216,8 +225,8 @@ public class FileConnector extends AbstractConnector {
 
     // discover and publish all valid file candidates
     try {
-      if (multithreaded && storageURIs.size() > 1) {
-        traversePathsWithMultithreading(publisher);
+      if (concurrent && storageURIs.size() > 1) {
+        traversePathsConcurrently(publisher);
       } else {
         for (URI resource : storageURIs) {
           traverseStoragePath(publisher, resource);
@@ -318,7 +327,7 @@ public class FileConnector extends AbstractConnector {
    * Traverses each of the storage paths on its own thread. Requires the paths to not overlap, so that concurrent
    * traversals never touch the same row of the state database.
    */
-  private void traversePathsWithMultithreading(Publisher publisher) throws ConnectorException {
+  private void traversePathsConcurrently(Publisher publisher) throws ConnectorException {
     ThreadFactory threadFactory = new BasicThreadFactory.Builder()
         .namingPattern(ThreadNameUtils.createName("PathTraversal") + "-%d")
         .build();
@@ -384,9 +393,38 @@ public class FileConnector extends AbstractConnector {
     }
   }
 
+  /**
+   * Rejects overlapping paths. Threads traversing overlapping paths would touch the same rows of the state database,
+   * and would publish the files under the shared paths more than once.
+   * <p> A StorageClient can only compare paths within its own storage provider, and cannot detect paths
+   * that reach the same files by another route, such as a symlink or an S3 access point alias.
+   */
+  private void validateNonOverlappingPaths() {
+    for (int i = 0; i < storageURIs.size(); i++) {
+      for (int j = i + 1; j < storageURIs.size(); j++) {
+        URI first = storageURIs.get(i);
+        URI second = storageURIs.get(j);
+        StorageClient client = storageClientMap.get(clientKeyFor(first));
+
+        // paths handled by different storage providers cannot overlap
+        if (client == null || client != storageClientMap.get(clientKeyFor(second))) {
+          continue;
+        }
+
+        if (client.containsPath(first, second) || client.containsPath(second, first)) {
+          throw new IllegalArgumentException("FileConnector cannot traverse overlapping paths concurrently: '"
+              + first + "' and '" + second + "'.");
+        }
+      }
+    }
+  }
+
+  private static String clientKeyFor(URI pathToTraverse) {
+    return pathToTraverse.getScheme() != null ? pathToTraverse.getScheme() : "file";
+  }
+
   private void traverseStoragePath(Publisher publisher, URI pathToTraverse) throws ConnectorException {
-    String clientKey = pathToTraverse.getScheme() != null ? pathToTraverse.getScheme() : "file";
-    StorageClient storageClient = storageClientMap.get(clientKey);
+    StorageClient storageClient = storageClientMap.get(clientKeyFor(pathToTraverse));
 
     if (storageClient == null) {
       throw new ConnectorException("No StorageClient was available for (" + pathToTraverse +

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnector.java
@@ -54,7 +54,7 @@ import com.typesafe.config.Config;
  *   <li>paths (List&lt;String&gt;, Required) : Paths or URIs to traverse (local paths or cloud storage URIs). s3 URIs must be
  *   percent-encoded; unencoded spaces or special characters will not be recognized. For example, use s3://test/folder%20with%20spaces.</li>
  *   <li>multithreaded (Boolean, Optional) : Traverse each of the paths concurrently, on its own thread. Only applies
- *   when more than one path is given; Requires that the paths do not overlap. Defaults to false.</li>
+ *   when more than one path is given. Requires that the paths do not overlap. Defaults to false.</li>
  *   <li>filterOptions.includes (List&lt;String&gt;, Optional) : Regex patterns to include files.</li>
  *   <li>filterOptions.excludes (List&lt;String&gt;, Optional) : Regex patterns to exclude files.</li>
  *   <li>filterOptions.pathsToSkip (List&lt;String&gt;, Optional) : URIs of paths to directories that should be skipped and not traversed.</li>
@@ -315,10 +315,8 @@ public class FileConnector extends AbstractConnector {
   }
 
   /**
-   * Traverses each of the storage paths on its own thread.
-   *
-   * <p> Requires the configured paths to not overlap so that concurrent traversals never touch the same row of the state database,
-   * <p> so the database's own row-level locking is all the synchronization needed.
+   * Traverses each of the storage paths on its own thread. Requires the paths to not overlap, so that concurrent
+   * traversals never touch the same row of the state database.
    */
   private void traversePathsWithMultithreading(Publisher publisher) throws ConnectorException {
     ThreadFactory threadFactory = new BasicThreadFactory.Builder()
@@ -336,9 +334,8 @@ public class FileConnector extends AbstractConnector {
         }));
       }
 
-      // Every traversal runs to completion, even after one of them fails. Aborting the others partway through would
-      // leave only some of this run's files marked as encountered in the state database, and the unmarked ones would
-      // then be treated as expired, tombstoned and deleted.
+      // Every traversal runs to completion, even after one fails. Aborting the others would leave some of this run's
+      // files unmarked in the state database, and they would then be expired, tombstoned and deleted.
       ConnectorException failure = null;
 
       // traversals is in the same order as storageURIs, so the index identifies the path that failed
@@ -370,8 +367,8 @@ public class FileConnector extends AbstractConnector {
     }
   }
 
-  // Gives the calling thread its own TraversalState for the duration of the traversal. A JDBC Connection is not
-  // thread-safe, so each traversal thread needs its own. Which the state manager keeps track of.
+  // Gives the calling thread its own TraversalState for the traversal. A JDBC Connection is not thread-safe, so each
+  // traversal thread needs its own.
   private void traverseStoragePathOnThisThread(Publisher publisher, URI pathToTraverse) throws Exception {
     if (stateManager == null) {
       traverseStoragePath(publisher, pathToTraverse);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
@@ -9,7 +9,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,10 +40,14 @@ import com.typesafe.config.Config;
  * <p> Lucille includes H2 as a dependency. You are welcome to configure the FileConnectorStateManager to use an embedded
  * H2 instance - use the <code>org.h2.Driver</code>, and something like <code>jdbc:h2:{LOCAL_FILE_PATH}</code> as your connectionString.
  *
- * <p> <b>Note:</b> This class is operating under two key assumptions about FileConnector / Connectors:
+ * <p> <b>Note:</b> This class is operating under these key assumptions about FileConnector / Connectors:
  * <ol>
  *   <li>Connectors run sequentially.</li>
- *   <li>The FileConnector is not multithreaded.</li>
+ *   <li>A FileConnector traversal may be multithreaded. The whole-table operations - {@link #init()},
+ *   {@link #incrementRunsNotEncountered()}, {@link #listExpiredFiles()}, and {@link #shutdown()} - run only on the
+ *   connector thread, before or after the traversal. Per-file operations are delegated to the calling thread's
+ *   {@link TraversalState}.</li>
+ *   <li>The paths a FileConnector traverses do not overlap.</li>
  * </ol>
  */
 public class FileConnectorStateManager {
@@ -64,9 +67,10 @@ public class FileConnectorStateManager {
   private Instant traversalInstant;
 
   private Connection jdbcConnection;
-  private PreparedStatement queryStatement;
-  private PreparedStatement updateStatement;
-  private PreparedStatement insertNewFileStatement;
+
+  // Per-file operations are delegated to the calling thread's TraversalState, since a JDBC Connection is not thread-safe.
+  // init() binds one for the thread that calls it, and each additional traversal thread binds its own with openStateForThread().
+  private final ThreadLocal<TraversalState> threadState = new ThreadLocal<>();
 
   /**
    * Creates a FileConnectorStateManager from the given config.
@@ -93,15 +97,9 @@ public class FileConnectorStateManager {
    * appropriate schema if it doesn't. After connecting to the table, sets encountered=FALSE for all rows.
    */
   public void init() throws ClassNotFoundException, SQLException {
-    try {
-      Class.forName(driver);
-    } catch (ClassNotFoundException e) {
-      log.error("Driver class {} not found. Is the jar file in your classpath?", driver);
-      throw e;
-    }
-
     traversalInstant = Instant.now();
-    jdbcConnection = DriverManager.getConnection(connectionString, jdbcUser, jdbcPassword);
+
+    jdbcConnection = openConnection();
 
     // After getting connection setup, make sure the table exists, create it if it doesn't.
     DatabaseMetaData metadata = jdbcConnection.getMetaData();
@@ -124,15 +122,78 @@ public class FileConnectorStateManager {
       log.debug("{} rows from the state database had encountered switched from TRUE to FALSE.", rowsAffected);
     }
 
-    // create PreparedStatements to be used for sql queries that take input
-    String querySQL = "SELECT last_published FROM \"" + tableName + "\" WHERE name=?";
-    queryStatement = jdbcConnection.prepareStatement(querySQL);
+    openStateForThread();
+  }
 
-    String updateSQL = "UPDATE \"" + tableName + "\" SET encountered=true, runs_not_encountered = 0 WHERE name=?";
-    updateStatement = jdbcConnection.prepareStatement(updateSQL);
+  /**
+   * Binds a {@link TraversalState}, holding its own connection to the state database, to the calling thread. The
+   * per-file methods on this class then operate through it. {@link #init()} does this for the thread that calls it, so
+   * only additional traversal threads need to call this.
+   *
+   * <p> Every call must be paired with {@link #closeStateForThread()}, or the thread's connection is leaked.
+   *
+   * @throws IllegalStateException If called before {@link #init()} (the state table is created there), or if the
+   * calling thread already has a state bound.
+   */
+  public void openStateForThread() throws ClassNotFoundException, SQLException {
+    if (jdbcConnection == null) {
+      throw new IllegalStateException("openStateForThread() was called before init().");
+    }
 
-    String insertNewFileSQL = "INSERT INTO \"" + tableName + "\" VALUES (?, NULL, TRUE, 0)";
-    insertNewFileStatement = jdbcConnection.prepareStatement(insertNewFileSQL);
+    if (threadState.get() != null) {
+      throw new IllegalStateException("Thread " + Thread.currentThread().getName() + " already has an open state.");
+    }
+
+    Connection connection = openConnection();
+
+    try {
+      threadState.set(new TraversalState(connection, tableName, traversalInstant));
+    } catch (SQLException e) {
+      // the TraversalState only takes ownership of the connection once it is fully constructed, so we close it here
+      try {
+        connection.close();
+      } catch (SQLException closeException) {
+        e.addSuppressed(closeException);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Closes the calling thread's {@link TraversalState} and unbinds it. Does nothing if the thread has none. Does not
+   * perform deletions - those belong to {@link #shutdown()}, and run once, after every traversal has finished.
+   */
+  public void closeStateForThread() {
+    TraversalState state = threadState.get();
+
+    if (state != null) {
+      threadState.remove();
+      state.close();
+    }
+  }
+
+  // Returns the calling thread's TraversalState. Every per-file operation goes through here.
+  private TraversalState currentState() {
+    TraversalState state = threadState.get();
+
+    if (state == null) {
+      throw new IllegalStateException("Thread " + Thread.currentThread().getName()
+          + " has no open state. Call openStateForThread() before traversing on this thread.");
+    }
+
+    return state;
+  }
+
+  // Opens a connection to the database specified by your Config. Throws an exception if an error occurs.
+  private Connection openConnection() throws ClassNotFoundException, SQLException {
+    try {
+      Class.forName(driver);
+    } catch (ClassNotFoundException e) {
+      log.error("Driver class {} not found. Is the jar file in your classpath?", driver);
+      throw e;
+    }
+
+    return DriverManager.getConnection(connectionString, jdbcUser, jdbcPassword);
   }
 
   /**
@@ -154,6 +215,8 @@ public class FileConnectorStateManager {
    * Throws an exception if an error occurs.
    */
   public void shutdown() throws SQLException {
+    closeStateForThread();
+
     if (performDeletions) {
       deleteExpiredFilesAndResetTable();
     }
@@ -163,30 +226,6 @@ public class FileConnectorStateManager {
         jdbcConnection.close();
       } catch (SQLException e) {
         log.warn("Couldn't close connection to database.", e);
-      }
-    }
-
-    if (queryStatement != null) {
-      try {
-        queryStatement.close();
-      } catch (SQLException e) {
-        log.warn("Couldn't close query statement (PreparedStatement).", e);
-      }
-    }
-
-    if (updateStatement != null) {
-      try {
-        updateStatement.close();
-      } catch (SQLException e) {
-        log.warn("Couldn't close update statement (PreparedStatement).", e);
-      }
-    }
-
-    if (insertNewFileStatement != null) {
-      try {
-        insertNewFileStatement.close();
-      } catch (SQLException e) {
-        log.warn("Couldn't close insert statement (PreparedStatement).", e);
       }
     }
   }
@@ -219,18 +258,7 @@ public class FileConnectorStateManager {
    * @param fullPathStr The full path to the file you encountered during a FileConnector traversal.
    */
   public void markFileEncountered(String fullPathStr) {
-    // First, we try an update statement, see if it updates an existing file.
-    try {
-      updateStatement.setString(1, fullPathStr);
-      int rowsChanged = updateStatement.executeUpdate();
-
-      // if it doesn't change any rows, then we need to insert this file - it is "new".
-      if (rowsChanged == 0) {
-        insertFile(fullPathStr);
-      }
-    } catch (SQLException e) {
-      log.warn("Error marking file encountered in state database.", e);
-    }
+    currentState().markFileEncountered(fullPathStr);
   }
 
   /**
@@ -241,20 +269,7 @@ public class FileConnectorStateManager {
    * @param prefix The prefix to match against entry names (typically archivePath + ARCHIVE_FILE_SEPARATOR).
    */
   public void markAllEntriesEncountered(String prefix) {
-    // updates every entry whose name starts with the given prefix
-    // this is useful for archive files, in which the paths look like:
-    // file:///tmp/archive.zip!entry1.txt or file:///tmp/archive.zip!subdir/entry2.txt.
-    // the LIKE operator allows us to target entries which don't match our parameter, but contain it.
-    // So the parameter/prefix could be "file:///tmp/archive.zip!" and those aforementioned paths would get updated.
-    String updateSQL = "UPDATE \"" + tableName + "\" SET encountered=true WHERE name LIKE ?";
-    try (PreparedStatement ps = jdbcConnection.prepareStatement(updateSQL)) {
-      // the "%" says anything can come after the prefix in a given DB entry and it will still match
-      ps.setString(1, prefix + "%");
-      int rowsChanged = ps.executeUpdate();
-      log.debug("Marked {} archive entries as encountered for prefix '{}'", rowsChanged, prefix);
-    } catch (SQLException e) {
-      log.warn("Error marking archive entries as encountered for prefix '{}'.", prefix, e);
-    }
+    currentState().markAllEntriesEncountered(prefix);
   }
 
   /**
@@ -266,23 +281,7 @@ public class FileConnectorStateManager {
    * on this file.
    */
   public Instant getLastPublished(String fullPathStr) {
-    try {
-      queryStatement.setString(1, fullPathStr);
-      try (ResultSet rs = queryStatement.executeQuery()) {
-        if (rs.next()) {
-          // Get timestamp as OffsetDateTime, which is stored in UTC
-          // Note: H2 may convert to local timezone on retrieval, but toInstant() returns the correct absolute point in time.
-          OffsetDateTime odt = rs.getObject("last_published", OffsetDateTime.class);
-          if (odt != null) {
-            return odt.toInstant();
-          }
-        }
-      }
-    } catch (SQLException e) {
-      log.warn("SQL error occurred getting last published for {}, lastPublishedCutoff won't apply.", fullPathStr, e);
-    }
-
-    return null;
+    return currentState().getLastPublished(fullPathStr);
   }
 
   /**
@@ -290,26 +289,6 @@ public class FileConnectorStateManager {
    * @param fullPathStr The full path to the file that was successfully published.
    */
   public void successfullyPublishedFile(String fullPathStr) {
-    String updateSQL = "UPDATE \"" + tableName + "\" SET last_published = ? WHERE name = ?";
-
-    try (PreparedStatement statement = jdbcConnection.prepareStatement(updateSQL)) {
-      statement.setObject(1, traversalInstant);
-      statement.setString(2, fullPathStr);
-
-      int rowsChanged = statement.executeUpdate();
-
-      if (rowsChanged != 1) {
-        log.warn("Updating {} last published timestamp changed {} rows.", fullPathStr, rowsChanged);
-      }
-    } catch (SQLException e) {
-      log.warn("Couldn't update a file's last published timestamp.", e);
-    }
-  }
-
-  // Insert a file with the given name into the database. It will have no "last_published" time, but will
-  // be marked as encountered.
-  private void insertFile(String fullPathStr) throws SQLException {
-    insertNewFileStatement.setString(1, fullPathStr);
-    insertNewFileStatement.executeUpdate();
+    currentState().successfullyPublishedFile(fullPathStr);
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
@@ -66,9 +66,7 @@ public class FileConnectorStateManager {
 
   private Instant traversalInstant;
 
-  // Used for the whole-table operations: creating the table, resetting encountered flags, incrementRunsNotEncountered(),
-  // listExpiredFiles(), and the deletions in shutdown(). Kept separate from the per-thread connections because it has to
-  // outlive them.
+  // Used for the whole-table operations. Kept separate from the per-thread connections because it has to outlive them.
   private Connection jdbcConnection;
 
   // Per-file operations are delegated to the calling thread's TraversalState, since a JDBC Connection is not thread-safe.
@@ -125,8 +123,8 @@ public class FileConnectorStateManager {
       log.debug("{} rows from the state database had encountered switched from TRUE to FALSE.", rowsAffected);
     }
 
-    // Binds a state to the thread that called init(), sharing this state manager's own connection rather than opening a second
-    // A single-threaded traversal runs on this thread, while a multithreaded traversal leaves this state unused.
+    // Binds a state to this thread, sharing the connection above rather than opening a second one. A single-threaded
+    // traversal runs on this thread; a multithreaded one leaves this state unused.
     threadState.set(new TraversalState(jdbcConnection, tableName, traversalInstant));
   }
 
@@ -154,7 +152,7 @@ public class FileConnectorStateManager {
     try {
       threadState.set(new TraversalState(connection, tableName, traversalInstant));
     } catch (SQLException e) {
-      // the TraversalState only takes ownership of the connection once it is fully constructed, so we close it here
+      // the connection has no owner until the TraversalState is bound, so close it here
       try {
         connection.close();
       } catch (SQLException closeException) {
@@ -165,8 +163,8 @@ public class FileConnectorStateManager {
   }
 
   /**
-   * Closes the calling thread's {@link TraversalState} and unbinds it. Does nothing if the thread has none. Does not
-   * perform deletions - those belong to {@link #shutdown()}, and run once, after every traversal has finished.
+   * Closes the calling thread's {@link TraversalState} and unbinds it, closing its connection unless that connection is
+   * this state manager's own. Does nothing if the thread has none.
    */
   public void closeStateForThread() {
     TraversalState state = threadState.get();
@@ -178,7 +176,6 @@ public class FileConnectorStateManager {
     threadState.remove();
     state.closeStatements();
 
-    // Any connection other than this state manager's own was opened for one traversal thread, so it closes here
     if (state.connection() != jdbcConnection) {
       closeConnection(state.connection());
     }
@@ -196,7 +193,7 @@ public class FileConnectorStateManager {
     return state;
   }
 
-  // Opens a connection to the database specified by your Config. Throws an exception if an error occurs.
+  // Opens a connection to the database specified by your Config.
   private Connection openConnection() throws ClassNotFoundException, SQLException {
     try {
       Class.forName(driver);

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
@@ -43,7 +43,7 @@ import com.typesafe.config.Config;
  * <p> <b>Note:</b> This class is operating under these key assumptions about FileConnector / Connectors:
  * <ol>
  *   <li>Connectors run sequentially.</li>
- *   <li>A FileConnector traversal may be multithreaded. The whole-table operations - {@link #init()},
+ *   <li>A FileConnector traversal may be concurrent. The whole-table operations - {@link #init()},
  *   {@link #incrementRunsNotEncountered()}, {@link #listExpiredFiles()}, and {@link #shutdown()} - run only on the
  *   connector thread, before or after the traversal. Per-file operations are delegated to the calling thread's
  *   {@link TraversalState}.</li>
@@ -123,20 +123,16 @@ public class FileConnectorStateManager {
       log.debug("{} rows from the state database had encountered switched from TRUE to FALSE.", rowsAffected);
     }
 
-    // Binds a state to this thread, sharing the connection above rather than opening a second one. A single-threaded
-    // traversal runs on this thread; a multithreaded one leaves this state unused.
+    // Binds a state to this thread, sharing the connection above rather than opening a second one. A sequential
+    // traversal runs on this thread; a concurrent one leaves this state unused.
     threadState.set(new TraversalState(jdbcConnection, tableName, traversalInstant));
   }
 
   /**
-   * Binds a {@link TraversalState}, holding its own connection to the state database, to the calling thread. The
-   * per-file methods on this class then operate through it. {@link #init()} does this for the thread that calls it, so
-   * only additional traversal threads need to call this.
-   *
-   * <p> Every call must be paired with {@link #closeStateForThread()}, or the thread's connection is leaked.
-   *
-   * @throws IllegalStateException If called before {@link #init()} (the state table is created there), or if the
-   * calling thread already has a state bound.
+   * Binds a {@link TraversalState}, with its own connection to the state database, to the calling thread. The per-file
+   * methods on this class then operate through it. {@link #init()} does this for the thread that calls it, so only
+   * additional traversal threads need to call this. Every call must be paired with {@link #closeStateForThread()}.
+   * @throws IllegalStateException If called before {@link #init()}, or if the calling thread already has a state bound.
    */
   public void openStateForThread() throws ClassNotFoundException, SQLException {
     if (jdbcConnection == null) {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/FileConnectorStateManager.java
@@ -66,6 +66,9 @@ public class FileConnectorStateManager {
 
   private Instant traversalInstant;
 
+  // Used for the whole-table operations: creating the table, resetting encountered flags, incrementRunsNotEncountered(),
+  // listExpiredFiles(), and the deletions in shutdown(). Kept separate from the per-thread connections because it has to
+  // outlive them.
   private Connection jdbcConnection;
 
   // Per-file operations are delegated to the calling thread's TraversalState, since a JDBC Connection is not thread-safe.
@@ -122,7 +125,9 @@ public class FileConnectorStateManager {
       log.debug("{} rows from the state database had encountered switched from TRUE to FALSE.", rowsAffected);
     }
 
-    openStateForThread();
+    // Binds a state to the thread that called init(), sharing this state manager's own connection rather than opening a second
+    // A single-threaded traversal runs on this thread, while a multithreaded traversal leaves this state unused.
+    threadState.set(new TraversalState(jdbcConnection, tableName, traversalInstant));
   }
 
   /**
@@ -166,9 +171,16 @@ public class FileConnectorStateManager {
   public void closeStateForThread() {
     TraversalState state = threadState.get();
 
-    if (state != null) {
-      threadState.remove();
-      state.close();
+    if (state == null) {
+      return;
+    }
+
+    threadState.remove();
+    state.closeStatements();
+
+    // Any connection other than this state manager's own was opened for one traversal thread, so it closes here
+    if (state.connection() != jdbcConnection) {
+      closeConnection(state.connection());
     }
   }
 
@@ -196,6 +208,18 @@ public class FileConnectorStateManager {
     return DriverManager.getConnection(connectionString, jdbcUser, jdbcPassword);
   }
 
+  private static void closeConnection(Connection connection) {
+    if (connection == null) {
+      return;
+    }
+
+    try {
+      connection.close();
+    } catch (SQLException e) {
+      log.warn("Couldn't close connection to database.", e);
+    }
+  }
+
   /**
    * Increments the runs_not_encountered counter for every file that was not seen during the current traversal. This method must
    * be called exactly once per run, after all markFileEncountered calls are complete.
@@ -221,13 +245,7 @@ public class FileConnectorStateManager {
       deleteExpiredFilesAndResetTable();
     }
 
-    if (jdbcConnection != null) {
-      try {
-        jdbcConnection.close();
-      } catch (SQLException e) {
-        log.warn("Couldn't close connection to database.", e);
-      }
-    }
+    closeConnection(jdbcConnection);
   }
   
   public List<URI> listExpiredFiles() throws SQLException {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/TraversalState.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/TraversalState.java
@@ -1,0 +1,163 @@
+package com.kmwllc.lucille.connector;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p> Holds a JDBC connection, and the PreparedStatements built on it, used to read and update state for the files
+ * encountered during a single FileConnector traversal.
+ *
+ * <p> A JDBC Connection is not thread-safe, so each traversal thread uses its own TraversalState. Obtain one from
+ * {@link FileConnectorStateManager} and close it when the traversal finishes.
+ *
+ * <p> Every operation here affects a single file (or, for {@link #markAllEntriesEncountered(String)}, the entries of a
+ * single archive). Operations spanning the whole table belong to {@link FileConnectorStateManager}.
+ */
+public class TraversalState implements AutoCloseable {
+
+  private static final Logger log = LoggerFactory.getLogger(TraversalState.class);
+
+  private final String tableName;
+  private final Instant traversalInstant;
+
+  private final Connection jdbcConnection;
+  private final PreparedStatement queryStatement;
+  private final PreparedStatement updateStatement;
+  private final PreparedStatement insertNewFileStatement;
+
+  /**
+   * Builds a TraversalState around the given connection, which it takes ownership of and closes in {@link #close()}.
+   * The table must already exist - PreparedStatements are validated against the schema as they are created.
+   *
+   * @param jdbcConnection An open connection to the state database.
+   * @param tableName The name of the state table.
+   * @param traversalInstant The instant stamped onto files published during this run.
+   */
+  TraversalState(Connection jdbcConnection, String tableName, Instant traversalInstant) throws SQLException {
+    this.jdbcConnection = jdbcConnection;
+    this.tableName = tableName;
+    this.traversalInstant = traversalInstant;
+
+    String querySQL = "SELECT last_published FROM \"" + tableName + "\" WHERE name=?";
+    this.queryStatement = jdbcConnection.prepareStatement(querySQL);
+
+    String updateSQL = "UPDATE \"" + tableName + "\" SET encountered=true, runs_not_encountered = 0 WHERE name=?";
+    this.updateStatement = jdbcConnection.prepareStatement(updateSQL);
+
+    String insertNewFileSQL = "INSERT INTO \"" + tableName + "\" VALUES (?, NULL, TRUE, 0)";
+    this.insertNewFileStatement = jdbcConnection.prepareStatement(insertNewFileSQL);
+  }
+
+  /**
+   * Update the database to reflect that the given file was encountered during a FileConnector traversal.
+   * @param fullPathStr The full path to the file you encountered during a FileConnector traversal.
+   */
+  public void markFileEncountered(String fullPathStr) {
+    // First, we try an update statement, see if it updates an existing file.
+    try {
+      updateStatement.setString(1, fullPathStr);
+      int rowsChanged = updateStatement.executeUpdate();
+
+      // if it doesn't change any rows, then we need to insert this file - it is "new".
+      if (rowsChanged == 0) {
+        insertNewFileStatement.setString(1, fullPathStr);
+        insertNewFileStatement.executeUpdate();
+      }
+    } catch (SQLException e) {
+      log.warn("Error marking file encountered in state database.", e);
+    }
+  }
+
+  /**
+   * Marks all state database entries whose name starts with the given prefix as encountered.
+   * Used to mark archive/compressed file entries as encountered when their container file is visited
+   * but not re-published (e.g., in incremental mode when the archive has not been modified since last publish).
+   *
+   * @param prefix The prefix to match against entry names (typically archivePath + ARCHIVE_FILE_SEPARATOR).
+   */
+  public void markAllEntriesEncountered(String prefix) {
+    // updates every entry whose name starts with the given prefix
+    // this is useful for archive files, in which the paths look like:
+    // file:///tmp/archive.zip!entry1.txt or file:///tmp/archive.zip!subdir/entry2.txt.
+    // the LIKE operator allows us to target entries which don't match our parameter, but contain it.
+    // So the parameter/prefix could be "file:///tmp/archive.zip!" and those aforementioned paths would get updated.
+    String updateSQL = "UPDATE \"" + tableName + "\" SET encountered=true WHERE name LIKE ?";
+    try (PreparedStatement ps = jdbcConnection.prepareStatement(updateSQL)) {
+      // the "%" says anything can come after the prefix in a given DB entry and it will still match
+      ps.setString(1, prefix + "%");
+      int rowsChanged = ps.executeUpdate();
+      log.debug("Marked {} archive entries as encountered for prefix '{}'", rowsChanged, prefix);
+    } catch (SQLException e) {
+      log.warn("Error marking archive entries as encountered for prefix '{}'.", prefix, e);
+    }
+  }
+
+  /**
+   * Retrieves the instant at which this file was last known to be published by Lucille. If the State Database has
+   * no record of publishing this file, a null Instant is returned.
+   *
+   * @param fullPathStr The full path to the file you want to get a last_published Timestamp for.
+   * @return The instant at which this file was last known to be published by Lucille; null if there is no information
+   * on this file.
+   */
+  public Instant getLastPublished(String fullPathStr) {
+    try {
+      queryStatement.setString(1, fullPathStr);
+      try (ResultSet rs = queryStatement.executeQuery()) {
+        if (rs.next()) {
+          // Get timestamp as OffsetDateTime, which is stored in UTC
+          // Note: H2 may convert to local timezone on retrieval, but toInstant() returns the correct absolute point in time.
+          OffsetDateTime odt = rs.getObject("last_published", OffsetDateTime.class);
+          if (odt != null) {
+            return odt.toInstant();
+          }
+        }
+      }
+    } catch (SQLException e) {
+      log.warn("SQL error occurred getting last published for {}, lastPublishedCutoff won't apply.", fullPathStr, e);
+    }
+
+    return null;
+  }
+
+  /**
+   * Updates the state database to reflect that the given file was successfully published during a FileConnector traversal.
+   * @param fullPathStr The full path to the file that was successfully published.
+   */
+  public void successfullyPublishedFile(String fullPathStr) {
+    String updateSQL = "UPDATE \"" + tableName + "\" SET last_published = ? WHERE name = ?";
+
+    try (PreparedStatement statement = jdbcConnection.prepareStatement(updateSQL)) {
+      statement.setObject(1, traversalInstant);
+      statement.setString(2, fullPathStr);
+
+      int rowsChanged = statement.executeUpdate();
+
+      if (rowsChanged != 1) {
+        log.warn("Updating {} last published timestamp changed {} rows.", fullPathStr, rowsChanged);
+      }
+    } catch (SQLException e) {
+      log.warn("Couldn't update a file's last published timestamp.", e);
+    }
+  }
+
+  /**
+   * Closes this TraversalState's connection, which also closes the PreparedStatements created from it. Does not perform
+   * any deletions - those belong to {@link FileConnectorStateManager}, and run once, after every traversal has finished.
+   */
+  @Override
+  public void close() {
+    try {
+      jdbcConnection.close();
+    } catch (SQLException e) {
+      log.warn("Couldn't close connection to database.", e);
+    }
+  }
+}

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/TraversalState.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/TraversalState.java
@@ -13,13 +13,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * <p> Holds a JDBC connection, and the PreparedStatements built on it, used to read and update state for the files
- * encountered during a single FileConnector traversal.
+ * encountered during a single FileConnector traversal. A JDBC Connection is not thread-safe, so each traversal thread
+ * uses its own TraversalState. Obtain one from {@link FileConnectorStateManager}, which owns the connection's lifetime.
  *
- * <p> A JDBC Connection is not thread-safe, so each traversal thread uses its own TraversalState. Obtain one from
- * {@link FileConnectorStateManager}, which owns the connection's lifetime.
- *
- * <p> Every operation here affects a single file (or, for {@link #markAllEntriesEncountered(String)}, the entries of a
- * single archive). Operations spanning the whole table belong to {@link FileConnectorStateManager}.
+ * <p> Every operation here affects a single file, or the entries of a single archive. Operations spanning the whole
+ * table belong to {@link FileConnectorStateManager}.
  */
 class TraversalState {
 
@@ -35,7 +33,6 @@ class TraversalState {
 
   /**
    * Builds a TraversalState on the given connection. Does not take ownership of it.
-   *
    * @param jdbcConnection An open connection to the state database.
    * @param tableName The name of the state table. Must already exist in the database with the correct schema.
    * @param traversalInstant The instant stamped onto files published during this run.

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/TraversalState.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/TraversalState.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,12 +16,12 @@ import org.slf4j.LoggerFactory;
  * encountered during a single FileConnector traversal.
  *
  * <p> A JDBC Connection is not thread-safe, so each traversal thread uses its own TraversalState. Obtain one from
- * {@link FileConnectorStateManager} and close it when the traversal finishes.
+ * {@link FileConnectorStateManager}, which owns the connection's lifetime.
  *
  * <p> Every operation here affects a single file (or, for {@link #markAllEntriesEncountered(String)}, the entries of a
  * single archive). Operations spanning the whole table belong to {@link FileConnectorStateManager}.
  */
-public class TraversalState implements AutoCloseable {
+class TraversalState {
 
   private static final Logger log = LoggerFactory.getLogger(TraversalState.class);
 
@@ -33,11 +34,10 @@ public class TraversalState implements AutoCloseable {
   private final PreparedStatement insertNewFileStatement;
 
   /**
-   * Builds a TraversalState around the given connection, which it takes ownership of and closes in {@link #close()}.
-   * The table must already exist - PreparedStatements are validated against the schema as they are created.
+   * Builds a TraversalState on the given connection. Does not take ownership of it.
    *
    * @param jdbcConnection An open connection to the state database.
-   * @param tableName The name of the state table.
+   * @param tableName The name of the state table. Must already exist in the database with the correct schema.
    * @param traversalInstant The instant stamped onto files published during this run.
    */
   TraversalState(Connection jdbcConnection, String tableName, Instant traversalInstant) throws SQLException {
@@ -59,7 +59,7 @@ public class TraversalState implements AutoCloseable {
    * Update the database to reflect that the given file was encountered during a FileConnector traversal.
    * @param fullPathStr The full path to the file you encountered during a FileConnector traversal.
    */
-  public void markFileEncountered(String fullPathStr) {
+  void markFileEncountered(String fullPathStr) {
     // First, we try an update statement, see if it updates an existing file.
     try {
       updateStatement.setString(1, fullPathStr);
@@ -82,7 +82,7 @@ public class TraversalState implements AutoCloseable {
    *
    * @param prefix The prefix to match against entry names (typically archivePath + ARCHIVE_FILE_SEPARATOR).
    */
-  public void markAllEntriesEncountered(String prefix) {
+  void markAllEntriesEncountered(String prefix) {
     // updates every entry whose name starts with the given prefix
     // this is useful for archive files, in which the paths look like:
     // file:///tmp/archive.zip!entry1.txt or file:///tmp/archive.zip!subdir/entry2.txt.
@@ -107,7 +107,7 @@ public class TraversalState implements AutoCloseable {
    * @return The instant at which this file was last known to be published by Lucille; null if there is no information
    * on this file.
    */
-  public Instant getLastPublished(String fullPathStr) {
+  Instant getLastPublished(String fullPathStr) {
     try {
       queryStatement.setString(1, fullPathStr);
       try (ResultSet rs = queryStatement.executeQuery()) {
@@ -131,7 +131,7 @@ public class TraversalState implements AutoCloseable {
    * Updates the state database to reflect that the given file was successfully published during a FileConnector traversal.
    * @param fullPathStr The full path to the file that was successfully published.
    */
-  public void successfullyPublishedFile(String fullPathStr) {
+  void successfullyPublishedFile(String fullPathStr) {
     String updateSQL = "UPDATE \"" + tableName + "\" SET last_published = ? WHERE name = ?";
 
     try (PreparedStatement statement = jdbcConnection.prepareStatement(updateSQL)) {
@@ -148,16 +148,19 @@ public class TraversalState implements AutoCloseable {
     }
   }
 
-  /**
-   * Closes this TraversalState's connection, which also closes the PreparedStatements created from it. Does not perform
-   * any deletions - those belong to {@link FileConnectorStateManager}, and run once, after every traversal has finished.
-   */
-  @Override
-  public void close() {
-    try {
-      jdbcConnection.close();
-    } catch (SQLException e) {
-      log.warn("Couldn't close connection to database.", e);
+  // The connection these PreparedStatements were prepared on.
+  Connection connection() {
+    return jdbcConnection;
+  }
+
+  // Closes the PreparedStatements. The connection may outlive this TraversalState, so they don't close with it.
+  void closeStatements() {
+    for (PreparedStatement statement : List.of(queryStatement, updateStatement, insertNewFileStatement)) {
+      try {
+        statement.close();
+      } catch (SQLException e) {
+        log.warn("Couldn't close a PreparedStatement.", e);
+      }
     }
   }
 }

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/BaseStorageClient.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
+import java.util.Objects;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveException;
@@ -111,6 +112,47 @@ public abstract class BaseStorageClient implements StorageClient {
   }
 
   protected abstract void traverseStorageClient(Publisher publisher, TraversalParams params, FileConnectorStateManager stateMgr) throws Exception;
+
+  /**
+   * {@inheritDoc}
+   * <p> Compares the URIs by path segment, so <code>s3://bucket/data</code> contains <code>s3://bucket/data/2024</code>.
+   * A URI with an empty path is the root of its bucket or container, and contains everything in it.
+   * <p> Object storage prefixes are raw strings rather than path segments, so overlaps that do not fall on a segment
+   * boundary are missed, implementations may override to catch them.
+   */
+  @Override
+  public boolean containsPath(URI parent, URI child) {
+    URI normalizedParent = parent.normalize();
+    URI normalizedChild = child.normalize();
+
+    if (!Objects.equals(normalizedParent.getScheme(), normalizedChild.getScheme())
+        || !Objects.equals(normalizedParent.getAuthority(), normalizedChild.getAuthority())) {
+      return false;
+    }
+
+    return pathContains(normalizedParent.getPath(), normalizedChild.getPath());
+  }
+
+  /**
+   * Returns whether the child path is the parent path, or sits underneath it, treating both as '/'-delimited.
+   * @param parentPath The path that may contain the other.
+   * @param childPath The path that may sit under the other.
+   */
+  protected static boolean pathContains(String parentPath, String childPath) {
+    String parent = stripTrailingSlash(parentPath);
+    String child = stripTrailingSlash(childPath);
+
+    // an empty path is the root of a bucket / container, which contains everything in it
+    return parent.isEmpty() || child.equals(parent) || child.startsWith(parent + "/");
+  }
+
+  private static String stripTrailingSlash(String path) {
+    if (path == null || path.isEmpty()) {
+      return "";
+    }
+
+    return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+  }
 
   /**
    * Returns whether the provided URI, which represents a directory in some storage provider, is a directory

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/LocalStorageClient.java
@@ -51,6 +51,19 @@ public class LocalStorageClient extends BaseStorageClient {
 
   private String getStartingDirectory(TraversalParams params) { return params.getURI().getPath(); }
 
+  /**
+   * {@inheritDoc}
+   * <p> Resolves both paths to an absolute, normalized form so a relative path and an absolute path to the same
+   * directory are recognized as the same. Does not resolve symlinks.
+   */
+  @Override
+  public boolean containsPath(URI parent, URI child) {
+    Path parentPath = Paths.get(parent.getPath()).toAbsolutePath().normalize();
+    Path childPath = Paths.get(child.getPath()).toAbsolutePath().normalize();
+
+    return childPath.startsWith(parentPath);
+  }
+
   @Override
   public void moveFile(URI filePath, URI folder) throws IOException {
     Path pathForFile = Paths.get(filePath.getPath());

--- a/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/StorageClient.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/connector/storageclient/StorageClient.java
@@ -46,6 +46,15 @@ public interface StorageClient {
   void traverse(Publisher publisher, TraversalParams params, FileConnectorStateManager stateMgr) throws Exception;
 
   /**
+   * Returns whether a traversal of the given parent would also visit the files under the given child, based on this
+   * provider's addressing rules. Does not require this client to be initialized, and does not contact the provider.
+   * @param parent A URI to a path in storage.
+   * @param child A URI to a path in storage, which may or may not sit under the parent.
+   * @return Whether traversing parent would also visit the files under child.
+   */
+  boolean containsPath(URI parent, URI child);
+
+  /**
    * Opens and returns an InputStream for a file's contents, located at the given URI.
    * @param uri A URI to the file whose contents you want to extract.
    * @return An InputStream for the file's contents.

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -2,6 +2,7 @@ package com.kmwllc.lucille.connector;
 
 import static com.kmwllc.lucille.connector.FileConnector.FILE_PATH;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -898,28 +899,28 @@ public class FileConnectorTest {
     assertEquals(8, documentList.size());
   }
 
-  // Verifies that a multithreaded traversal publishes the same files as a sequential one, and none of them twice.
+  // Verifies that a concurrent traversal publishes the same files as a sequential one, and none of them twice.
   @Test
-  public void testMultithreadedTraversal() throws Exception {
+  public void testConcurrentTraversal() throws Exception {
     Config sequentialConfig = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf");
-    Config multithreadedConfig = sequentialConfig.withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+    Config concurrentConfig = sequentialConfig.withValue("concurrent", ConfigValueFactory.fromAnyRef(true));
 
     List<Document> sequentialDocs = publishedDocuments(sequentialConfig);
-    List<Document> multithreadedDocs = publishedDocuments(multithreadedConfig);
+    List<Document> concurrentDocs = publishedDocuments(concurrentConfig);
 
     // 3 files in each of the 3 directories
-    assertEquals(9, multithreadedDocs.size());
-    assertEquals(documentIds(sequentialDocs), documentIds(multithreadedDocs));
+    assertEquals(9, concurrentDocs.size());
+    assertEquals(documentIds(sequentialDocs), documentIds(concurrentDocs));
     // a file published twice would collapse in the Set above, so check the count separately
-    assertEquals(multithreadedDocs.size(), documentIds(multithreadedDocs).size());
+    assertEquals(concurrentDocs.size(), documentIds(concurrentDocs).size());
   }
 
   // Verifies that the paths are traversed concurrently. Each traversal waits for the others to start, so this times out
   // and fails if they ran one after another.
   @Test
-  public void testMultithreadedTraversalsRunConcurrently() throws Exception {
+  public void testConcurrentTraversalsOverlap() throws Exception {
     Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
-        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+        .withValue("concurrent", ConfigValueFactory.fromAnyRef(true));
     TestMessenger messenger = new TestMessenger();
     Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
 
@@ -946,40 +947,79 @@ public class FileConnectorTest {
     }
   }
 
-  // Verifies that multithreading with no paths is harmless, since it is skipped when there are fewer than two.
+  // Verifies that concurrent traversal is rejected alongside collapse, which a Publisher cannot do concurrently.
   @Test
-  public void testMultithreadedTraversalNoPaths() throws Exception {
+  public void testPreventConcurrentAndCollapse() {
     Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
-        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true))
+        .withValue("concurrent", ConfigValueFactory.fromAnyRef(true))
+        .withValue("collapse", ConfigValueFactory.fromAnyRef(true));
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new FileConnector(config));
+    assertTrue(e.getMessage().contains("collapse"));
+  }
+
+  // Verifies that overlapping paths are rejected for a concurrent traversal, but still allowed for a sequential one.
+  @Test
+  public void testPreventConcurrentOverlappingPaths() {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
+        .withValue("paths", ConfigValueFactory.fromIterable(List.of(
+            "./src/test/resources/FileConnectorTest/directory1",
+            "./src/test/resources/FileConnectorTest/directory1/nested")));
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new FileConnector(config.withValue("concurrent", ConfigValueFactory.fromAnyRef(true))));
+    assertTrue(e.getMessage().contains("overlapping"));
+
+    // sequential traversals of overlapping paths already worked before concurrency was an option, so they still do
+    assertDoesNotThrow(() -> new FileConnector(config));
+  }
+
+  // Verifies that paths sharing a name prefix, but not a path segment, are not mistaken for overlapping paths.
+  @Test
+  public void testConcurrentPathsSharingNamePrefixAllowed() {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
+        .withValue("concurrent", ConfigValueFactory.fromAnyRef(true))
+        .withValue("paths", ConfigValueFactory.fromIterable(List.of(
+            "./src/test/resources/FileConnectorTest/directory1",
+            "./src/test/resources/FileConnectorTest/directory1-archive")));
+
+    assertDoesNotThrow(() -> new FileConnector(config));
+  }
+
+  // Verifies that concurrent traversal with no paths is harmless, since it is skipped when there are fewer than two.
+  @Test
+  public void testConcurrentTraversalNoPaths() throws Exception {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
+        .withValue("concurrent", ConfigValueFactory.fromAnyRef(true))
         .withValue("paths", ConfigValueFactory.fromIterable(List.of()));
 
     assertEquals(0, publishedDocuments(config).size());
   }
 
-  // Verifies that a multithreaded traversal with a state db, where each thread opens its own connection to the one
+  // Verifies that a concurrent traversal with a state db, where each thread opens its own connection to the one
   // state table, publishes the same documents as a sequential run.
   @Test
-  public void testMultithreadedTraversalWithState() throws Exception {
+  public void testConcurrentTraversalWithState() throws Exception {
     Config baseConfig = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/stateMultiplePaths.conf");
 
     // a separate in-memory database for each run, so the second run doesn't see the first run's publish times
     List<Document> sequentialDocs = publishedDocuments(baseConfig
         .withValue("state.connectionString", ConfigValueFactory.fromAnyRef("jdbc:h2:mem:sequentialRun")));
 
-    List<Document> multithreadedDocs = publishedDocuments(baseConfig
-        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true))
-        .withValue("state.connectionString", ConfigValueFactory.fromAnyRef("jdbc:h2:mem:multithreadedRun")));
+    List<Document> concurrentDocs = publishedDocuments(baseConfig
+        .withValue("concurrent", ConfigValueFactory.fromAnyRef(true))
+        .withValue("state.connectionString", ConfigValueFactory.fromAnyRef("jdbc:h2:mem:concurrentRun")));
 
-    assertFalse(multithreadedDocs.isEmpty());
-    assertEquals(sequentialDocs.size(), multithreadedDocs.size());
-    assertEquals(documentIds(sequentialDocs), documentIds(multithreadedDocs));
+    assertFalse(concurrentDocs.isEmpty());
+    assertEquals(sequentialDocs.size(), concurrentDocs.size());
+    assertEquals(documentIds(sequentialDocs), documentIds(concurrentDocs));
   }
 
   // Verifies that a failed traversal does not stop the others, and that the resulting exception names the failed path.
   @Test
-  public void testMultithreadedTraversalContinuesAfterFailure() throws Exception {
+  public void testConcurrentTraversalContinuesAfterFailure() throws Exception {
     Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
-        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+        .withValue("concurrent", ConfigValueFactory.fromAnyRef(true));
     TestMessenger messenger = new TestMessenger();
     Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
 
@@ -999,9 +1039,9 @@ public class FileConnectorTest {
 
   // Verifies that when more than one traversal fails, the failures after the first are kept as suppressed exceptions.
   @Test
-  public void testMultithreadedTraversalMultipleFailures() throws Exception {
+  public void testConcurrentTraversalMultipleFailures() throws Exception {
     Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
-        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+        .withValue("concurrent", ConfigValueFactory.fromAnyRef(true));
     TestMessenger messenger = new TestMessenger();
     Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
 
@@ -1022,8 +1062,8 @@ public class FileConnectorTest {
     }
   }
 
-  // A StorageClient that fails when traversing any of the named directories, and otherwise publishes one Document
-  // named after the directory it traversed.
+  // Returns a mock StorageClient. Traversing a directory in directoriesToFail throws an IOException.
+  // Traversing any other directory publishes a single Document whose id is the directory name.
   private static StorageClient publishOrFailFor(Publisher publisher, String... directoriesToFail) throws Exception {
     Set<String> failing = Set.of(directoriesToFail);
     StorageClient mockClient = mock(StorageClient.class);

--- a/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/connector/FileConnectorTest.java
@@ -23,6 +23,10 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import java.nio.file.attribute.FileTime;
@@ -892,5 +896,168 @@ public class FileConnectorTest {
 
     // 5 docs from example (no file handlers!), 3 from directory 1
     assertEquals(8, documentList.size());
+  }
+
+  // Verifies that a multithreaded traversal publishes the same files as a sequential one, and none of them twice.
+  @Test
+  public void testMultithreadedTraversal() throws Exception {
+    Config sequentialConfig = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf");
+    Config multithreadedConfig = sequentialConfig.withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+
+    List<Document> sequentialDocs = publishedDocuments(sequentialConfig);
+    List<Document> multithreadedDocs = publishedDocuments(multithreadedConfig);
+
+    // 3 files in each of the 3 directories
+    assertEquals(9, multithreadedDocs.size());
+    assertEquals(documentIds(sequentialDocs), documentIds(multithreadedDocs));
+    // a file published twice would collapse in the Set above, so check the count separately
+    assertEquals(multithreadedDocs.size(), documentIds(multithreadedDocs).size());
+  }
+
+  // Verifies that the paths are traversed concurrently. Each traversal waits for the others to start, so this times out
+  // and fails if they ran one after another.
+  @Test
+  public void testMultithreadedTraversalsRunConcurrently() throws Exception {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
+        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+    TestMessenger messenger = new TestMessenger();
+    Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
+
+    // the config has three paths, so all three traversals should be in flight at once
+    CountDownLatch allStarted = new CountDownLatch(3);
+
+    try (MockedStatic<StorageClient> mockedStorage = mockStatic(StorageClient.class)) {
+      StorageClient mockClient = mock(StorageClient.class);
+
+      doAnswer(invocation -> {
+        allStarted.countDown();
+        if (!allStarted.await(5, TimeUnit.SECONDS)) {
+          throw new IllegalStateException("Traversals did not overlap - they ran sequentially.");
+        }
+        return null;
+      }).when(mockClient).traverse(any(), any(), any());
+
+      mockedStorage.when(() -> StorageClient.createClients(any())).thenReturn(Map.of("file", mockClient));
+
+      connector = new FileConnector(config);
+      connector.execute(publisher);
+
+      verify(mockClient, times(3)).traverse(any(), any(), any());
+    }
+  }
+
+  // Verifies that multithreading with no paths is harmless, since it is skipped when there are fewer than two.
+  @Test
+  public void testMultithreadedTraversalNoPaths() throws Exception {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
+        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true))
+        .withValue("paths", ConfigValueFactory.fromIterable(List.of()));
+
+    assertEquals(0, publishedDocuments(config).size());
+  }
+
+  // Verifies that a multithreaded traversal with a state db, where each thread opens its own connection to the one
+  // state table, publishes the same documents as a sequential run.
+  @Test
+  public void testMultithreadedTraversalWithState() throws Exception {
+    Config baseConfig = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/stateMultiplePaths.conf");
+
+    // a separate in-memory database for each run, so the second run doesn't see the first run's publish times
+    List<Document> sequentialDocs = publishedDocuments(baseConfig
+        .withValue("state.connectionString", ConfigValueFactory.fromAnyRef("jdbc:h2:mem:sequentialRun")));
+
+    List<Document> multithreadedDocs = publishedDocuments(baseConfig
+        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true))
+        .withValue("state.connectionString", ConfigValueFactory.fromAnyRef("jdbc:h2:mem:multithreadedRun")));
+
+    assertFalse(multithreadedDocs.isEmpty());
+    assertEquals(sequentialDocs.size(), multithreadedDocs.size());
+    assertEquals(documentIds(sequentialDocs), documentIds(multithreadedDocs));
+  }
+
+  // Verifies that a failed traversal does not stop the others, and that the resulting exception names the failed path.
+  @Test
+  public void testMultithreadedTraversalContinuesAfterFailure() throws Exception {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
+        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+    TestMessenger messenger = new TestMessenger();
+    Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
+
+    StorageClient mockClient = publishOrFailFor(publisher, "directory2");
+
+    try (MockedStatic<StorageClient> mockedStorage = mockStatic(StorageClient.class)) {
+      mockedStorage.when(() -> StorageClient.createClients(any())).thenReturn(Map.of("file", mockClient));
+
+      connector = new FileConnector(config);
+      ConnectorException e = assertThrows(ConnectorException.class, () -> connector.execute(publisher));
+
+      // directory1 and directory3 both ran to completion, even though directory2 failed
+      assertEquals(Set.of("directory1", "directory3"), documentIds(messenger.getDocsSentForProcessing()));
+      assertTrue(e.getCause().getMessage().contains("directory2"));
+    }
+  }
+
+  // Verifies that when more than one traversal fails, the failures after the first are kept as suppressed exceptions.
+  @Test
+  public void testMultithreadedTraversalMultipleFailures() throws Exception {
+    Config config = ConfigFactory.parseResourcesAnySyntax("FileConnectorTest/multiplePathsLocal.conf")
+        .withValue("multithreaded", ConfigValueFactory.fromAnyRef(true));
+    TestMessenger messenger = new TestMessenger();
+    Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
+
+    StorageClient mockClient = publishOrFailFor(publisher, "directory1", "directory3");
+
+    try (MockedStatic<StorageClient> mockedStorage = mockStatic(StorageClient.class)) {
+      mockedStorage.when(() -> StorageClient.createClients(any())).thenReturn(Map.of("file", mockClient));
+
+      connector = new FileConnector(config);
+      ConnectorException e = assertThrows(ConnectorException.class, () -> connector.execute(publisher));
+
+      assertEquals(Set.of("directory2"), documentIds(messenger.getDocsSentForProcessing()));
+
+      // the paths are waited on in order, so directory1 becomes the cause and directory3 is suppressed onto it
+      assertTrue(e.getCause().getMessage().contains("directory1"));
+      assertEquals(1, e.getSuppressed().length);
+      assertTrue(e.getSuppressed()[0].getMessage().contains("directory3"));
+    }
+  }
+
+  // A StorageClient that fails when traversing any of the named directories, and otherwise publishes one Document
+  // named after the directory it traversed.
+  private static StorageClient publishOrFailFor(Publisher publisher, String... directoriesToFail) throws Exception {
+    Set<String> failing = Set.of(directoriesToFail);
+    StorageClient mockClient = mock(StorageClient.class);
+
+    doAnswer(invocation -> {
+      TraversalParams params = invocation.getArgument(1);
+      String directory = Paths.get(params.getURI().getPath()).getFileName().toString();
+
+      if (failing.contains(directory)) {
+        throw new IOException("Traversal of " + directory + " failed.");
+      }
+
+      publisher.publish(Document.create(directory));
+      return null;
+    }).when(mockClient).traverse(any(), any(), any());
+
+    return mockClient;
+  }
+
+  private List<Document> publishedDocuments(Config config) throws Exception {
+    TestMessenger messenger = new TestMessenger();
+    Publisher publisher = new PublisherImpl(config, messenger, "run", "pipeline1");
+
+    Connector conn = new FileConnector(config);
+    try {
+      conn.execute(publisher);
+    } finally {
+      conn.close();
+    }
+
+    return messenger.getDocsSentForProcessing();
+  }
+
+  private static Set<String> documentIds(List<Document> documents) {
+    return documents.stream().map(Document::getId).collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
Adds an optional `multithreaded` flag to the FileConnector. When set to true, each configured path is traversed on its own thread with one thread per path. Files under a single path are not split across threads and paths are assumed to not overlap. 

`FileConnectorStateManager` retains the same public methods and they are still called the same way from `BaseStorageClient`. However those methods now delegate to the calling thread's `TraversalState` a new thread local class holding one JDBC connections and its prepared statements. `init()` binds a state for the thread that calls it, each additional traversal thread binds its own with `openStateForThread()` and releases it with `closeStateForThread()`. 

The manager retains its own separate connection for whole-table operations such as table creation, resetting encountered flags, `incrementRunsNotEncountered()`, `listExpiredFiles()`, and deletions which run only on the connector thread, before or after the traversal window.
