### PR TITLE
Raise Jackson maxStringLength so Documents with large byte[] fields survive the Kafka round-trip

### DIFF
--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/HashMapDocument.java
@@ -32,7 +32,8 @@ public class HashMapDocument implements Document, Serializable {
 
   static final long serialVersionUID = 1L;
 
-  protected static final ObjectMapper MAPPER = new ObjectMapper();
+  // shares JsonDocument's read constraints so large byte[] fields parse; see JsonDocument.createDocumentMapper()
+  protected static final ObjectMapper MAPPER = JsonDocument.createDocumentMapper();
 
   private static final Function<Object, Integer> TO_INT =
       value -> {

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
@@ -2,7 +2,9 @@ package com.kmwllc.lucille.core;
 
 import com.dashjoin.jsonata.Jsonata;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,13 +31,32 @@ import java.util.function.UnaryOperator;
  */
 public class JsonDocument implements Document {
 
-  protected static final ObjectMapper MAPPER = new ObjectMapper();
+  protected static final ObjectMapper MAPPER = createDocumentMapper();
   private static final TypeReference<Map<String, Object>> TYPE = new TypeReference<Map<String, Object>>() {
   };
   private static final Logger log = LoggerFactory.getLogger(JsonDocument.class);
 
   @JsonValue
   protected ObjectNode data;
+
+  /**
+   * Creates the ObjectMapper used to parse Documents from JSON.
+   *
+   * Jackson's default StreamReadConstraints cap any single JSON string value at 20,000,000 chars
+   * (StreamReadConstraints.DEFAULT_MAX_STRING_LEN). A Document's byte[] field is serialized as one
+   * base64 string, so a byte[] of 15 MiB or more (20,054,016 chars) is written without complaint by
+   * KafkaDocumentSerializer, accepted by the broker, and then rejected with a StreamConstraintsException
+   * by every consumer that tries to read it back. The constraint exists to bound untrusted input, but a
+   * Kafka record is already bounded by the producer's max.request.size (kafka.maxRequestSize) and the
+   * broker's message.max.bytes, so a lower limit here only adds a hidden consumer-side cliff below
+   * limits the user has already sized. maxStringLength is therefore raised to Integer.MAX_VALUE; all
+   * other constraints keep their defaults.
+   */
+  public static ObjectMapper createDocumentMapper() {
+    return new ObjectMapper(JsonFactory.builder()
+        .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+        .build());
+  }
 
   /**
    * A copy constructor for {@link Document} that deep copies the ObjectNode and verifies the

--- a/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/core/JsonDocument.java
@@ -40,17 +40,26 @@ public class JsonDocument implements Document {
   protected ObjectNode data;
 
   /**
-   * Creates the ObjectMapper used to parse Documents from JSON.
+   * Creates the ObjectMapper used to parse JSON into Documents.
+   *
+   * This is not a Kafka-only mapper. It backs {@link #MAPPER} (and therefore {@link #fromJsonString},
+   * which {@link Document#createFromJson} dispatches to and which JsonFileHandler calls for each line of
+   * a JSON-Lines file), {@link HashMapDocument}'s mapper, {@link KafkaDocument}'s ConsumerRecord
+   * constructor, and KafkaDocumentDeserializer. Every path that turns JSON text into a Document goes
+   * through the constraints configured here.
    *
    * Jackson's default StreamReadConstraints cap any single JSON string value at 20,000,000 chars
    * (StreamReadConstraints.DEFAULT_MAX_STRING_LEN). A Document's byte[] field is serialized as one
-   * base64 string, so a byte[] of 15 MiB or more (20,054,016 chars) is written without complaint by
-   * KafkaDocumentSerializer, accepted by the broker, and then rejected with a StreamConstraintsException
-   * by every consumer that tries to read it back. The constraint exists to bound untrusted input, but a
-   * Kafka record is already bounded by the producer's max.request.size (kafka.maxRequestSize) and the
-   * broker's message.max.bytes, so a lower limit here only adds a hidden consumer-side cliff below
-   * limits the user has already sized. maxStringLength is therefore raised to Integer.MAX_VALUE; all
-   * other constraints keep their defaults.
+   * base64 string of 4 * ceil(n / 3) chars, so any byte[] larger than 15,000,000 bytes (about 14.3 MiB;
+   * a 15 MiB array encodes to 20,971,520 chars) is written without complaint by KafkaDocumentSerializer,
+   * accepted by the broker, and then rejected with a StreamConstraintsException by every consumer that
+   * tries to read it back. The constraint exists to bound untrusted input, but a Kafka record is already
+   * bounded by the producer's max.request.size (kafka.maxRequestSize) and the broker's
+   * message.max.bytes, so a lower limit here only adds a hidden consumer-side cliff below limits the
+   * user has already sized. On the non-Kafka paths the caller has already materialized the whole JSON
+   * String in memory before the mapper sees it, so the cap could only reject the input after that
+   * allocation, not prevent it. maxStringLength is therefore raised to Integer.MAX_VALUE; all other
+   * constraints keep their defaults.
    */
   public static ObjectMapper createDocumentMapper() {
     return new ObjectMapper(JsonFactory.builder()

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaDocumentDeserializer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaDocumentDeserializer.java
@@ -10,7 +10,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 
 public class KafkaDocumentDeserializer implements Deserializer<Document> {
 
-  // a stock ObjectMapper rejects any byte[] field of 15 MiB or more that the serializer happily wrote;
+  // a stock ObjectMapper rejects any byte[] field over 15,000,000 bytes (~14.3 MiB) that the serializer happily wrote;
   // see JsonDocument.createDocumentMapper()
   private static final ObjectMapper MAPPER = JsonDocument.createDocumentMapper();
 

--- a/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaDocumentDeserializer.java
+++ b/lucille-core/src/main/java/com/kmwllc/lucille/message/KafkaDocumentDeserializer.java
@@ -3,13 +3,16 @@ package com.kmwllc.lucille.message;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.JsonDocument;
 import com.kmwllc.lucille.core.KafkaDocument;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 
 public class KafkaDocumentDeserializer implements Deserializer<Document> {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  // a stock ObjectMapper rejects any byte[] field of 15 MiB or more that the serializer happily wrote;
+  // see JsonDocument.createDocumentMapper()
+  private static final ObjectMapper MAPPER = JsonDocument.createDocumentMapper();
 
   @Override
   public Document deserialize(String topic, byte[] data) {

--- a/lucille-core/src/test/java/com/kmwllc/lucille/message/KafkaDocumentDeserializerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/message/KafkaDocumentDeserializerTest.java
@@ -1,0 +1,60 @@
+package com.kmwllc.lucille.message;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.kmwllc.lucille.core.Document;
+import com.kmwllc.lucille.core.KafkaDocument;
+import org.junit.Test;
+
+public class KafkaDocumentDeserializerTest {
+
+  // 15 MiB of bytes base64-encodes to 20,054,016 chars, just over Jackson's default
+  // StreamReadConstraints maxStringLength of 20,000,000. A 14 MiB payload fits under the default.
+  private static final int LARGE_BYTES_LEN = 15 * 1024 * 1024;
+
+  private static byte[] patternedBytes(int len) {
+    byte[] bytes = new byte[len];
+    for (int i = 0; i < len; i++) {
+      bytes[i] = (byte) (i * 31);
+    }
+    return bytes;
+  }
+
+  @Test
+  public void testDeserializeLargeByteArrayField() throws Exception {
+    byte[] content = patternedBytes(LARGE_BYTES_LEN);
+    Document doc = Document.create("doc1");
+    doc.setField("file_content", content);
+
+    byte[] serialized = new KafkaDocumentSerializer().serialize("topic", doc);
+    Document deserialized = new KafkaDocumentDeserializer().deserialize("topic", serialized);
+
+    assertTrue(deserialized instanceof KafkaDocument);
+    assertEquals("doc1", deserialized.getId());
+    byte[] roundTripped = deserialized.getBytes("file_content");
+    assertEquals(LARGE_BYTES_LEN, roundTripped.length);
+    assertArrayEquals(content, roundTripped);
+  }
+
+  @Test
+  public void testCreateFromJsonLargeByteArrayField() throws Exception {
+    byte[] content = patternedBytes(LARGE_BYTES_LEN);
+    Document doc = Document.create("doc2");
+    doc.setField("file_content", content);
+
+    Document parsed = Document.createFromJson(doc.toString());
+
+    assertEquals("doc2", parsed.getId());
+    byte[] roundTripped = parsed.getBytes("file_content");
+    assertEquals(LARGE_BYTES_LEN, roundTripped.length);
+    assertArrayEquals(content, roundTripped);
+  }
+
+  @Test
+  public void testDeserializeNull() {
+    assertNull(new KafkaDocumentDeserializer().deserialize("topic", null));
+  }
+}

--- a/lucille-core/src/test/java/com/kmwllc/lucille/message/KafkaDocumentDeserializerTest.java
+++ b/lucille-core/src/test/java/com/kmwllc/lucille/message/KafkaDocumentDeserializerTest.java
@@ -11,8 +11,9 @@ import org.junit.Test;
 
 public class KafkaDocumentDeserializerTest {
 
-  // 15 MiB of bytes base64-encodes to 20,054,016 chars, just over Jackson's default
-  // StreamReadConstraints maxStringLength of 20,000,000. A 14 MiB payload fits under the default.
+  // Base64 encodes n bytes as 4 * ceil(n / 3) chars, so Jackson's default StreamReadConstraints
+  // maxStringLength of 20,000,000 is exceeded by any byte[] over 15,000,000 bytes (~14.3 MiB).
+  // 15 MiB (15,728,640 bytes) encodes to 20,971,520 chars; a 14 MiB payload fits under the default.
   private static final int LARGE_BYTES_LEN = 15 * 1024 * 1024;
 
   private static byte[] patternedBytes(int len) {


### PR DESCRIPTION
`KafkaDocumentDeserializer`, `JsonDocument` and `HashMapDocument` used a stock `ObjectMapper`, whose default `StreamReadConstraints.maxStringLength` is 20,000,000 chars. A `byte[]` field (e.g. `file_content` from `FileConnector` with `getFileContent: true`) serializes as one base64 string, so any file of 15 MiB or more is written by the serializer and accepted by the broker, then fails in every consumer with `StreamConstraintsException` → `RecordDeserializationException`, which kills the Worker thread and orphans its partitions.

This adds `JsonDocument.createDocumentMapper()` with `maxStringLength` raised to `Integer.MAX_VALUE` (other constraints unchanged) and uses it for the three Document-reading mappers. The record size is already bounded by `max.request.size` / `message.max.bytes`, so a lower consumer-side limit only adds a hidden cliff below limits users have already sized. `KafkaDocumentDeserializerTest` round-trips a 15 MiB `byte[]` through the Kafka serializer/deserializer and `Document.createFromJson`; both cases fail on `main` and pass here.

Generated with Claude Code

https://claude.ai/code/session_01CcuhP2BcLFwZqHQVjbXe6u