### PR TITLE
Ignore Claude Code local files (.claude/, CLAUDE.md) and Gradle caches (.gradle/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,9 @@ dist/
 # Package files
 *.jar
 
-# Maven
+# Maven / Gradle build output
 target/
+.gradle/
 dist/
 
 # JetBrains IDE

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,10 @@ DetectLanguage/profiles
 # VSCode
 .vscode
 
+# Claude Code: local worktrees/settings and per-checkout instructions
+.claude/
+CLAUDE.md
+
 # Python files created from ExternalPython resources
 python/
 


### PR DESCRIPTION
Adds `.claude/` (local worktrees and settings) and `CLAUDE.md` (per-checkout assistant instructions) to `.gitignore` alongside the existing IDE entries, and `.gradle/` next to `target/` — an IDE opening the `solr/test-framework` `build.gradle` test fixture drops a Gradle cache directory beside it. None of these is tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcuhP2BcLFwZqHQVjbXe6u